### PR TITLE
Refactor lvglDevice build and add cross‑platform stubs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -157,9 +157,9 @@ in favour of the LVGL implementations.  `Generals/Code/GameEngineDevice/Source/l
 and `Generals/Code/GameEngineDevice/Source/lvglDevice/GameClient/LvglMouse.cpp`
 previously provided only a basic keyboard and pointer interface.  Modifier keys
 are now detected and `convert_lv_key()` translates every key listed in
-`KeyDefs.h`, matching the behaviour of `Win32DIKeyboard`.  Once these files
-replace their Win32 counterparts `src/CMakeLists.txt` will link the
-`lvglDevice` library unconditionally.
+`KeyDefs.h`, matching the behaviour of `Win32DIKeyboard`.  The new
+`lvglDevice` library now lives under `src/GameEngineDevice/lvglDevice` and is
+linked unconditionally from `src/CMakeLists.txt`.
 
 Stub headers for `Common/File.h` and `lib/basetype.h` were added to fix case-sensitive buil
 - The W3D device common files (radar, convert and factory helpers) now live under `src/GameEngineDevice/W3DDevice/Common` with their headers available in `include/GameEngineDevice/W3DDevice`. Basic player management classes have been moved to `src/GameEngine/Common/RTS` and corresponding headers under `include/GameEngine/Common`.

--- a/include/Common/win32_compat.h
+++ b/include/Common/win32_compat.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifndef _WIN32
+#include <cstdint>
+
+using DWORD = std::uint32_t;
+using WORD  = std::uint16_t;
+using BYTE  = std::uint8_t;
+using BOOL  = int;
+using LONG  = std::int32_t;
+
+#ifndef MAX_PATH
+#define MAX_PATH 260
+#endif
+#ifndef _MAX_PATH
+#define _MAX_PATH MAX_PATH
+#endif
+
+using HANDLE = void*;
+using HWND   = HANDLE;
+
+#ifndef SUCCEEDED
+#define SUCCEEDED(hr) ((hr) >= 0)
+#endif
+#ifndef FAILED
+#define FAILED(hr) ((hr) < 0)
+#endif
+#endif // _WIN32

--- a/include/GameEngineDevice/lvglDevice/Common/Win32CDManager.h
+++ b/include/GameEngineDevice/lvglDevice/Common/Win32CDManager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Common/CDManager.h"
+
+class Win32CDDrive : public CDDrive
+{
+public:
+    Win32CDDrive();
+    virtual ~Win32CDDrive();
+    virtual void refreshInfo() override;
+};
+
+class Win32CDManager : public CDManager
+{
+public:
+    Win32CDManager();
+    virtual ~Win32CDManager();
+
+    virtual void init() override;
+    virtual void update() override;
+    virtual void reset() override;
+    virtual void refreshDrives() override;
+
+protected:
+    virtual CDDriveInterface *createDrive() override;
+};
+

--- a/include/GameEngineDevice/lvglDevice/Common/Win32GameEngine.h
+++ b/include/GameEngineDevice/lvglDevice/Common/Win32GameEngine.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Common/GameEngine.h"
+#include "GameNetwork/NetworkInterface.h"
+#include "GameLogic/GameLogic.h"
+
+class Win32GameEngine : public GameEngine
+{
+public:
+    Win32GameEngine() = default;
+    virtual ~Win32GameEngine() = default;
+
+    virtual void init();
+    virtual void reset();
+    virtual void update();
+    virtual void serviceWindowsOS();
+
+protected:
+    virtual GameLogic *createGameLogic();
+    virtual GameClient *createGameClient();
+    virtual ModuleFactory *createModuleFactory();
+    virtual ThingFactory *createThingFactory();
+    virtual FunctionLexicon *createFunctionLexicon();
+    virtual LocalFileSystem *createLocalFileSystem();
+    virtual ArchiveFileSystem *createArchiveFileSystem();
+    virtual NetworkInterface *createNetwork();
+    virtual Radar *createRadar();
+    virtual WebBrowser *createWebBrowser();
+    virtual AudioManager *createAudioManager();
+    virtual ParticleSystemManager *createParticleSystemManager();
+};
+

--- a/include/GameEngineDevice/lvglDevice/Common/Win32LocalFile.h
+++ b/include/GameEngineDevice/lvglDevice/Common/Win32LocalFile.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Common/LocalFile.h"
+
+class Win32LocalFile : public LocalFile
+{
+public:
+    Win32LocalFile();
+    virtual ~Win32LocalFile();
+};
+

--- a/include/GameEngineDevice/lvglDevice/Common/Win32LocalFileSystem.h
+++ b/include/GameEngineDevice/lvglDevice/Common/Win32LocalFileSystem.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Common/LocalFileSystem.h"
+
+class Win32LocalFileSystem : public LocalFileSystem
+{
+public:
+    Win32LocalFileSystem() = default;
+    virtual ~Win32LocalFileSystem() {}
+
+    virtual void init() override;
+    virtual void reset() override;
+    virtual void update() override;
+
+    virtual File *openFile(const Char *filename, Int access = 0) override;
+    virtual Bool doesFileExist(const Char *filename) const override;
+    virtual void getFileListInDirectory(const AsciiString &currentDirectory,
+                                        const AsciiString &originalDirectory,
+                                        const AsciiString &searchName,
+                                        FilenameList &filenameList,
+                                        Bool searchSubdirectories) const override;
+    virtual Bool getFileInfo(const AsciiString &filename, FileInfo *fileInfo) const override;
+    virtual Bool createDirectory(AsciiString directory) override;
+};
+

--- a/include/GameEngineDevice/lvglDevice/Common/Win32OSDisplay.h
+++ b/include/GameEngineDevice/lvglDevice/Common/Win32OSDisplay.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Common/OSDisplay.h"

--- a/include/GameEngineDevice/lvglDevice/GameClient/Win32DIKeyboard.h
+++ b/include/GameEngineDevice/lvglDevice/GameClient/Win32DIKeyboard.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "GameClient/Keyboard.h"
+
+class Win32DIKeyboard : public Keyboard
+{
+public:
+    Win32DIKeyboard();
+    virtual ~Win32DIKeyboard();
+
+    virtual void init() override;
+    virtual void reset() override;
+    virtual void update() override;
+    virtual Bool getCapsState() override;
+
+protected:
+    virtual void getKey(KeyboardIO *key) override;
+};
+

--- a/include/GameEngineDevice/lvglDevice/GameClient/Win32DIMouse.h
+++ b/include/GameEngineDevice/lvglDevice/GameClient/Win32DIMouse.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "GameClient/Mouse.h"
+
+class Win32DIMouse : public Mouse
+{
+public:
+    Win32DIMouse();
+    virtual ~Win32DIMouse();
+
+    virtual void init() override;
+    virtual void reset() override;
+    virtual void update() override;
+    virtual void initCursorResources() override;
+
+    virtual void setCursor(MouseCursor cursor) override;
+    virtual void capture() override;
+    virtual void releaseCapture() override;
+    virtual void setVisibility(Bool visible) override;
+
+protected:
+    virtual UnsignedByte getMouseEvent(MouseIO *result, Bool flush) override;
+};
+

--- a/include/GameEngineDevice/lvglDevice/GameClient/Win32Mouse.h
+++ b/include/GameEngineDevice/lvglDevice/GameClient/Win32Mouse.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "GameClient/Mouse.h"
+
+class Win32Mouse : public Mouse
+{
+public:
+    Win32Mouse();
+    virtual ~Win32Mouse();
+
+    virtual void init() override;
+    virtual void reset() override;
+    virtual void update() override;
+    virtual void initCursorResources() override;
+
+    virtual void setCursor(MouseCursor cursor) override;
+    virtual void capture() override;
+    virtual void releaseCapture() override;
+    virtual void setVisibility(Bool visible) override;
+
+protected:
+    virtual UnsignedByte getMouseEvent(MouseIO *result, Bool flush) override;
+};
+

--- a/include/Precompiled/PreRTS.h
+++ b/include/Precompiled/PreRTS.h
@@ -58,6 +58,8 @@ class STLSpecialAlloc;
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#else
+#include "Common/win32_compat.h"
 #endif
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ target_include_directories(LvglPlatform PUBLIC
 )
 target_link_libraries(LvglPlatform PUBLIC lvgl)
 
+add_subdirectory(GameEngineDevice/lvglDevice)
+
 set(GENERALS_SRC
     main.cpp
     LvglGameEngine/LvglGameEngine.cpp
@@ -22,7 +24,7 @@ target_include_directories(Generals PRIVATE
     ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/src/LvglGameEngine
 )
-target_link_libraries(Generals PRIVATE LvglPlatform)
+target_link_libraries(Generals PRIVATE LvglPlatform lvglDevice)
 
 target_link_libraries(Generals PRIVATE gameenginedevice)
 target_link_libraries(Generals PRIVATE gameengine)

--- a/src/GameEngineDevice/CMakeLists.txt
+++ b/src/GameEngineDevice/CMakeLists.txt
@@ -2,12 +2,6 @@ add_library(gameenginedevice EXCLUDE_FROM_ALL
     W3DDevice/GameLogic/W3DGameLogic.cpp
 )
 
-# lvglDevice sources migrated from Generals/Code
-file(GLOB_RECURSE LVGLDEVICE_SRCS CONFIGURE_DEPENDS
-    lvglDevice/*.cpp
-)
-target_sources(gameenginedevice PRIVATE ${LVGLDEVICE_SRCS})
-
 target_include_directories(gameenginedevice PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/GameEngine
@@ -16,9 +10,4 @@ target_include_directories(gameenginedevice PUBLIC
     ${PROJECT_SOURCE_DIR}/include/Precompiled
 )
 
-# Link against the Miles Sound System stub which in turn
-# bridges legacy audio calls to miniaudio. This removes the
-# remaining DirectSound dependency from the GameEngineDevice
-# module.
-target_link_libraries(gameenginedevice PUBLIC milesstub LvglPlatform)
-# Partial migration of GameEngineDevice sources
+target_link_libraries(gameenginedevice PUBLIC milesstub)

--- a/src/GameEngineDevice/lvglDevice/CMakeLists.txt
+++ b/src/GameEngineDevice/lvglDevice/CMakeLists.txt
@@ -1,17 +1,16 @@
-# Placeholder lvglDevice module
-add_library(lvglDevice STATIC EXCLUDE_FROM_ALL
-    GameClient/LvglMouse.cpp
-    Common/LvglOSDisplay.cpp
-    GameClient/LvglKeyboard.cpp
+file(GLOB LVGLDEVICE_SRC CONFIGURE_DEPENDS
+    Common/*.cpp
+    GameClient/*.cpp
 )
+
+add_library(lvglDevice STATIC ${LVGLDEVICE_SRC})
+
 target_include_directories(lvglDevice PUBLIC
     ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/GameEngine
     ${PROJECT_SOURCE_DIR}/include/GameEngineDevice
+    ${PROJECT_SOURCE_DIR}/Generals/Code/GameEngine/Include
     ${PROJECT_SOURCE_DIR}/include/Precompiled
 )
 
-target_sources(lvglDevice PRIVATE
-    Common/LvglOSDisplay.cpp
-    Common/LvglBIGFile.cpp
-    Common/LvglBIGFileSystem.cpp
-)
+target_link_libraries(lvglDevice PUBLIC LvglPlatform)

--- a/src/GameEngineDevice/lvglDevice/Common/Win32BIGFile.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32BIGFile.cpp
@@ -1,0 +1,12 @@
+#include "lvglDevice/Common/Win32BIGFile.h"
+
+Win32BIGFile::Win32BIGFile() {}
+Win32BIGFile::~Win32BIGFile() {}
+
+File* Win32BIGFile::openFile(const Char *, Int) { return nullptr; }
+void Win32BIGFile::closeAllFiles() {}
+AsciiString Win32BIGFile::getName() { return AsciiString(); }
+AsciiString Win32BIGFile::getPath() { return AsciiString(); }
+void Win32BIGFile::setSearchPriority(Int) {}
+void Win32BIGFile::close() {}
+Bool Win32BIGFile::getFileInfo(const AsciiString &, FileInfo *) const { return FALSE; }

--- a/src/GameEngineDevice/lvglDevice/Common/Win32BIGFileSystem.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32BIGFileSystem.cpp
@@ -1,0 +1,14 @@
+#include "lvglDevice/Common/Win32BIGFileSystem.h"
+
+Win32BIGFileSystem::Win32BIGFileSystem() {}
+Win32BIGFileSystem::~Win32BIGFileSystem() {}
+
+void Win32BIGFileSystem::init() {}
+void Win32BIGFileSystem::update() {}
+void Win32BIGFileSystem::reset() {}
+void Win32BIGFileSystem::postProcessLoad() {}
+void Win32BIGFileSystem::closeAllArchiveFiles() {}
+ArchiveFile *Win32BIGFileSystem::openArchiveFile(const Char *) { return nullptr; }
+void Win32BIGFileSystem::closeArchiveFile(const Char *) {}
+void Win32BIGFileSystem::closeAllFiles() {}
+Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString, AsciiString, Bool) { return FALSE; }

--- a/src/GameEngineDevice/lvglDevice/Common/Win32CDManager.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32CDManager.cpp
@@ -1,0 +1,14 @@
+#include "lvglDevice/Common/Win32CDManager.h"
+
+Win32CDDrive::Win32CDDrive() {}
+Win32CDDrive::~Win32CDDrive() {}
+void Win32CDDrive::refreshInfo() {}
+
+Win32CDManager::Win32CDManager() {}
+Win32CDManager::~Win32CDManager() {}
+
+void Win32CDManager::init() {}
+void Win32CDManager::update() {}
+void Win32CDManager::reset() {}
+void Win32CDManager::refreshDrives() {}
+CDDriveInterface *Win32CDManager::createDrive() { return nullptr; }

--- a/src/GameEngineDevice/lvglDevice/Common/Win32GameEngine.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32GameEngine.cpp
@@ -1,0 +1,19 @@
+#include "lvglDevice/Common/Win32GameEngine.h"
+
+void Win32GameEngine::init() {}
+void Win32GameEngine::reset() {}
+void Win32GameEngine::update() {}
+void Win32GameEngine::serviceWindowsOS() {}
+
+GameLogic *Win32GameEngine::createGameLogic() { return nullptr; }
+GameClient *Win32GameEngine::createGameClient() { return nullptr; }
+ModuleFactory *Win32GameEngine::createModuleFactory() { return nullptr; }
+ThingFactory *Win32GameEngine::createThingFactory() { return nullptr; }
+FunctionLexicon *Win32GameEngine::createFunctionLexicon() { return nullptr; }
+LocalFileSystem *Win32GameEngine::createLocalFileSystem() { return nullptr; }
+ArchiveFileSystem *Win32GameEngine::createArchiveFileSystem() { return nullptr; }
+NetworkInterface *Win32GameEngine::createNetwork() { return nullptr; }
+Radar *Win32GameEngine::createRadar() { return nullptr; }
+WebBrowser *Win32GameEngine::createWebBrowser() { return nullptr; }
+AudioManager *Win32GameEngine::createAudioManager() { return nullptr; }
+ParticleSystemManager *Win32GameEngine::createParticleSystemManager() { return nullptr; }

--- a/src/GameEngineDevice/lvglDevice/Common/Win32LocalFile.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32LocalFile.cpp
@@ -1,0 +1,4 @@
+#include "lvglDevice/Common/Win32LocalFile.h"
+
+Win32LocalFile::Win32LocalFile() {}
+Win32LocalFile::~Win32LocalFile() {}

--- a/src/GameEngineDevice/lvglDevice/Common/Win32LocalFileSystem.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32LocalFileSystem.cpp
@@ -1,0 +1,11 @@
+#include "lvglDevice/Common/Win32LocalFileSystem.h"
+
+void Win32LocalFileSystem::init() {}
+void Win32LocalFileSystem::reset() {}
+void Win32LocalFileSystem::update() {}
+
+File *Win32LocalFileSystem::openFile(const Char *, Int) { return nullptr; }
+Bool Win32LocalFileSystem::doesFileExist(const Char *) const { return FALSE; }
+void Win32LocalFileSystem::getFileListInDirectory(const AsciiString &, const AsciiString &, const AsciiString &, FilenameList &, Bool) const {}
+Bool Win32LocalFileSystem::getFileInfo(const AsciiString &, FileInfo *) const { return FALSE; }
+Bool Win32LocalFileSystem::createDirectory(AsciiString) { return FALSE; }

--- a/src/GameEngineDevice/lvglDevice/Common/Win32OSDisplay.cpp
+++ b/src/GameEngineDevice/lvglDevice/Common/Win32OSDisplay.cpp
@@ -1,0 +1,1 @@
+#include "lvglDevice/Common/Win32OSDisplay.h"

--- a/src/GameEngineDevice/lvglDevice/GameClient/Win32DIKeyboard.cpp
+++ b/src/GameEngineDevice/lvglDevice/GameClient/Win32DIKeyboard.cpp
@@ -1,0 +1,10 @@
+#include "lvglDevice/GameClient/Win32DIKeyboard.h"
+
+Win32DIKeyboard::Win32DIKeyboard() {}
+Win32DIKeyboard::~Win32DIKeyboard() {}
+
+void Win32DIKeyboard::init() {}
+void Win32DIKeyboard::reset() {}
+void Win32DIKeyboard::update() {}
+Bool Win32DIKeyboard::getCapsState() { return FALSE; }
+void Win32DIKeyboard::getKey(KeyboardIO *) {}

--- a/src/GameEngineDevice/lvglDevice/GameClient/Win32DIMouse.cpp
+++ b/src/GameEngineDevice/lvglDevice/GameClient/Win32DIMouse.cpp
@@ -1,0 +1,14 @@
+#include "lvglDevice/GameClient/Win32DIMouse.h"
+
+Win32DIMouse::Win32DIMouse() {}
+Win32DIMouse::~Win32DIMouse() {}
+
+void Win32DIMouse::init() {}
+void Win32DIMouse::reset() {}
+void Win32DIMouse::update() {}
+void Win32DIMouse::initCursorResources() {}
+void Win32DIMouse::setCursor(MouseCursor) {}
+void Win32DIMouse::capture() {}
+void Win32DIMouse::releaseCapture() {}
+void Win32DIMouse::setVisibility(Bool) {}
+UnsignedByte Win32DIMouse::getMouseEvent(MouseIO *, Bool) { return MOUSE_NONE; }

--- a/src/GameEngineDevice/lvglDevice/GameClient/Win32Mouse.cpp
+++ b/src/GameEngineDevice/lvglDevice/GameClient/Win32Mouse.cpp
@@ -1,0 +1,14 @@
+#include "lvglDevice/GameClient/Win32Mouse.h"
+
+Win32Mouse::Win32Mouse() {}
+Win32Mouse::~Win32Mouse() {}
+
+void Win32Mouse::init() {}
+void Win32Mouse::reset() {}
+void Win32Mouse::update() {}
+void Win32Mouse::initCursorResources() {}
+void Win32Mouse::setCursor(MouseCursor) {}
+void Win32Mouse::capture() {}
+void Win32Mouse::releaseCapture() {}
+void Win32Mouse::setVisibility(Bool) {}
+UnsignedByte Win32Mouse::getMouseEvent(MouseIO *, Bool) { return MOUSE_NONE; }


### PR DESCRIPTION
## Summary
- flesh out empty lvglDevice headers and sources
- pull lvglDevice into its own library and link it in main build
- add win32_compat.h for MSVC type stubs
- include compat header from PreRTS
- document new linking in MIGRATION

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing Windows-specific headers)*

------
https://chatgpt.com/codex/tasks/task_e_6856b213937483258aec1521469e23cd