### PR TITLE
Introduce LvglPlatform wrapper

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -113,3 +113,7 @@ Each backend opens a window whose size defaults to 800x600. The size can be
 overridden with `--width` and `--height` command line options. A timer in the
 stub application demonstrates runtime resizing of the LVGL display so all
 backends handle resolution changes consistently.
+
+LVGL setup code has been moved into a small `LvglPlatform` module under `src/`.
+This wrapper exposes `create_window()` and `poll_events()` so future
+components can initialise the UI without including the driver headers.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,19 @@
+set(LVGL_PLATFORM_SRC
+    LvglPlatform/LvglPlatform.cpp
+)
+
+add_library(LvglPlatform STATIC ${LVGL_PLATFORM_SRC})
+target_include_directories(LvglPlatform PUBLIC
+    ${PROJECT_SOURCE_DIR}/src/LvglPlatform
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/Precompiled
+)
+target_link_libraries(LvglPlatform PUBLIC lvgl)
+
 add_executable(GeneralsStub main.cpp)
 target_include_directories(GeneralsStub PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/Precompiled
+    ${PROJECT_SOURCE_DIR}/src/LvglPlatform
 )
-target_link_libraries(GeneralsStub PRIVATE lvgl)
+target_link_libraries(GeneralsStub PRIVATE LvglPlatform)

--- a/src/LvglPlatform/LvglPlatform.cpp
+++ b/src/LvglPlatform/LvglPlatform.cpp
@@ -1,0 +1,96 @@
+#include "LvglPlatform.h"
+
+#include <cstring>
+#include <unistd.h>
+
+#if LV_USE_SDL
+#include "lvgl/src/drivers/sdl/lv_sdl_window.h"
+#endif
+
+#if LV_USE_X11
+#include "lvgl/src/drivers/x11/lv_x11.h"
+#endif
+
+#if LV_USE_WAYLAND
+#include "lvgl/src/drivers/wayland/lv_wayland.h"
+#include "lvgl/src/drivers/wayland/lv_wl_window.h"
+#endif
+
+#if LV_USE_LINUX_DRM
+#include "lvgl/src/drivers/display/drm/lv_linux_drm.h"
+#endif
+
+#if LV_USE_LINUX_FBDEV
+#include "lvgl/src/drivers/display/fb/lv_linux_fbdev.h"
+#endif
+
+#if LV_USE_NUTTX
+#include "lvgl/src/drivers/nuttx/lv_nuttx_entry.h"
+#endif
+
+namespace LvglPlatform {
+
+static bool lvgl_initialized = false;
+
+lv_display_t *create_window(uint32_t width, uint32_t height, const char *backend)
+{
+    if(!lvgl_initialized) {
+        lv_init();
+        lvgl_initialized = true;
+    }
+
+#if LV_USE_SDL
+    if(backend && std::strcmp(backend, "sdl") == 0) {
+        return lv_sdl_window_create(width, height);
+    }
+#endif
+
+#if LV_USE_WAYLAND
+    if(backend && std::strcmp(backend, "wayland") == 0) {
+        return lv_wayland_window_create(width, height, (char *)"LVGL Simulator", NULL);
+    }
+#endif
+
+#if LV_USE_LINUX_DRM
+    if(backend && std::strcmp(backend, "drm") == 0) {
+        lv_display_t *d = lv_linux_drm_create();
+        if(d) lv_linux_drm_set_file(d, "/dev/dri/card0", -1);
+        return d;
+    }
+#endif
+
+#if LV_USE_LINUX_FBDEV
+    if(backend && std::strcmp(backend, "fbdev") == 0) {
+        lv_display_t *d = lv_linux_fbdev_create();
+        if(d) lv_linux_fbdev_set_file(d, "/dev/fb0");
+        return d;
+    }
+#endif
+
+#if LV_USE_NUTTX
+    if(backend && std::strcmp(backend, "nuttx") == 0) {
+        lv_nuttx_dsc_t dsc; lv_nuttx_result_t res;
+        lv_nuttx_dsc_init(&dsc);
+        lv_nuttx_init(&dsc, &res);
+        return res.disp;
+    }
+#endif
+
+#if LV_USE_X11
+    lv_display_t *disp = lv_x11_window_create("LVGL", width, height);
+    if(disp) lv_x11_inputs_create(disp, nullptr);
+    return disp;
+#else
+    (void)width; (void)height; (void)backend;
+    return nullptr;
+#endif
+}
+
+void poll_events()
+{
+    uint32_t wait = lv_timer_handler();
+    usleep(wait * 1000);
+}
+
+} // namespace LvglPlatform
+

