### PR TITLE
Support runtime window resizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(GeneralsPort LANGUAGES CXX)
+project(GeneralsPort LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,6 +92,24 @@ The key dependencies are:
 - **zlib** – compression library used by the original asset archives.
 - **liblzhl** – reference implementation of EA's LZH-Light algorithm.
 
+LVGL is compiled as a static library with its sources globbed from
+`lib/lvgl/src` and `lib/lvgl/demos`. The build defaults to the X11 backend
+with optional support for SDL, Wayland, DRM, fbdev and NuttX via
+`-DLVGL_USE_SDL`, `-DLVGL_USE_WAYLAND`, `-DLVGL_USE_LINUX_DRM`,
+`-DLVGL_USE_LINUX_FBDEV` and `-DLVGL_USE_NUTTX`.
+
+Miniaudio is also compiled as a small static library so the engine can
+link it directly.
+
 A dedicated `lib/CMakeLists.txt` pulls in these libraries so they can
 be linked from other modules during the port.  `zlib` and `liblzhl`
-are now built as static targets rather than header-only stubs.
+remain built as static targets rather than header-only stubs.
+
+The prototype executable selects the LVGL backend at runtime. The window
+defaults to the X11 driver but passing `sdl`, `wayland`, `drm`, `fbdev`
+or `nuttx` as the first command line argument (or via the
+`LV_BACKEND` environment variable) switches to the respective backend.
+Each backend opens a window whose size defaults to 800x600. The size can be
+overridden with `--width` and `--height` command line options. A timer in the
+stub application demonstrates runtime resizing of the LVGL display so all
+backends handle resolution changes consistently.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,11 +1,101 @@
 # Build third party libraries used by the port
-# Currently they are treated as header-only interface targets
+# Currently LVGL is built as a static library so its sources can be
+# selectively compiled with optional backends.
 
-add_library(lvgl INTERFACE)
-target_include_directories(lvgl INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/lvgl)
+option(LVGL_USE_SDL "Enable LVGL SDL backend" OFF)
+option(LVGL_USE_X11 "Enable LVGL X11 backend" ON)
+option(LVGL_USE_WAYLAND "Enable LVGL Wayland backend" OFF)
+option(LVGL_USE_LINUX_DRM "Enable LVGL DRM backend" OFF)
+option(LVGL_USE_LINUX_FBDEV "Enable LVGL FBDev backend" OFF)
+option(LVGL_USE_NUTTX "Enable LVGL NuttX backend" OFF)
 
-add_library(miniaudio INTERFACE)
-target_include_directories(miniaudio INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio)
+file(GLOB_RECURSE LVGL_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/*.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/demos/*.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/demos/*.cpp)
+
+if(LVGL_USE_SDL)
+    list(APPEND LVGL_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_keyboard.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_mouse.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_window.c)
+    find_package(SDL2 REQUIRED)
+endif()
+
+if(LVGL_USE_X11)
+    list(APPEND LVGL_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/x11/lv_x11_display.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/x11/lv_x11_input.c)
+    find_package(X11 REQUIRED)
+endif()
+
+if(LVGL_USE_WAYLAND)
+    file(GLOB WAYLAND_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/wayland/*.c)
+    list(APPEND LVGL_SOURCES ${WAYLAND_SOURCES})
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(WAYLAND REQUIRED wayland-client wayland-cursor xkbcommon)
+endif()
+
+if(LVGL_USE_LINUX_DRM)
+    list(APPEND LVGL_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/display/drm/lv_linux_drm.c)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(DRM REQUIRED gbm)
+endif()
+
+if(LVGL_USE_LINUX_FBDEV)
+    list(APPEND LVGL_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/display/fb/lv_linux_fbdev.c)
+endif()
+
+if(LVGL_USE_NUTTX)
+    file(GLOB NUTTX_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/nuttx/*.c)
+    list(APPEND LVGL_SOURCES ${NUTTX_SOURCES})
+endif()
+
+add_library(lvgl STATIC ${LVGL_SOURCES})
+target_include_directories(lvgl PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/lvgl
+)
+
+if(LVGL_USE_SDL)
+    target_link_libraries(lvgl PUBLIC SDL2::SDL2)
+    target_compile_definitions(lvgl PUBLIC LV_USE_SDL=1)
+endif()
+
+if(LVGL_USE_X11)
+    target_include_directories(lvgl PUBLIC ${X11_INCLUDE_DIR})
+    target_link_libraries(lvgl PUBLIC ${X11_LIBRARIES})
+    target_compile_definitions(lvgl PUBLIC LV_USE_X11=1)
+endif()
+
+if(LVGL_USE_WAYLAND)
+    target_include_directories(lvgl PUBLIC ${WAYLAND_INCLUDE_DIRS})
+    target_link_libraries(lvgl PUBLIC ${WAYLAND_LIBRARIES})
+    target_compile_definitions(lvgl PUBLIC LV_USE_WAYLAND=1)
+endif()
+
+if(LVGL_USE_LINUX_DRM)
+    target_link_libraries(lvgl PUBLIC ${DRM_LIBRARIES})
+    target_include_directories(lvgl PUBLIC ${DRM_INCLUDE_DIRS})
+    target_compile_definitions(lvgl PUBLIC LV_USE_LINUX_DRM=1)
+endif()
+
+if(LVGL_USE_LINUX_FBDEV)
+    target_compile_definitions(lvgl PUBLIC LV_USE_LINUX_FBDEV=1)
+endif()
+
+if(LVGL_USE_NUTTX)
+    target_compile_definitions(lvgl PUBLIC LV_USE_NUTTX=1)
+endif()
+
+add_library(miniaudio STATIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/miniaudio.c)
+target_include_directories(miniaudio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio)
 
 add_library(uGLES INTERFACE)
 target_include_directories(uGLES INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uGLES)

--- a/lib/lvgl/lv_conf.h
+++ b/lib/lvgl/lv_conf.h
@@ -1,0 +1,17 @@
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#define LV_CONF_INCLUDE_SIMPLE
+
+/* Use X11 by default for development */
+#define LV_USE_SDL 0
+#define LV_USE_X11 1
+#define LV_USE_WAYLAND 0
+#define LV_USE_LINUX_FBDEV 0
+#define LV_USE_NUTTX 0
+#define LV_USE_LINUX_DRM 0
+#define LV_LINUX_DRM_GBM_BUFFERS 1
+
+#include "src/lv_conf_internal.h"
+
+#endif /* LV_CONF_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,3 +3,4 @@ target_include_directories(GeneralsStub PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/Precompiled
 )
+target_link_libraries(GeneralsStub PRIVATE lvgl)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,137 @@
+#include <lvgl.h>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
-int main() {
-    std::cout << "Placeholder executable" << std::endl;
+#include <unistd.h>
+
+#if LV_USE_SDL
+#include "lvgl/src/drivers/sdl/lv_sdl_window.h"
+#endif
+
+#if LV_USE_X11
+#include "lvgl/src/drivers/x11/lv_x11.h"
+#endif
+
+#if LV_USE_WAYLAND
+#include "lvgl/src/drivers/wayland/lv_wayland.h"
+#include "lvgl/src/drivers/wayland/lv_wl_window.h"
+#endif
+
+#if LV_USE_LINUX_DRM
+#include "lvgl/src/drivers/display/drm/lv_linux_drm.h"
+#endif
+
+#if LV_USE_LINUX_FBDEV
+#include "lvgl/src/drivers/display/fb/lv_linux_fbdev.h"
+#endif
+
+#if LV_USE_NUTTX
+#include "lvgl/src/drivers/nuttx/lv_nuttx_entry.h"
+#endif
+
+static uint32_t window_width = 800;
+static uint32_t window_height = 600;
+
+static lv_display_t * init_display(const char *backend)
+{
+#if LV_USE_SDL
+    if(backend && std::strcmp(backend, "sdl") == 0) {
+        return lv_sdl_window_create(window_width, window_height);
+    }
+#endif
+
+#if LV_USE_WAYLAND
+    if(backend && std::strcmp(backend, "wayland") == 0) {
+        return lv_wayland_window_create(window_width, window_height,
+                                        (char *)"LVGL Simulator", NULL);
+    }
+#endif
+
+#if LV_USE_LINUX_DRM
+    if(backend && std::strcmp(backend, "drm") == 0) {
+        lv_display_t *d = lv_linux_drm_create();
+        if(d) lv_linux_drm_set_file(d, "/dev/dri/card0", -1);
+        return d;
+    }
+#endif
+
+#if LV_USE_LINUX_FBDEV
+    if(backend && std::strcmp(backend, "fbdev") == 0) {
+        lv_display_t *d = lv_linux_fbdev_create();
+        if(d) lv_linux_fbdev_set_file(d, "/dev/fb0");
+        return d;
+    }
+#endif
+
+#if LV_USE_NUTTX
+    if(backend && std::strcmp(backend, "nuttx") == 0) {
+        lv_nuttx_dsc_t dsc; lv_nuttx_result_t res;
+        lv_nuttx_dsc_init(&dsc);
+        lv_nuttx_init(&dsc, &res);
+        return res.disp;
+    }
+#endif
+
+#if LV_USE_X11
+    lv_display_t *disp = lv_x11_window_create("LVGL", window_width, window_height);
+    if(disp) lv_x11_inputs_create(disp, nullptr);
+    return disp;
+#else
+    (void)backend;
+    return nullptr;
+#endif
+}
+
+int main(int argc, char **argv)
+{
+    lv_init();
+
+    const char *backend = nullptr;
+    for(int i = 1; i < argc; ++i) {
+        if(std::strncmp(argv[i], "--width=", 8) == 0) {
+            window_width = static_cast<uint32_t>(std::atoi(argv[i] + 8));
+        } else if(std::strncmp(argv[i], "--height=", 9) == 0) {
+            window_height = static_cast<uint32_t>(std::atoi(argv[i] + 9));
+        } else if(std::strncmp(argv[i], "--backend=", 10) == 0) {
+            backend = argv[i] + 10;
+        } else if(std::strcmp(argv[i], "--backend") == 0 && i + 1 < argc) {
+            backend = argv[++i];
+        } else if(!backend) {
+            backend = argv[i];
+        }
+    }
+
+    if(!backend)
+        backend = std::getenv("LV_BACKEND");
+
+    lv_display_t *disp = init_display(backend);
+    if(!disp) {
+        std::cerr << "Failed to initialize LVGL backend" << std::endl;
+        return 1;
+    }
+
+    struct resize_ctx {
+        lv_display_t *disp;
+        uint32_t base_w;
+        uint32_t base_h;
+        bool toggled;
+    } ctx { disp, window_width, window_height, false };
+
+    auto resize_cb = [](lv_timer_t *t){
+        resize_ctx *c = static_cast<resize_ctx *>(lv_timer_get_user_data(t));
+        uint32_t new_w = c->toggled ? c->base_w : c->base_w + 100;
+        uint32_t new_h = c->toggled ? c->base_h : c->base_h + 100;
+        lv_display_set_resolution(c->disp, new_w, new_h);
+        c->toggled = !c->toggled;
+    };
+
+    lv_timer_t *timer = lv_timer_create(resize_cb, 3000, &ctx);
+    (void)timer;
+
+    while(true) {
+        uint32_t wait = lv_timer_handler();
+        usleep(wait * 1000);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- parse `--width` and `--height` so the LVGL stub window size can be set on launch
- use the parsed size when creating backends
- add a timer that toggles resolution at runtime as a demo
- document size options and runtime resizing in MIGRATION

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`


------
https://chatgpt.com/codex/tasks/task_e_6855f2b2b8d0832595d3c54a5a3a04ca