### PR TITLE
Update documentation for lvgl upgrade

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -75,14 +75,16 @@ The networking subsystem under `GameEngine/Source/GameNetwork` has been moved
 into `src/GameEngine/GameNetwork` with headers in `include/GameEngine/GameNetwork`.
 The GameSpy-based files remain for now and will be replaced with UniSpySDK code.
 Legacy code still depends on the Visual Studio projects and will not compile without extensive work.
+The engine relies on several third party libraries stored under `lib/`.
+Most of them are tracked as git submodules. After cloning run
+`git submodule update --init --recursive` to fetch their sources.
+The LVGL UI framework is an exception: version 9.3 is bundled directly in
+the repository to allow local patching.
+The key dependencies are:
 
-Additional open source libraries are now tracked as submodules under `lib/`.
-After cloning the repository, run `git submodule update --init --recursive`
-to fetch the following dependencies:
-
-- **lvgl** – provides the window and canvas system for new ports.
+- **lvgl** – provides the window and canvas system for new ports (bundled v9.3).
 - **miniaudio** – simple cross‑platform audio backend.
--   The README in `lib/miniaudio` highlights built-in MP3 support which will
+   The README in `lib/miniaudio` highlights built-in MP3 support which will
     simplify shimming the Miles Sound System calls.
 - **uGLES** – a lightweight OpenGL ES 1.1 wrapper.
 - **UniSpySDK** – open source networking toolkit used in place of GameSpy.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ If you wish to rebuild the source code and tools successfully you will need to f
 
 Source code now resides in `src/`, public headers in `include/`, and libraries in `lib/`. The legacy tree under `Generals/Code` will be migrated here over time.
 
-External libraries such as LVGL, miniaudio, uGLES, UniSpySDK, zlib and liblzhl are provided in submodules within `lib/`. After cloning this repository run:
+External libraries such as LVGL, miniaudio, uGLES, UniSpySDK, zlib and liblzhl are provided under `lib/`. Most of them are git submodules. After cloning this repository run:
 
 ```sh
 git submodule update --init --recursive
 ```
-to fetch them.
+to fetch the submodule sources. LVGL (version 9.3) is included directly in the repository to allow local modifications.
 
 CMake builds these third party libraries via `lib/CMakeLists.txt`.
 


### PR DESCRIPTION
## Summary
- clarify that lvgl is bundled at v9.3
- list lvgl and other libs accordingly

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6855de98adf88325bbfeba7c6a02178d