### PR TITLE
Fix macOS gcc build flag

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -106,6 +106,11 @@ original audio subsystem compiles against the new backend. It now stores
 per-sample user data and exposes a minimal 3D provider interface so older
 audio managers work without modification.
 
+On macOS the build now checks for Apple Clang before enabling the `-fblocks`
+option required by the CoreAudio headers. When GCC is used the option is
+omitted and a warning is emitted explaining that Clang is expected for this
+target.
+
 A dedicated `lib/CMakeLists.txt` pulls in these libraries so they can
 be linked from other modules during the port.  `zlib` and `liblzhl`
 remain built as static targets rather than header-only stubs.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ cmake --build build
 ```
 This will compile a placeholder executable while migration is in progress.
 
+On **macOS** you must use the Apple Clang compiler (usually `/usr/bin/clang`).
+Using GCC will fail because the audio backend requires Clang's `-fblocks`
+extension when compiling against CoreAudio headers.
+
 NOTE: As modern versions of MSVC enforce newer revisions of the C++ standard, you will need to make extensive changes to the codebase before it successfully compiles, even more so if you plan on compiling for the Win64 platform.
 
 When the workspace has finished building, the compiled binaries will be copied to the folder called `/Run/` found in the root of each games directory. 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -98,8 +98,13 @@ add_library(miniaudio STATIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/miniaudio.c)
 target_include_directories(miniaudio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio)
 if(APPLE)
     # CoreAudio headers rely on Clang blocks which are disabled by default for C
-    # sources. Enable them when building on macOS to avoid compilation errors.
-    target_compile_options(miniaudio PRIVATE -fblocks)
+    # sources. GCC does not support this extension, so only enable it when using
+    # Clang to avoid build failures on macOS systems that use gcc.
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        target_compile_options(miniaudio PRIVATE -fblocks)
+    else()
+        message(WARNING "The miniaudio target expects Clang on macOS. Blocks support is disabled")
+    endif()
 endif()
 
 add_library(uGLES INTERFACE)


### PR DESCRIPTION
## Summary
- gate `-fblocks` usage on macOS so gcc doesn't fail
- document clang requirement in README
- note compiler check in migration log

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68561da8b3c083258981106ef00cac8e