### PR TITLE
Update CI build deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libx11-dev libgl1-mesa-dev libglu1-mesa-dev xorg-dev
       - name: Configure and Build
         run: |
           cmake -S . -B build

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -188,3 +188,4 @@ Stub headers for `Common/File.h` and `lib/basetype.h` were added to fix case-sen
   `src/GameEngineDevice/W3DDevice/Common`.
 
 - Networking now links against the full UniSpySDK library. GameEngine sources include headers from `lib/UniSpySDK` and no longer rely on GameSpy stubs.
+- GitHub Actions now installs `build-essential`, X11 and Mesa development packages so Linux builds compile on CI.


### PR DESCRIPTION
## Summary
- ensure GitHub Actions installs X11 & Mesa build tools
- note new CI packages in `MIGRATION.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: redefinition errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856be62640083258ffc5e5fe2a6f6f0