### PR TITLE
Add lvglDevice build option

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/OSDisplay.h
+++ b/Generals/Code/GameEngine/Include/Common/OSDisplay.h
@@ -31,7 +31,7 @@
 #ifndef __OSDISPLAY_H__
 #define __OSDISPLAY_H__
 
-#include "Lib/Basetype.h"
+#include "Lib/BaseType.h"
 
 class AsciiString;
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -136,3 +136,8 @@ only compiled on Windows targets.
 A new `lvglDevice` directory mirrors the legacy Win32 layout. It currently holds empty source and header files ready for the LVGL-based implementation.
 The first implemented piece is `LvglOSDisplay.cpp` which provides OSDisplayWarningBox() via lv_msgbox.
 
+The CMake build now globs the `lvglDevice` sources into a static library and
+links it to the `Generals` stub by default on non‑Windows hosts. Pass
+`-DUSE_LVGL_DEVICE=ON` to force this implementation or `OFF` to fall back to the
+unported `Win32Device` tree on Windows.
+

--- a/include/Lib/BaseType.h
+++ b/include/Lib/BaseType.h
@@ -129,7 +129,7 @@ typedef bool							Bool;							//
 typedef __int64						Int64;							// 8 bytes 
 typedef unsigned __int64	UnsignedInt64;	  	// 8 bytes 
 
-#include "Lib/Trig.h"
+#include "Lib/trig.h"
 
 //-----------------------------------------------------------------------------
 typedef wchar_t WideChar;  ///< multi-byte character representations

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,47 @@
+set(_default_lvgl_device ON)
+if(WIN32)
+    set(_default_lvgl_device OFF)
+endif()
+
+option(USE_LVGL_DEVICE "Use LVGL based device implementation" ${_default_lvgl_device})
+
 set(LVGL_PLATFORM_SRC
     LvglPlatform/LvglPlatform.cpp
 )
 
 add_library(LvglPlatform STATIC ${LVGL_PLATFORM_SRC})
 target_include_directories(LvglPlatform PUBLIC
-    ${PROJECT_SOURCE_DIR}/src/LvglPlatform
+    ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/Precompiled
 )
 target_link_libraries(LvglPlatform PUBLIC lvgl)
 
+file(GLOB_RECURSE LVGL_DEVICE_SRC CONFIGURE_DEPENDS
+    ${PROJECT_SOURCE_DIR}/Generals/Code/GameEngineDevice/Source/lvglDevice/*.cpp)
+
+add_library(lvglDevice STATIC ${LVGL_DEVICE_SRC})
+target_include_directories(lvglDevice PUBLIC
+    ${PROJECT_SOURCE_DIR}/Generals/Code/GameEngineDevice/Include
+    ${PROJECT_SOURCE_DIR}/include/GameEngine
+    ${PROJECT_SOURCE_DIR}/Generals/Code/GameEngine/Include
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/Precompiled
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(lvglDevice PUBLIC LvglPlatform)
+
 add_executable(Generals main.cpp)
 target_include_directories(Generals PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/Precompiled
-    ${PROJECT_SOURCE_DIR}/src/LvglPlatform
+    ${PROJECT_SOURCE_DIR}/src
 )
+
 target_link_libraries(Generals PRIVATE LvglPlatform)
+
+if(USE_LVGL_DEVICE OR NOT WIN32)
+    target_link_libraries(Generals PRIVATE lvglDevice)
+else()
+    # TODO: add Win32Device library when available
+endif()


### PR DESCRIPTION
## Summary
- glob lvglDevice sources and build the lvglDevice library
- link Generals against lvglDevice when requested
- update OSDisplay and BaseType headers to match case-sensitive filenames
- document new USE_LVGL_DEVICE option in MIGRATION.md

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing types and functions in old headers)*

------
https://chatgpt.com/codex/tasks/task_e_685626f2b4f883259bf2abbcb9cb54fc