### PR TITLE
Expand AIL stub features

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -100,6 +100,9 @@ with optional support for SDL, Wayland, DRM, fbdev and NuttX via
 
 Miniaudio is also compiled as a small static library so the engine can
 link it directly.
+A Miles SDK stub under `lib/miles-sdk-stub` now links against miniaudio to provide the legacy `mss32.dll` interface.
+The stub has been expanded with additional `AIL_*` helpers so more of the
+original audio subsystem compiles against the new backend.
 
 A dedicated `lib/CMakeLists.txt` pulls in these libraries so they can
 be linked from other modules during the port.  `zlib` and `liblzhl`

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -111,6 +111,7 @@ target_include_directories(UniSpySDK INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/UniSp
 add_library(STLport INTERFACE)
 target_include_directories(STLport INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/STLport)
 
+add_subdirectory(miles-sdk-stub)
 add_subdirectory(zlib)
 add_subdirectory(liblzhl)
 

--- a/lib/miles-sdk-stub/CMakeLists.txt
+++ b/lib/miles-sdk-stub/CMakeLists.txt
@@ -12,8 +12,9 @@ add_library(milesstub SHARED miles.c)
 set_target_properties(milesstub PROPERTIES OUTPUT_NAME mss32)
 set_target_properties(milesstub PROPERTIES SOVERSION 1.0 VERSION 1.0.0)
 target_include_directories(milesstub PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/miniaudio>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>      #include <mss/mss.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mss>  #include <mss.h>
 )
 target_compile_definitions(milesstub PRIVATE BUILD_STUBS)
-target_link_libraries(milesstub INTERFACE milescleanup)
+target_link_libraries(milesstub PUBLIC milescleanup miniaudio)

--- a/lib/miles-sdk-stub/miles.c
+++ b/lib/miles-sdk-stub/miles.c
@@ -4,6 +4,7 @@
  * @author OmniBlade
  *
  * @brief Stub library containing subset of functions from mss32.dll as used by the W3D engine.
+    free(ptr);
  *
  * @copyright This is free software: you can redistribute it and/or
  *            modify it under the terms of the GNU General Public License
@@ -14,6 +15,15 @@
  */
 #include "mss/mss.h"
 #include <stddef.h>
+#include <stdlib.h>
+#include "miniaudio.h"
+
+static ma_engine g_engine;
+
+typedef struct _SAMPLE { ma_sound sound; float volume; int pan; int loop_count; } SAMPLE;
+typedef struct _STREAM { ma_sound sound; float volume; int pan; int loop_count; } STREAM;
+typedef struct _AUDIO { ma_sound sound; float volume; } AUDIO;
+static DIG_DRIVER g_driver;
 
 long __stdcall AIL_3D_sample_volume(H3DSAMPLE sample)
 {
@@ -84,6 +94,10 @@ void __stdcall AIL_set_filter_sample_preference(HSAMPLE sample, const char* name
 
 void __stdcall AIL_release_sample_handle(HSAMPLE sample)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_sound_uninit(&s->sound);
+    free(s);
 }
 
 void __stdcall AIL_close_3D_provider(HPROVIDER lib)
@@ -110,24 +124,45 @@ void __stdcall AIL_set_3D_sample_loop_count(H3DSAMPLE sample, unsigned int count
 
 void __stdcall AIL_set_stream_playback_rate(HSTREAM stream, int rate)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    float pitch = rate / (float)ma_engine_get_sample_rate(&g_engine);
+    ma_sound_set_pitch(&s->sound, pitch);
 }
 
 int __stdcall AIL_stream_playback_rate(HSTREAM stream)
 {
-    return 0;
+    STREAM *s = (STREAM*)stream;
+    if(!s) return 0;
+    float pitch = ma_sound_get_pitch(&s->sound);
+    return (int)(pitch * ma_engine_get_sample_rate(&g_engine));
 }
 
 void __stdcall AIL_stream_ms_position(HSTREAM sample, S32* total_milliseconds, S32* current_milliseconds)
 {
+    STREAM *s = (STREAM*)sample;
+    if(!s) return;
+    ma_uint64 len = 0, cur = 0;
+    ma_sound_get_length_in_pcm_frames(&s->sound, &len);
+    ma_sound_get_cursor_in_pcm_frames(&s->sound, &cur);
+    ma_uint32 rate = ma_engine_get_sample_rate(&g_engine);
+    if(total_milliseconds) *total_milliseconds = (S32)((len * 1000) / rate);
+    if(current_milliseconds) *current_milliseconds = (S32)((cur * 1000) / rate);
 }
 
 void __stdcall AIL_set_stream_ms_position(HSTREAM stream, int pos)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    ma_uint64 frame = ((ma_uint64)pos * ma_engine_get_sample_rate(&g_engine)) / 1000;
+    ma_sound_seek_to_pcm_frame(&s->sound, frame);
 }
 
 int __stdcall AIL_stream_loop_count(HSTREAM stream)
 {
-    return 0;
+    STREAM *s = (STREAM*)stream;
+    if(!s) return 0;
+    return s->loop_count;
 }
 
 void __stdcall AIL_set_stream_loop_block(HSTREAM stream, int loop_start, int loop_end)
@@ -136,32 +171,56 @@ void __stdcall AIL_set_stream_loop_block(HSTREAM stream, int loop_start, int loo
 
 void __stdcall AIL_set_stream_loop_count(HSTREAM stream, int count)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    s->loop_count = count;
+    ma_sound_set_looping(&s->sound, count != 0);
 }
 
 int __stdcall AIL_stream_volume(HSTREAM stream)
 {
-    return 0;
+    STREAM *s = (STREAM*)stream;
+    if(!s) return 0;
+    return (int)(s->volume * 127);
 }
 
 void __stdcall AIL_set_stream_volume(HSTREAM stream, int volume)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    s->volume = volume / 127.0f;
+    ma_sound_set_volume(&s->sound, s->volume);
 }
 
 int __stdcall AIL_stream_pan(HSTREAM stream)
 {
-    return 0;
+    STREAM *s = (STREAM*)stream;
+    if(!s) return 0;
+    return s->pan;
 }
 
 void __stdcall AIL_set_stream_pan(HSTREAM stream, int pan)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    s->pan = pan;
