### PR TITLE
Add cross-platform main entry point

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -117,3 +117,8 @@ backends handle resolution changes consistently.
 LVGL setup code has been moved into a small `LvglPlatform` module under `src/`.
 This wrapper exposes `create_window()` and `poll_events()` so future
 components can initialise the UI without including the driver headers.
+
+The stub application now builds from a portable `src/main.cpp` which
+creates the LVGL window through `LvglPlatform` and enters a simple
+polling loop.  The legacy `WinMain.cpp` remains under `src/Main` but is
+only compiled on Windows targets.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,10 +10,10 @@ target_include_directories(LvglPlatform PUBLIC
 )
 target_link_libraries(LvglPlatform PUBLIC lvgl)
 
-add_executable(GeneralsStub main.cpp)
-target_include_directories(GeneralsStub PRIVATE
+add_executable(Generals main.cpp)
+target_include_directories(Generals PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/Precompiled
     ${PROJECT_SOURCE_DIR}/src/LvglPlatform
 )
-target_link_libraries(GeneralsStub PRIVATE LvglPlatform)
+target_link_libraries(Generals PRIVATE LvglPlatform)

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -1,3 +1,4 @@
+if(WIN32)
 add_library(gen_main EXCLUDE_FROM_ALL
     WinMain.cpp
     RTS.RC
@@ -8,3 +9,4 @@ target_include_directories(gen_main PUBLIC
     ${PROJECT_SOURCE_DIR}/include/Precompiled
 )
 # Legacy Win32 entry point not built by default
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,24 +34,6 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    struct resize_ctx {
-        lv_display_t *disp;
-        uint32_t base_w;
-        uint32_t base_h;
-        bool toggled;
-    } ctx { disp, window_width, window_height, false };
-
-    auto resize_cb = [](lv_timer_t *t){
-        resize_ctx *c = static_cast<resize_ctx *>(lv_timer_get_user_data(t));
-        uint32_t new_w = c->toggled ? c->base_w : c->base_w + 100;
-        uint32_t new_h = c->toggled ? c->base_h : c->base_h + 100;
-        lv_display_set_resolution(c->disp, new_w, new_h);
-        c->toggled = !c->toggled;
-    };
-
-    lv_timer_t *timer = lv_timer_create(resize_cb, 3000, &ctx);
-    (void)timer;
-
     while(true) {
         LvglPlatform::poll_events();
     }


### PR DESCRIPTION
## Summary
- simplify `src/main.cpp` and run the LVGL loop via `LvglPlatform`
- compile WinMain only when building on Windows
- build new `main.cpp` by default as the `Generals` target
- document the new entry point in `MIGRATION.md`

## Testing
- `cmake -S . -B build && cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685606151a8c8325a290aca3dadbf5e2