### PR TITLE
Extend Miles stub for more AIL features

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -102,7 +102,9 @@ Miniaudio is also compiled as a small static library so the engine can
 link it directly.
 A Miles SDK stub under `lib/miles-sdk-stub` now links against miniaudio to provide the legacy `mss32.dll` interface.
 The stub has been expanded with additional `AIL_*` helpers so more of the
-original audio subsystem compiles against the new backend.
+original audio subsystem compiles against the new backend. It now stores
+per-sample user data and exposes a minimal 3D provider interface so older
+audio managers work without modification.
 
 A dedicated `lib/CMakeLists.txt` pulls in these libraries so they can
 be linked from other modules during the port.  `zlib` and `liblzhl`


### PR DESCRIPTION
## Summary
- expand Miles stub structures with user data and basic 3D fields
- implement a number of AIL_* handlers
- expose a minimal 3D provider in the stub
- update migration notes

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6856199f85e483258208872b1d63d2a7