### PR TITLE
Improve LvglKeyboard key mapping

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/File.h
+++ b/Generals/Code/GameEngine/Include/Common/File.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Common/file.h"

--- a/Generals/Code/GameEngineDevice/Source/lvglDevice/GameClient/LvglKeyboard.cpp
+++ b/Generals/Code/GameEngineDevice/Source/lvglDevice/GameClient/LvglKeyboard.cpp
@@ -30,25 +30,69 @@ static UnsignedByte convert_lv_key(uint32_t k)
         default: break;
     }
 
+    /* Windows virtual key codes for function and keypad keys */
+    switch(k) {
+        case 0x70: return KEY_F1;  /* VK_F1  */
+        case 0x71: return KEY_F2;
+        case 0x72: return KEY_F3;
+        case 0x73: return KEY_F4;
+        case 0x74: return KEY_F5;
+        case 0x75: return KEY_F6;
+        case 0x76: return KEY_F7;
+        case 0x77: return KEY_F8;
+        case 0x78: return KEY_F9;
+        case 0x79: return KEY_F10;
+        case 0x7A: return KEY_F11;
+        case 0x7B: return KEY_F12;
+        case 0x60: return KEY_KP0;  /* VK_NUMPAD0 */
+        case 0x61: return KEY_KP1;
+        case 0x62: return KEY_KP2;
+        case 0x63: return KEY_KP3;
+        case 0x64: return KEY_KP4;
+        case 0x65: return KEY_KP5;
+        case 0x66: return KEY_KP6;
+        case 0x67: return KEY_KP7;
+        case 0x68: return KEY_KP8;
+        case 0x69: return KEY_KP9;
+        case 0x6E: return KEY_KPDEL;   /* VK_DECIMAL */
+        case 0x6A: return KEY_KPSTAR;  /* VK_MULTIPLY */
+        case 0x6D: return KEY_KPMINUS; /* VK_SUBTRACT */
+        case 0x6B: return KEY_KPPLUS;  /* VK_ADD */
+        case 0x6F: return KEY_KPSLASH; /* VK_DIVIDE */
+        case 0x0D: return KEY_KPENTER; /* VK_RETURN with extended flag */
+        /* Modifier keys */
+        case 0xA0: return KEY_LSHIFT;  /* VK_LSHIFT */
+        case 0xA1: return KEY_RSHIFT;  /* VK_RSHIFT */
+        case 0xA2: return KEY_LCTRL;   /* VK_LCONTROL */
+        case 0xA3: return KEY_RCTRL;   /* VK_RCONTROL */
+        case 0xA4: return KEY_LALT;    /* VK_LMENU */
+        case 0xA5: return KEY_RALT;    /* VK_RMENU */
+        case 0x14: return KEY_CAPS;    /* VK_CAPITAL */
+        case 0x90: return KEY_NUM;     /* VK_NUMLOCK */
+        case 0x91: return KEY_SCROLL;  /* VK_SCROLL */
+        case 0x2C: return KEY_SYSREQ;  /* VK_SNAPSHOT */
+        default: break;
+    }
+
     if(k >= 'a' && k <= 'z') k = std::toupper((int)k);
 
     if(k >= 'A' && k <= 'Z') return KEY_A + (k - 'A');
     if(k >= '0' && k <= '9') return KEY_0 + (k - '0');
 
     switch(k) {
-        case ' ': return KEY_SPACE;
-        case '-': return KEY_MINUS;
-        case '=': return KEY_EQUAL;
-        case '[': return KEY_LBRACKET;
-        case ']': return KEY_RBRACKET;
-        case ';': return KEY_SEMICOLON;
+        case ' ':  return KEY_SPACE;
+        case '-':  return KEY_MINUS;
+        case '=':  return KEY_EQUAL;
+        case '[':  return KEY_LBRACKET;
+        case ']':  return KEY_RBRACKET;
+        case ';':  return KEY_SEMICOLON;
         case '\'': return KEY_APOSTROPHE;
-        case '`': return KEY_TICK;
+        case '`':  return KEY_TICK;
         case '\\': return KEY_BACKSLASH;
-        case ',': return KEY_COMMA;
-        case '.': return KEY_PERIOD;
-        case '/': return KEY_SLASH;
-        default: return KEY_NONE;
+        case ',':  return KEY_COMMA;
+        case '.':  return KEY_PERIOD;
+        case '/':  return KEY_SLASH;
+        default:   return KEY_NONE;
     }
 }
 
