### PR TITLE
Link milesstub to Generals build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,3 +40,4 @@ target_link_libraries(Generals PRIVATE LvglPlatform)
 
 target_link_libraries(Generals PRIVATE lvglDevice)
 target_link_libraries(Generals PRIVATE gameengine)
+target_link_libraries(Generals PRIVATE milesstub)


### PR DESCRIPTION
## Summary
- link the `milesstub` library in `src/CMakeLists.txt`
- confirmed that include directories from the stub are present in the compile flags

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: lvglDevice missing Win32BIGFile.h)*

------
https://chatgpt.com/codex/tasks/task_e_6856a4c6e28c83259989752d4f0f8686