### PR TITLE
Build zlib and liblzhl libraries

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,6 +63,9 @@ to fetch the following dependencies:
 - **lvgl** – provides the window and canvas system for new ports.
 - **miniaudio** – simple cross‑platform audio backend.
 - **uGLES** – a lightweight OpenGL ES 1.1 wrapper.
+- **zlib** – legacy compression code now compiled via CMake.
+- **liblzhl** – alternative LZ-based compressor bundled with SAGE.
 
-A dedicated `lib/CMakeLists.txt` exposes these libraries as interface
-targets so they can be linked from other modules during the port.
+A dedicated `lib/CMakeLists.txt` pulls in these libraries so they can
+be linked from other modules during the port.  `zlib` and `liblzhl`
+are now built as static targets rather than header-only stubs.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(miniaudio INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/minia
 add_library(uGLES INTERFACE)
 target_include_directories(uGLES INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uGLES)
 
-add_library(zlib INTERFACE)
-target_include_directories(zlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/zlib)
+add_subdirectory(zlib)
+add_subdirectory(liblzhl)
 
-add_library(liblzhl INTERFACE)
-target_include_directories(liblzhl INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/liblzhl/include)
+# Provide a simple alias matching the previous interface target name
+add_library(liblzhl ALIAS lzhl)

--- a/lib/zlib/CMakeLists.txt
+++ b/lib/zlib/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+project(zlib C)
+
+add_library(zlib STATIC
+    adler32.c
+    compress.c
+    crc32.c
+    gzio.c
+    uncompr.c
+    deflate.c
+    trees.c
+    zutil.c
+    infblock.c
+    infcodes.c
+    inftrees.c
+    infutil.c
+    inflate.c
+    inffast.c
+    maketree.c
+)
+
+target_include_directories(zlib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+set_target_properties(zlib PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
## Summary
- build zlib from sources
- build liblzhl instead of using header-only stubs
- note new libs in MIGRATION docs

## Testing
- `cmake -S . -B build && cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6854b6b6f7a88325a0e385f110825f07