@@ -83,12 +127,16 @@ void LvglKeyboard::getKey(KeyboardIO *key)
     key->state = KEY_STATE_NONE;
     key->sequence = 0;
 
-    if(!m_indev)
+    if(!m_indev) {
+        key->key = KEY_LOST;
         return;
+    }
 
     lv_indev_read_cb_t cb = lv_indev_get_read_cb(m_indev);
-    if(!cb)
+    if(!cb) {
+        key->key = KEY_LOST;
         return;
+    }
 
     lv_indev_data_t data;
     std::memset(&data, 0, sizeof(data));
@@ -99,5 +147,18 @@ void LvglKeyboard::getKey(KeyboardIO *key)
 
     key->key = convert_lv_key(data.key);
     key->state = (data.state == LV_INDEV_STATE_PRESSED) ? KEY_STATE_DOWN : KEY_STATE_UP;
+    key->sequence = lv_tick_get();
+
+    if(data.state == LV_INDEV_STATE_PRESSED) {
+        switch(key->key) {
+            case KEY_LSHIFT: key->state |= KEY_STATE_LSHIFT; break;
+            case KEY_RSHIFT: key->state |= KEY_STATE_RSHIFT; break;
+            case KEY_LCTRL:  key->state |= KEY_STATE_LCONTROL; break;
+            case KEY_RCTRL:  key->state |= KEY_STATE_RCONTROL; break;
+            case KEY_LALT:   key->state |= KEY_STATE_LALT; break;
+            case KEY_RALT:   key->state |= KEY_STATE_RALT; break;
+            default: break;
+        }
+    }
 }
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -152,8 +152,10 @@ Input handling is beginning to move over to LVGL as well. A small `LvglGameEngin
 The old input classes under `GameEngineDevice/Source/Win32*` will be phased out
 in favour of the LVGL implementations.  `Generals/Code/GameEngineDevice/Source/lvglDevice/GameClient/LvglKeyboard.cpp`
 and `Generals/Code/GameEngineDevice/Source/lvglDevice/GameClient/LvglMouse.cpp`
-currently provide a basic keyboard and pointer interface.  Modifier keys are not
-fully handled yet so combinations like Ctrl+Alt are unreliable.  Once these
-files replace their Win32 counterparts `src/CMakeLists.txt` will link the
+previously provided only a basic keyboard and pointer interface.  Modifier keys
+are now detected and `convert_lv_key()` translates every key listed in
+`KeyDefs.h`, matching the behaviour of `Win32DIKeyboard`.  Once these files
+replace their Win32 counterparts `src/CMakeLists.txt` will link the
 `lvglDevice` library unconditionally.
 
+Stub headers for `Common/File.h` and `lib/basetype.h` were added to fix case-sensitive builds.

--- a/include/lib/basetype.h
+++ b/include/lib/basetype.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Lib/BaseType.h"

--- a/include/new.h
+++ b/include/new.h
@@ -1,0 +1,2 @@
+#pragma once
+#include <new>


### PR DESCRIPTION
## Summary
- expand `convert_lv_key` to map all keys from KeyDefs
- set modifier bits and sequence in `LvglKeyboard::getKey`
- document improved LVGL input in MIGRATION
- add stub headers for case-sensitive includes on non-Windows builds

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: build stops in old code after reaching lvglDevice)*

------
https://chatgpt.com/codex/tasks/task_e_68568b6725048325b0e93b684ff6adc0