### PR TITLE
Handle OSDisplay flags in LVGL warning boxes

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/lvglDevice/Common/LvglOSDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/lvglDevice/Common/LvglOSDisplay.cpp
@@ -14,10 +14,19 @@ struct ButtonEventData {
 
 static void btn_event_cb(lv_event_t *e)
 {
-    ButtonEventData *data = static_cast<ButtonEventData*>(lv_event_get_user_data(e));
+    ButtonEventData *data = static_cast<ButtonEventData *>(lv_event_get_user_data(e));
     *data->result = data->value;
     *data->done = true;
     lv_msgbox_close(data->box);
+}
+
+static void close_event_cb(lv_event_t *e)
+{
+    ButtonEventData *data = static_cast<ButtonEventData *>(lv_event_get_user_data(e));
+    if(!*data->done) {
+        *data->result = data->value;
+        *data->done = true;
+    }
 }
 
 static const char *icon_from_flags(UnsignedInt flags)
@@ -40,7 +49,20 @@ OSDisplayButtonType OSDisplayWarningBox(AsciiString p, AsciiString m, UnsignedIn
     promptA.translate(promptStr);
     mesgA.translate(mesgStr);
 
-    lv_obj_t *box = lv_msgbox_create(nullptr);
+    bool modal = BitTest(otherFlags, OSDOF_SYSTEMMODAL) ||
+                 BitTest(otherFlags, OSDOF_APPLICATIONMODAL) ||
+                 BitTest(otherFlags, OSDOF_TASKMODAL) ||
+                 otherFlags == 0; /*Win32 default*/
+
+    lv_obj_t *parent = modal ? lv_layer_top() : lv_scr_act();
+
+    if(modal) {
+        lv_obj_add_flag(parent, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_set_style_bg_color(parent, lv_palette_main(LV_PALETTE_GREY), 0);
+        lv_obj_set_style_bg_opa(parent, LV_OPA_50, 0);
+    }
+
+    lv_obj_t *box = lv_msgbox_create(parent);
     lv_msgbox_add_title(box, promptA.str());
     const char *icon = icon_from_flags(otherFlags);
     if(icon)
@@ -49,6 +71,11 @@ OSDisplayButtonType OSDisplayWarningBox(AsciiString p, AsciiString m, UnsignedIn
 
     bool done = false;
     OSDisplayButtonType result = OSDBT_CANCEL;
+
+    OSDisplayButtonType close_value = BitTest(buttonFlags, OSDBT_CANCEL) ? OSDBT_CANCEL : OSDBT_OK;
+    ButtonEventData close_data{box, close_value, &done, &result};
+    lv_obj_t *close_btn = lv_msgbox_add_close_button(box);
+    lv_obj_add_event_cb(close_btn, close_event_cb, LV_EVENT_CLICKED, &close_data);
 
     if(BitTest(buttonFlags, OSDBT_OK)) {
         ButtonEventData ok_data{box, OSDBT_OK, &done, &result};
@@ -66,6 +93,11 @@ OSDisplayButtonType OSDisplayWarningBox(AsciiString p, AsciiString m, UnsignedIn
 
     while(!done) {
         LvglPlatform::poll_events();
+    }
+
+    if(modal) {
+        lv_obj_remove_flag(parent, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_set_style_bg_opa(parent, LV_OPA_TRANSP, 0);
     }
 
     return result;

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -137,6 +137,7 @@ only compiled on Windows targets.
 A new `lvglDevice` directory mirrors the legacy Win32 layout. It currently holds empty source and header files ready for the LVGL-based implementation.
 The first implemented piece is `LvglOSDisplay.cpp` which provides OSDisplayWarningBox() via lv_msgbox.
 `LvglBIGFile.cpp` and `LvglBIGFileSystem.cpp` now port the original BIG archive loader using only standard C++ headers.
+`LvglOSDisplay.cpp` has been expanded to handle all button and icon combinations. Modal flags now create a clickable overlay on `lv_layer_top` to block background input and the returned value matches the pressed button.
 `LvglMouse.cpp` now registers a pointer device with LVGL and translates its button states and coordinates into the engine's `MouseIO` structure.
 
 LvglLocalFileSystem now replaces Win32 directory calls with std::filesystem for file access.


### PR DESCRIPTION
## Summary
- support modal backgrounds, close buttons and icons in `LvglOSDisplay.cpp`
- describe the new behaviour in `MIGRATION.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4` *(fails: fatal error: Common/File.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6856843152fc8325a847237d5dda75eb