+    ma_sound_set_pan(&s->sound, (pan - 64) / 64.0f);
 }
 
 void __stdcall AIL_close_stream(HSTREAM stream)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    ma_sound_uninit(&s->sound);
+    free(s);
 }
 
 void __stdcall AIL_pause_stream(HSTREAM stream, int onoff)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    if(onoff) ma_sound_stop(&s->sound);
+    else ma_sound_start(&s->sound);
 }
 
 AIL_stream_callback __stdcall AIL_register_stream_callback(HSTREAM stream, AIL_stream_callback callback)
@@ -181,6 +240,9 @@ AIL_sample_callback __stdcall AIL_register_EOS_callback(HSAMPLE sample, AIL_samp
 
 void __stdcall AIL_start_stream(HSTREAM stream)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    ma_sound_start(&s->sound);
 }
 
 HSTREAM __stdcall AIL_open_stream_by_sample(HDIGDRIVER driver, HSAMPLE sample, const char* file_name, int mem)
@@ -190,72 +252,129 @@ HSTREAM __stdcall AIL_open_stream_by_sample(HDIGDRIVER driver, HSAMPLE sample, c
 
 void __stdcall AIL_set_sample_playback_rate(HSAMPLE sample, int playback_rate)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    float pitch = playback_rate / (float)ma_engine_get_sample_rate(&g_engine);
+    ma_sound_set_pitch(&s->sound, pitch);
 }
 
 int __stdcall AIL_sample_playback_rate(HSAMPLE sample)
 {
-    return 0;
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return 0;
+    float pitch = ma_sound_get_pitch(&s->sound);
+    return (int)(pitch * ma_engine_get_sample_rate(&g_engine));
 }
 
 void __stdcall AIL_sample_ms_position(HSAMPLE sample, S32* total_ms, S32* current_ms)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_uint64 len=0, cur=0;
