### PR TITLE
Implement LvglGameEngine message polling

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/lvglDevice/Common/LvglGameEngine.h
+++ b/Generals/Code/GameEngineDevice/Include/lvglDevice/Common/LvglGameEngine.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Common/GameEngine.h"
+#include "GameNetwork/NetworkInterface.h"
+#include "GameLogic/GameLogic.h"
+
+class LvglGameEngine : public GameEngine
+{
+public:
+    LvglGameEngine() = default;
+    virtual ~LvglGameEngine() = default;
+
+    virtual void init();
+    virtual void reset();
+    virtual void update();
+    virtual void serviceWindowsOS();
+};

--- a/Generals/Code/GameEngineDevice/Source/lvglDevice/Common/LvglGameEngine.cpp
+++ b/Generals/Code/GameEngineDevice/Source/lvglDevice/Common/LvglGameEngine.cpp
@@ -1,0 +1,37 @@
+#include "LvglGameEngine.h"
+#include "LvglPlatform/LvglPlatform.h"
+
+void LvglGameEngine::init()
+{
+    GameEngine::init();
+}
+
+void LvglGameEngine::reset()
+{
+    GameEngine::reset();
+}
+
+void LvglGameEngine::update()
+{
+    GameEngine::update();
+
+    if(!isActive()) {
+        while(!isActive()) {
+            LvglPlatform::poll_events();
+            if(TheLAN != NULL) {
+                TheLAN->setIsActive(isActive());
+                TheLAN->update();
+            }
+            if(TheGameEngine->getQuitting() || TheGameLogic->isInInternetGame() || TheGameLogic->isInLanGame()) {
+                break;
+            }
+        }
+    }
+
+    LvglPlatform::poll_events();
+}
+
+void LvglGameEngine::serviceWindowsOS()
+{
+    LvglPlatform::poll_events();
+}


### PR DESCRIPTION
## Summary
- add LvglGameEngine class
- poll LVGL events instead of Win32 messages
- update when minimized/inactive similar to Win32GameEngine

## Testing
- `cmake -S . -B build && cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6856283892648325ac8825786e21dbb1