### PR TITLE
Fix macOS build failure for miniaudio

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -96,6 +96,11 @@ endif()
 
 add_library(miniaudio STATIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/miniaudio.c)
 target_include_directories(miniaudio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio)
+if(APPLE)
+    # CoreAudio headers rely on Clang blocks which are disabled by default for C
+    # sources. Enable them when building on macOS to avoid compilation errors.
+    target_compile_options(miniaudio PRIVATE -fblocks)
+endif()
 
 add_library(uGLES INTERFACE)
 target_include_directories(uGLES INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uGLES)


### PR DESCRIPTION
## Summary
- enable Clang blocks when compiling `miniaudio` on Apple platforms

## Testing
- `cmake -S . -B build && cmake --build build -j2`

------
https://chatgpt.com/codex/tasks/task_e_6856028120c8832589b171df32e51618