+    ma_sound_get_length_in_pcm_frames(&s->sound, &len);
+    ma_sound_get_cursor_in_pcm_frames(&s->sound, &cur);
+    ma_uint32 rate = ma_engine_get_sample_rate(&g_engine);
+    if(total_ms) *total_ms = (S32)((len * 1000) / rate);
+    if(current_ms) *current_ms = (S32)((cur * 1000) / rate);
 }
 
 void __stdcall AIL_set_sample_ms_position(HSAMPLE sample, int pos)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_uint64 frame = ((ma_uint64)pos * ma_engine_get_sample_rate(&g_engine)) / 1000;
+    ma_sound_seek_to_pcm_frame(&s->sound, frame);
 }
 
 int __stdcall AIL_sample_loop_count(HSAMPLE sample)
 {
-    return 0;
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return 0;
+    return s->loop_count;
 }
 
 void __stdcall AIL_set_sample_loop_count(HSAMPLE sample, int count)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    s->loop_count = count;
+    ma_sound_set_looping(&s->sound, count != 0);
 }
 
 int __stdcall AIL_sample_volume(HSAMPLE sample)
 {
-    return 0;
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return 0;
+    return (int)(s->volume * 127);
 }
 
 void __stdcall AIL_set_sample_volume(HSAMPLE sample, int volume)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    s->volume = volume / 127.0f;
+    ma_sound_set_volume(&s->sound, s->volume);
 }
 
 int __stdcall AIL_sample_pan(HSAMPLE sample)
 {
-    return 0;
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return 0;
+    return s->pan;
 }
 
 void __stdcall AIL_set_sample_pan(HSAMPLE sample, int pan)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    s->pan = pan;
+    ma_sound_set_pan(&s->sound, (pan - 64) / 64.0f);
 }
 
 void __stdcall AIL_end_sample(HSAMPLE sample)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_sound_stop(&s->sound);
 }
 
 void __stdcall AIL_resume_sample(HSAMPLE sample)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_sound_start(&s->sound);
 }
 
 void __stdcall AIL_stop_sample(HSAMPLE sample)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_sound_stop(&s->sound);
 }
 
 void __stdcall AIL_start_sample(HSAMPLE sample)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    ma_sound_start(&s->sound);
 }
 
 void __stdcall AIL_init_sample(HSAMPLE sample)
 {
+    (void)sample;
 }
 
 int __stdcall AIL_set_named_sample_file(
     HSAMPLE sample, const char* file_name, const void* file_image, int file_size, int block)
 {
-    return 0;
+    (void)file_image;
+    (void)file_size;
+    (void)block;
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return 0;
+    if(ma_sound_init_from_file(&g_engine, file_name, 0, NULL, NULL, &s->sound) != MA_SUCCESS)
+        return 0;
+    return 1;
 }
 
 void __stdcall AIL_set_3D_sample_effects_level(H3DSAMPLE sample, float effect_level)
