### PR TITLE
Integrate UniSpySDK

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -186,3 +186,5 @@ Stub headers for `Common/File.h` and `lib/basetype.h` were added to fix case-sen
 - Removed the legacy `Generals/Code` copies of the W3D device common files.
   `src/GameEngineDevice/CMakeLists.txt` now globs these sources from
   `src/GameEngineDevice/W3DDevice/Common`.
+
+- Networking now links against the full UniSpySDK library. GameEngine sources include headers from `lib/UniSpySDK` and no longer rely on GameSpy stubs.

--- a/include/GameEngine/GameNetwork/GameSpy.h
+++ b/include/GameEngine/GameNetwork/GameSpy.h
@@ -31,7 +31,7 @@
 #ifndef __GameSpy_H__
 #define __GameSpy_H__
 
-#include "GameSpy/Peer/Peer.h"
+#include "Peer/peer.h"
 
 #include "GameClient/Color.h"
 #include "Common/STLTypedefs.h"

--- a/include/GameEngine/GameNetwork/GameSpy/BuddyThread.h
+++ b/include/GameEngine/GameNetwork/GameSpy/BuddyThread.h
@@ -31,7 +31,7 @@
 #ifndef __BUDDYTHREAD_H__
 #define __BUDDYTHREAD_H__
 
-#include "GameSpy/GP/GP.h"
+#include "GP/gp.h"
 
 #define MAX_BUDDY_CHAT_LEN 128
 

--- a/include/GameEngine/GameNetwork/GameSpy/PeerDefs.h
+++ b/include/GameEngine/GameNetwork/GameSpy/PeerDefs.h
@@ -31,8 +31,8 @@
 #ifndef __PEERDEFS_H__
 #define __PEERDEFS_H__
 
-#include "GameSpy/Peer/Peer.h"
-#include "GameSpy/GP/GP.h"
+#include "Peer/peer.h"
+#include "GP/gp.h"
 
 #include "GameClient/Color.h"
 #include "Common/STLTypedefs.h"

--- a/include/GameEngine/GameNetwork/GameSpy/PeerThread.h
+++ b/include/GameEngine/GameNetwork/GameSpy/PeerThread.h
@@ -31,7 +31,7 @@
 #ifndef __PEERTHREAD_H__
 #define __PEERTHREAD_H__
 
-#include "GameSpy/Peer/Peer.h"
+#include "Peer/peer.h"
 #include "GameNetwork/NetworkDefs.h"
 
 enum SerialAuthResult

--- a/include/GameEngine/GameNetwork/GameSpy/PersistentStorageThread.h
+++ b/include/GameEngine/GameNetwork/GameSpy/PersistentStorageThread.h
@@ -31,7 +31,7 @@
 #ifndef __PERSISTENTSTORAGETHREAD_H__
 #define __PERSISTENTSTORAGETHREAD_H__
 
-#include "GameSpy/gstats/gpersist.h"
+#include "gstats/gpersist.h"
 
 #define MAX_BUDDY_CHAT_LEN 128
 

--- a/include/GameEngine/GameNetwork/GameSpyChat.h
+++ b/include/GameEngine/GameNetwork/GameSpyChat.h
@@ -31,7 +31,7 @@
 #ifndef __GAMESPYCHAT_H__
 #define __GAMESPYCHAT_H__
 
-#include "GameSpy/Peer/Peer.h"
+#include "Peer/peer.h"
 
 class GameWindow;
 class WindowLayout;

--- a/include/GameEngine/GameNetwork/GameSpyGP.h
+++ b/include/GameEngine/GameNetwork/GameSpyGP.h
@@ -31,7 +31,7 @@
 #ifndef __GAMESPYGP_H__
 #define __GAMESPYGP_H__
 
-#include "GameSpy/GP/GP.h"
+#include "GP/gp.h"
 
 void GPRecvBuddyRequestCallback(GPConnection * connection, GPRecvBuddyRequestArg * arg, void * param);
 void GPRecvBuddyMessageCallback(GPConnection * pconnection, GPRecvBuddyMessageArg * arg, void * param);

--- a/include/GameEngine/GameNetwork/GameSpyGameInfo.h
+++ b/include/GameEngine/GameNetwork/GameSpyGameInfo.h
@@ -33,7 +33,7 @@
 #ifndef __GAMESPYGAMEINFO_H__
 #define __GAMESPYGAMEINFO_H__
 
-#include "GameSpy/Peer/Peer.h"
+#include "Peer/peer.h"
 
 #include "GameNetwork/GameInfo.h"
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -115,8 +115,8 @@ endif()
 add_library(uGLES INTERFACE)
 target_include_directories(uGLES INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uGLES)
 
-add_library(UniSpySDK INTERFACE)
-target_include_directories(UniSpySDK INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/UniSpySDK)
+add_subdirectory(UniSpySDK)
+target_include_directories(UniSpySDK PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/UniSpySDK)
 
 add_library(STLport INTERFACE)
 target_include_directories(STLport INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/STLport)

--- a/src/GameEngine/CMakeLists.txt
+++ b/src/GameEngine/CMakeLists.txt
@@ -81,4 +81,7 @@ if(COMMAND target_precompile_headers)
     target_precompile_headers(gameengine PRIVATE
         ${PROJECT_SOURCE_DIR}/include/Precompiled/PreRTS.h)
 endif()
+
+# Link against UniSpy networking library
+target_link_libraries(gameengine PUBLIC UniSpySDK)
 # Partial migration of GameEngine sources

--- a/src/GameEngine/GameNetwork/GameSpy.cpp
+++ b/src/GameEngine/GameNetwork/GameSpy.cpp
@@ -28,8 +28,8 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#include "GameSpy/GP/GP.h"
-#include "GameSpy/gstats/gpersist.h"
+#include "GP/gp.h"
+#include "gstats/gpersist.h"
 
 #include "GameNetwork/FirewallHelper.h"
 #include "GameNetwork/GameSpy.h"

--- a/src/GameEngine/GameNetwork/GameSpy/MainMenuUtils.cpp
+++ b/src/GameEngine/GameNetwork/GameSpy/MainMenuUtils.cpp
@@ -43,7 +43,7 @@
 
 #include "GameClient/ShellHooks.h"
 
-#include "GameSpy/ghttp/ghttp.h"
+#include "ghttp/ghttp.h"
 
 #include "GameNetwork/DownloadManager.h"
 #include "GameNetwork/GameSpy/BuddyThread.h"

--- a/src/GameEngine/GameNetwork/GameSpyPersistentStorage.cpp
+++ b/src/GameEngine/GameNetwork/GameSpyPersistentStorage.cpp
@@ -28,7 +28,7 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#include "GameSpy/gstats/gpersist.h"
+#include "gstats/gpersist.h"
 
 #include "GameClient/Shell.h"
 #include "GameClient/MessageBox.h"


### PR DESCRIPTION
## Summary
- build UniSpySDK instead of header-only interface
- link UniSpySDK from the gameengine target
- switch GameNetwork headers to include UniSpy headers
- update network code to use new include paths
- document UniSpySDK integration in MIGRATION.md

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: error in LvglBIGFile.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6856b8062b4483258fc6c5659c6652e8