### PR TITLE
Add Linux build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Configure and Build
+        run: |
+          cmake -S . -B build
+          cmake --build build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build on ubuntu-latest

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: redefinition of `operator new[]`)*

------
https://chatgpt.com/codex/tasks/task_e_6856b45501c48325b681b18d9897c8ce