@@ -281,7 +400,37 @@ void __stdcall AIL_set_3D_orientation(
 
 int __stdcall AIL_WAV_info(const void* data, AILSOUNDINFO* info)
 {
-    return 0;
+    if(!data || !info) return 0;
+    const unsigned char* p = (const unsigned char*)data;
+    if(memcmp(p, "RIFF", 4) != 0 || memcmp(p+8, "WAVE", 4) != 0) return 0;
+    size_t offset = 12;
+    uint16_t fmt=0, channels=0, bits=0, blockAlign=0; uint32_t rate=0; const unsigned char* dataPtr=NULL; uint32_t dataLen=0;
+    while(offset < 0xFFFF){
+        const char* id = (const char*)(p + offset); offset += 4;
+        uint32_t size = p[offset] | (p[offset+1]<<8) | (p[offset+2]<<16) | (p[offset+3]<<24); offset += 4;
+        if(memcmp(id, "fmt ",4)==0){
+            fmt = p[offset] | (p[offset+1]<<8);
+            channels = p[offset+2] | (p[offset+3]<<8);
+            rate = p[offset+4] | (p[offset+5]<<8) | (p[offset+6]<<16) | (p[offset+7]<<24);
+            blockAlign = p[offset+12] | (p[offset+13]<<8);
+            bits = p[offset+14] | (p[offset+15]<<8);
+        } else if(memcmp(id,"data",4)==0){
+            dataPtr = p + offset;
+            dataLen = size;
+            break;
+        }
+        offset += size;
+    }
+    info->format = fmt;
+    info->data_ptr = dataPtr;
+    info->data_len = dataLen;
+    info->rate = rate;
+    info->bits = bits;
+    info->channels = channels;
+    info->samples = blockAlign ? dataLen / blockAlign : 0;
+    info->block_size = blockAlign;
+    info->initial_ptr = data;
+    return 1;
 }
 
 void __stdcall AIL_stop_timer(HTIMER timer)
@@ -294,6 +443,7 @@ void __stdcall AIL_release_timer_handle(HTIMER timer)
 
 void __stdcall AIL_shutdown(void)
 {
+    ma_engine_uninit(&g_engine);
 }
 
 int __stdcall AIL_enumerate_filters(HPROENUM* next, HPROVIDER* dest, char** name)
@@ -367,7 +517,13 @@ int __stdcall AIL_sample_user_data(HSAMPLE sample, unsigned int index)
 
 HSAMPLE __stdcall AIL_allocate_sample_handle(HDIGDRIVER dig)
 {
-    return 0;
+    (void)dig;
+    SAMPLE *s = calloc(1, sizeof(SAMPLE));
+    if(!s) return NULL;
+    s->volume = 1.0f;
+    s->pan = 64;
+    s->loop_count = 0;
+    return s;
 }
 
 void __stdcall AIL_set_sample_user_data(HSAMPLE sample, unsigned int index, int value)
@@ -376,7 +532,22 @@ void __stdcall AIL_set_sample_user_data(HSAMPLE sample, unsigned int index, int 
 
 int __stdcall AIL_decompress_ADPCM(const AILSOUNDINFO *info, void **outdata, unsigned long *outsize)
 {
-    return 0;
+    if(!info || !outdata || !outsize) return 0;
+    ma_decoder_config cfg = ma_decoder_config_init(ma_format_s16, info->channels, info->rate);
+    ma_decoder dec;
+    if(ma_decoder_init_memory(info->data_ptr, info->data_len, &cfg, &dec) != MA_SUCCESS)
+        return 0;
+    ma_uint64 frames = 0;
+    ma_decoder_get_length_in_pcm_frames(&dec, &frames);
+    *outsize = (unsigned long)(frames * info->channels * sizeof(short));
+    *outdata = malloc(*outsize);
+    if(!*outdata){
+        ma_decoder_uninit(&dec);
+        return 0;
+    }
+    ma_decoder_read_pcm_frames(&dec, *outdata, frames, NULL);
+    ma_decoder_uninit(&dec);
+    return 1;
 }
 
 void __stdcall AIL_get_DirectSound_info(HSAMPLE sample, AILLPDIRECTSOUND *lplpDS, AILLPDIRECTSOUNDBUFFER *lplpDSB)
@@ -385,38 +556,75 @@ void __stdcall AIL_get_DirectSound_info(HSAMPLE sample, AILLPDIRECTSOUND *lplpDS
 
 void __stdcall AIL_mem_free_lock(void *ptr)
 {
+    free(ptr);
 }
 
 HSTREAM __stdcall AIL_open_stream(HDIGDRIVER dig, const char *filename, int stream_mem)
 {
-    return NULL;
+    (void)dig; (void)stream_mem;
+    STREAM *s = (STREAM*)malloc(sizeof(STREAM));
+    if(!s) return NULL;
+    if(ma_sound_init_from_file(&g_engine, filename, MA_SOUND_FLAG_STREAM, NULL, NULL, &s->sound) != MA_SUCCESS){
+        free(s);
+        return NULL;
+    }
+    s->volume = 1.0f;
+    s->pan = 64;
+    s->loop_count = 0;
+    return s;
 }
 
 void __stdcall AIL_quick_unload(HAUDIO audio)
 {
+    AUDIO *a = (AUDIO*)audio;
+    if(!a) return;
+    ma_sound_uninit(&a->sound);
+    free(a);
 }
 
 HAUDIO __stdcall AIL_quick_load_and_play(const char *filename, unsigned int loop_count, int wait_request)
 {
-    return NULL;
+    (void)wait_request;
+    AUDIO *a = (AUDIO*)malloc(sizeof(AUDIO));
+    if(!a) return NULL;
+    if(ma_sound_init_from_file(&g_engine, filename, 0, NULL, NULL, &a->sound) != MA_SUCCESS){
+        free(a);
+        return NULL;
+    }
+    ma_sound_set_looping(&a->sound, loop_count > 1);
+    ma_sound_start(&a->sound);
+    a->volume = 1.0f;
+    return a;
 }
 
 void __stdcall AIL_quick_set_volume(HAUDIO audio, float volume, float extravol)
-{  
+{
+    (void)extravol;
+    AUDIO *a = (AUDIO*)audio;
+    if(!a) return;
+    a->volume = volume;
+    ma_sound_set_volume(&a->sound, volume);
 }
 
-int __stdcall AIL_quick_startup(
-    int use_digital, int use_MIDI, unsigned int output_rate, int output_bits, int output_channels)
+int __stdcall AIL_quick_startup(int use_digital, int use_MIDI, unsigned int output_rate, int output_bits, int output_channels)
 {
-    return 0;
+    (void)use_digital; (void)use_MIDI; (void)output_rate; (void)output_bits; (void)output_channels;
+    return AIL_startup();
 }
 
 void __stdcall AIL_quick_handles(HDIGDRIVER *pdig, HMDIDRIVER *pmdi, HDLSDEVICE *pdls)
 {
+    if(pdig) *pdig = &g_driver;
+    if(pmdi) *pmdi = NULL;
+    if(pdls) *pdls = NULL;
 }
 
 void __stdcall AIL_sample_volume_pan(HSAMPLE sample, float *volume, float *pan)
-{ 
+{
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    if(volume) *volume = s->volume;
+    if(pan) *pan = s->pan / 127.0f;
 }
 
 void __stdcall AIL_set_3D_sample_occlusion(H3DSAMPLE sample, float occlusion)
@@ -435,18 +643,36 @@ int __stdcall AIL_set_sample_file(HSAMPLE sample, const void *file_image, int bl
 
 void __stdcall AIL_set_sample_volume_pan(HSAMPLE sample, float volume, float pan)
 {
+    SAMPLE *s = (SAMPLE*)sample;
+    if(!s) return;
+    s->volume = volume;
+    s->pan = (int)(pan * 127);
+    ma_sound_set_volume(&s->sound, s->volume);
+    ma_sound_set_pan(&s->sound, pan * 2.0f - 1.0f);
 }
 
 void __stdcall AIL_set_stream_volume_pan(HSTREAM stream, float volume, float pan)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    s->volume = volume;
+    s->pan = (int)(pan * 127);
+    ma_sound_set_volume(&s->sound, s->volume);
+    ma_sound_set_pan(&s->sound, pan * 2.0f - 1.0f);
 }
 
 void __stdcall AIL_stream_volume_pan(HSTREAM stream, float *volume, float *pan)
 {
+    STREAM *s = (STREAM*)stream;
+    if(!s) return;
+    if(volume) *volume = s->volume;
+    if(pan) *pan = s->pan / 127.0f;
 }
 
 int __stdcall AIL_startup(void)
 {
+    if (ma_engine_init(NULL, &g_engine) != MA_SUCCESS)
+        return -1;
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- expand Miles stub with stream and sample helpers
- implement ADPCM decode and WAV header parser
- document expanded AIL helpers in the migration notes

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68560c409ee48325a897f3f585c05981