### PR TITLE
Fix mac clang detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,15 @@
 cmake_minimum_required(VERSION 3.10)
+
+# On macOS the build relies on Clang to enable the Blocks extension required by
+# CoreAudio. When the user configures the project without explicitly selecting
+# Clang, CMake may default to GCC which causes compilation failures. Detect the
+# Apple platform early and force the compilers to clang/clang++ so the rest of
+# the build can assume Blocks support is available.
+if(APPLE)
+    set(CMAKE_C_COMPILER clang CACHE STRING "C compiler" FORCE)
+    set(CMAKE_CXX_COMPILER clang++ CACHE STRING "C++ compiler" FORCE)
+endif()
+
 project(GeneralsPort LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -106,10 +106,11 @@ original audio subsystem compiles against the new backend. It now stores
 per-sample user data and exposes a minimal 3D provider interface so older
 audio managers work without modification.
 
-On macOS the build now checks for Apple Clang before enabling the `-fblocks`
-option required by the CoreAudio headers. When GCC is used the option is
-omitted and a warning is emitted explaining that Clang is expected for this
-target.
+On macOS the build previously checked for Apple Clang before enabling the
+`-fblocks` option required by the CoreAudio headers. When GCC was selected the
+option was omitted and compilation failed. The root `CMakeLists.txt` now forces
+`clang` and `clang++` to be used on Apple platforms so the correct Blocks
+support is available without manual configuration.
 
 A dedicated `lib/CMakeLists.txt` pulls in these libraries so they can
 be linked from other modules during the port.  `zlib` and `liblzhl`


### PR DESCRIPTION
## Summary
- force clang/clang++ on macOS from the root CMakeLists
- document the new compiler behaviour in MIGRATION

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685622b9079c8325bc5d8c3133c3107d