### PR TITLE
Add submodule guard for miniaudio

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -94,7 +94,11 @@ if(LVGL_USE_NUTTX)
     target_compile_definitions(lvgl PUBLIC LV_USE_NUTTX=1)
 endif()
 
-add_library(miniaudio STATIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/miniaudio.c)
+set(MINIAUDIO_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/miniaudio.c)
+if(NOT EXISTS ${MINIAUDIO_SOURCE})
+    message(FATAL_ERROR "miniaudio source not found: did you forget to init the submodule?")
+endif()
+add_library(miniaudio STATIC ${MINIAUDIO_SOURCE})
 target_include_directories(miniaudio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/miniaudio)
 if(APPLE)
     # CoreAudio headers rely on Clang blocks which are disabled by default for C


### PR DESCRIPTION
## Summary
- ensure the miniaudio submodule is present before building

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: Win32BIGFile.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856ab91155c8325a969d44680a287a6