--- a/src/LvglPlatform/LvglPlatform.h
+++ b/src/LvglPlatform/LvglPlatform.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <lvgl.h>
+#include <cstdint>
+
+namespace LvglPlatform {
+
+/**
+ * Create an LVGL window using the requested backend. The backend string
+ * matches the LVGL driver name ("sdl", "x11", "wayland", "drm", "fbdev",
+ * "nuttx"). If nullptr, platform defaults are used.
+ *
+ * This call performs lv_init() if it hasn't been called yet.
+ */
+lv_display_t *create_window(uint32_t width, uint32_t height, const char *backend = nullptr);
+
+/**
+ * Process LVGL timers and events. Call periodically from the main loop.
+ */
+void poll_events();
+
+} // namespace LvglPlatform
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,91 +1,15 @@
-#include <lvgl.h>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <unistd.h>
 
-#if LV_USE_SDL
-#include "lvgl/src/drivers/sdl/lv_sdl_window.h"
-#endif
-
-#if LV_USE_X11
-#include "lvgl/src/drivers/x11/lv_x11.h"
-#endif
-
-#if LV_USE_WAYLAND
-#include "lvgl/src/drivers/wayland/lv_wayland.h"
-#include "lvgl/src/drivers/wayland/lv_wl_window.h"
-#endif
-
-#if LV_USE_LINUX_DRM
-#include "lvgl/src/drivers/display/drm/lv_linux_drm.h"
-#endif
-
-#if LV_USE_LINUX_FBDEV
-#include "lvgl/src/drivers/display/fb/lv_linux_fbdev.h"
-#endif
-
-#if LV_USE_NUTTX
-#include "lvgl/src/drivers/nuttx/lv_nuttx_entry.h"
-#endif
+#include "LvglPlatform/LvglPlatform.h"
 
 static uint32_t window_width = 800;
 static uint32_t window_height = 600;
 
-static lv_display_t * init_display(const char *backend)
-{
-#if LV_USE_SDL
-    if(backend && std::strcmp(backend, "sdl") == 0) {
-        return lv_sdl_window_create(window_width, window_height);
-    }
-#endif
-
-#if LV_USE_WAYLAND
-    if(backend && std::strcmp(backend, "wayland") == 0) {
-        return lv_wayland_window_create(window_width, window_height,
-                                        (char *)"LVGL Simulator", NULL);
-    }
-#endif
-
-#if LV_USE_LINUX_DRM
-    if(backend && std::strcmp(backend, "drm") == 0) {
-        lv_display_t *d = lv_linux_drm_create();
-        if(d) lv_linux_drm_set_file(d, "/dev/dri/card0", -1);
-        return d;
-    }
-#endif
-
-#if LV_USE_LINUX_FBDEV
-    if(backend && std::strcmp(backend, "fbdev") == 0) {
-        lv_display_t *d = lv_linux_fbdev_create();
-        if(d) lv_linux_fbdev_set_file(d, "/dev/fb0");
-        return d;
-    }
-#endif
-
-#if LV_USE_NUTTX
-    if(backend && std::strcmp(backend, "nuttx") == 0) {
-        lv_nuttx_dsc_t dsc; lv_nuttx_result_t res;
-        lv_nuttx_dsc_init(&dsc);
-        lv_nuttx_init(&dsc, &res);
-        return res.disp;
-    }
-#endif
-
-#if LV_USE_X11
-    lv_display_t *disp = lv_x11_window_create("LVGL", window_width, window_height);
-    if(disp) lv_x11_inputs_create(disp, nullptr);
-    return disp;
-#else
-    (void)backend;
-    return nullptr;
-#endif
-}
-
 int main(int argc, char **argv)
 {
-    lv_init();
-
     const char *backend = nullptr;
     for(int i = 1; i < argc; ++i) {
         if(std::strncmp(argv[i], "--width=", 8) == 0) {
@@ -104,7 +28,7 @@ int main(int argc, char **argv)
     if(!backend)
         backend = std::getenv("LV_BACKEND");
 
-    lv_display_t *disp = init_display(backend);
+    lv_display_t *disp = LvglPlatform::create_window(window_width, window_height, backend);
     if(!disp) {
         std::cerr << "Failed to initialize LVGL backend" << std::endl;
         return 1;
@@ -129,8 +53,7 @@ int main(int argc, char **argv)
     (void)timer;
 
     while(true) {
-        uint32_t wait = lv_timer_handler();
-        usleep(wait * 1000);
+        LvglPlatform::poll_events();
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- add `LvglPlatform` module under `src` to hide LVGL init and backend selection
- update `src/CMakeLists.txt` to build the new module
- call `LvglPlatform::create_window` and `poll_events` from `main.cpp`
- document the wrapper in `MIGRATION.md`

## Testing
- `cmake -S . -B build && cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685602dc90708325af1fc89dfc4e0a76