### PR TITLE
Fix case-sensitive include for transport header

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -197,3 +197,4 @@ Stub headers for `Common/File.h` and `lib/basetype.h` were added to fix case-sen
 - A portable LocalFile implementation now lives under `src/GameEngine/Common/System` with its header in `include/Common`.  The class wraps the C stdio API instead of Win32 handles.
 - Header paths updated to prefer `Common/File.h` so the new implementation is used on case-sensitive systems.
 - LocalFile now overrides `operator new` and `delete` to sidestep the old memory pool hooks.
+- Added `GameNetwork/transport.h` shim header to resolve case sensitive include errors on Linux.

--- a/include/GameEngine/GameNetwork/transport.h
+++ b/include/GameEngine/GameNetwork/transport.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Transport.h"

--- a/log/build.log
+++ b/log/build.log
@@ -1,6 +1,6 @@
 -- Configuring bundled libraries
 -- Git version 2.43.0 found at '/usr/bin/git'.
--- Git using branch 'main', commit 64aa185bb3dd26dd2cf60d22b64de96517ffc5c2/'Merge pull request #57 from agentdavo/codex/update-includes-for-networkdefs.h'.
+-- Git using branch 'main', commit cf516d6b2f795c50c9f42d5d31e0e892a152dca4/'Merge pull request #58 from agentdavo/codex/update-seek-method-signature-and-verify-usages'.
 -- Could NOT find Speex (missing: SPEEX_LIBRARY SPEEX_INCLUDE_DIR) 
 -- Could NOT find FFTW (missing: FFTW_INCLUDE_DIR FFTW_LIBRARY) 
 -- Could NOT find Ogg (missing: OGG_INCLUDE_DIR OGG_LIBRARY) 
@@ -77,7 +77,7 @@
 -- Configuring core sources
 -- Configuring migrated engine modules
 -- Configuring legacy tools
--- Configuring done (0.3s)
+-- Configuring done (0.1s)
 -- Generating done (0.2s)
 -- Build files have been written to: /workspace/CnC_Generals_Zero_Hour/build
 /usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
@@ -181,34 +181,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/UniSpySDK/gcdkey/CMakeFiles/uscdkey.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 49%] Building C object lib/UniSpySDK/gcdkey/CMakeFiles/uscdkey.dir/gcdkeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gcdkey && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/gcdkey/CMakeFiles/uscdkey.dir/gcdkeys.c.o -MF CMakeFiles/uscdkey.dir/gcdkeys.c.o.d -o CMakeFiles/uscdkey.dir/gcdkeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c: In function ‘gcd_think’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c:449:36: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  449 |                                 if (client->ntries <= VAL_RETRIES)
-      |                                    ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c:454:25: note: here
-  454 |                         case cs_gotok:
-      |                         ^~~~
-In function ‘get_sockaddrin’,
-    inlined from ‘init_incoming_socket’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c:566:2,
-    inlined from ‘gcd_init’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c:136:9:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c:882:54: warning: argument 1 null where non-null expected [-Wnonnull]
-  882 |         if (saddr->sin_addr.s_addr == INADDR_NONE && strcmp(host,broadcast_t) != 0)
-      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/../common/gsPlatform.h:84,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.h:14,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gcdkey/gcdkeys.c:12:
-/usr/include/string.h: In function ‘gcd_init’:
-/usr/include/string.h:156:12: note: in a call to function ‘strcmp’ declared ‘nonnull’
-  156 | extern int strcmp (const char *__s1, const char *__s2)
-      |            ^~~~~~
-[ 49%] Linking C static library libuscdkey.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gcdkey && /usr/bin/cmake -P CMakeFiles/uscdkey.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gcdkey && /usr/bin/cmake -E cmake_link_script CMakeFiles/uscdkey.dir/link.txt --verbose=1
-/usr/bin/ar qc libuscdkey.a CMakeFiles/uscdkey.dir/gcdkeyc.c.o CMakeFiles/uscdkey.dir/gcdkeys.c.o
-/usr/bin/ranlib libuscdkey.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/gcdkey/CMakeFiles/uscdkey.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 49%] Built target uscdkey
 /usr/bin/gmake  -f lib/UniSpySDK/GP/CMakeFiles/usgp.dir/build.make lib/UniSpySDK/GP/CMakeFiles/usgp.dir/depend
@@ -217,271 +190,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/GP/CMakeFiles/usgp.dir/build.make lib/UniSpySDK/GP/CMakeFiles/usgp.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 49%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gp.c.o -MF CMakeFiles/usgp.dir/gp.c.o.d -o CMakeFiles/usgp.dir/gp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:671:14: warning: argument 2 of type ‘const char[31]’ with mismatched bound [-Warray-parameter=]
-  671 |   const char desirednick[GP_NICK_LEN],
-      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.h:21,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:14:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.h:1787:24: note: previously declared as ‘const char[21]’
- 1787 |         const gsi_char desirednick[GP_UNIQUENICK_LEN],
-      |         ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c: In function ‘gpConnectA’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 21 bytes from a region of size 1 [-Wstringop-overread]
-  158 |         return gpiConnect(connection, nick, "", email, password, "", "", "", NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:158:16: note: referencing argument 9 of type ‘const char[65]’
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.h:65:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c: In function ‘gpConnectNewUserA’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-  245 |         return gpiConnect(connection, nick, uniquenick, email, password, "", "", "", cdkey, firewall, GPITrue, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:245:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c: In function ‘gpConnectUniqueNickA’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-  312 |         return gpiConnect(connection, "", uniquenick, "", password, "", "", "", NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 2 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 51 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:312:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c: In function ‘gpConnectPreAuthenticatedA’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-  371 |         return gpiConnect(connection, "", "", "", "", authtoken, partnerchallenge, "", NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 2 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 21 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 51 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:371:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c: In function ‘gpConnectLoginTicketA’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-  431 |         return gpiConnect(connection, "", "", "", "", "", "", loginticket, NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 2 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 21 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 51 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:431:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c: In function ‘gpSuggestUniqueNickA’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:704:16: warning: ‘gpiSuggestUniqueNick’ reading 31 bytes from a region of size 21 [-Wstringop-overread]
-  704 |         return gpiSuggestUniqueNick(connection, desirednick, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gp.c:704:16: note: referencing argument 2 of type ‘const char[31]’
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.h:70:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiSearch.h:163:10: note: in a call to function ‘gpiSuggestUniqueNick’
-  163 | GPResult gpiSuggestUniqueNick(
-      |          ^~~~~~~~~~~~~~~~~~~~
-[ 49%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpi.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpi.c.o -MF CMakeFiles/usgp.dir/gpi.c.o.d -o CMakeFiles/usgp.dir/gpi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.c
-[ 49%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiBuddy.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiBuddy.c.o -MF CMakeFiles/usgp.dir/gpiBuddy.c.o.d -o CMakeFiles/usgp.dir/gpiBuddy.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiBuddy.c
-[ 49%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiBuffer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiBuffer.c.o -MF CMakeFiles/usgp.dir/gpiBuffer.c.o.d -o CMakeFiles/usgp.dir/gpiBuffer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiBuffer.c
-[ 49%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiCallback.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiCallback.c.o -MF CMakeFiles/usgp.dir/gpiCallback.c.o.d -o CMakeFiles/usgp.dir/gpiCallback.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiCallback.c
-[ 49%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiConnect.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiConnect.c.o -MF CMakeFiles/usgp.dir/gpiConnect.c.o.d -o CMakeFiles/usgp.dir/gpiConnect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c: In function ‘gpiSendLogin’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:401:34: warning: comparison between ‘GPIBool’ {aka ‘enum _GPIBool’} and ‘enum _GPEnum’ [-Wenum-compare]
-  401 |         if(iconnection->firewall == GP_FIREWALL)
-      |                                  ^~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c: In function ‘gpiDisconnectCleanupProfile’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:798:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
-  798 |     if (profile->blocked)
-      |     ^~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.h:62,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:14:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.h:23:29: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
-   23 | #define freeclear(mem)      { gsifree(mem); (mem) = NULL; }
-      |                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:801:9: note: in expansion of macro ‘freeclear’
-  801 |         freeclear(profile->authSig);
-      |         ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c: In function ‘gpiSendLogin’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:340:36: warning: ‘%s’ directive writing up to 32 bytes into a region of size between 18 and 464 [-Wformat-overflow=]
-  340 |         sprintf(buffer, "%s%s%s%s%s%s",
-      |                                    ^~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:12:
-In function ‘sprintf’,
-    inlined from ‘gpiSendLogin’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:340:2:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 49 and 527 bytes into a destination of size 512
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c: In function ‘gpiProcessConnect’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:637:44: warning: ‘%s’ directive writing up to 32 bytes into a region of size between 18 and 464 [-Wformat-overflow=]
-  637 |                 sprintf(buffer, "%s%s%s%s%s%s",
-      |                                            ^~
-In function ‘sprintf’,
-    inlined from ‘gpiProcessConnect’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiConnect.c:637:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 49 and 527 bytes into a destination of size 512
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiInfo.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiInfo.c.o -MF CMakeFiles/usgp.dir/gpiInfo.c.o.d -o CMakeFiles/usgp.dir/gpiInfo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiInfo.c
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiKeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiKeys.c.o -MF CMakeFiles/usgp.dir/gpiKeys.c.o.d -o CMakeFiles/usgp.dir/gpiKeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiKeys.c
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiOperation.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiOperation.c.o -MF CMakeFiles/usgp.dir/gpiOperation.c.o.d -o CMakeFiles/usgp.dir/gpiOperation.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiOperation.c
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiPeer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiPeer.c.o -MF CMakeFiles/usgp.dir/gpiPeer.c.o.d -o CMakeFiles/usgp.dir/gpiPeer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiPeer.c
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiProfile.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiProfile.c.o -MF CMakeFiles/usgp.dir/gpiProfile.c.o.d -o CMakeFiles/usgp.dir/gpiProfile.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.h:62,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c:11:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c: In function ‘gpiReadDiskProfile’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c:264:30: warning: ‘gpiReadDiskKeyValue’ accessing 512 bytes in a region of size 256 [-Wstringop-overflow=]
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c:264:30: note: referencing argument 3 of type ‘char[512]’
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c:264:30: warning: ‘gpiReadDiskKeyValue’ accessing 512 bytes in a region of size 256 [-Wstringop-overflow=]
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c:264:30: note: referencing argument 4 of type ‘char[512]’
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiProfile.c:124:17: note: in a call to function ‘gpiReadDiskKeyValue’
-  124 | static GPResult gpiReadDiskKeyValue(GPConnection * connection,
-      |                 ^~~~~~~~~~~~~~~~~~~
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiSearch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiSearch.c.o -MF CMakeFiles/usgp.dir/gpiSearch.c.o.d -o CMakeFiles/usgp.dir/gpiSearch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiSearch.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiSearch.c: In function ‘gpiProcessSearch’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiSearch.c:928:50: warning: comparison between ‘GPIBool’ {aka ‘enum _GPIBool’} and ‘enum _GPEnum’ [-Wenum-compare]
-  928 |                                         if((more == GP_MORE) && (arg.more == GP_MORE))
-      |                                                  ^~
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiTransfer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiTransfer.c.o -MF CMakeFiles/usgp.dir/gpiTransfer.c.o.d -o CMakeFiles/usgp.dir/gpiTransfer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c: In function ‘gpiHandleSendRequest.isra’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:492:41: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
-  492 |                 sprintf(key, "\\name%d\\", i);
-      |                                         ^
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/../common/gsPlatform.h:86,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpi.h:15,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:17:
-In function ‘sprintf’,
-    inlined from ‘gpiHandleSendRequest.isra’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:492:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 8 and 17 bytes into a destination of size 16
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c: In function ‘gpiHandleSendRequest.isra’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:506:41: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
-  506 |                 sprintf(key, "\\size%d\\", i);
-      |                                         ^
-In function ‘sprintf’,
-    inlined from ‘gpiHandleSendRequest.isra’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:506:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 8 and 17 bytes into a destination of size 16
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c: In function ‘gpiHandleSendRequest.isra’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:520:40: warning: ‘\’ directive writing 1 byte into a region of size between 0 and 9 [-Wformat-overflow=]
-  520 |                 sprintf(key, "\\mtime%d\\", i);
-      |                                        ^~
-In function ‘sprintf’,
-    inlined from ‘gpiHandleSendRequest.isra’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiTransfer.c:520:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 9 and 18 bytes into a destination of size 16
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiUnique.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiUnique.c.o -MF CMakeFiles/usgp.dir/gpiUnique.c.o.d -o CMakeFiles/usgp.dir/gpiUnique.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUnique.c
-[ 50%] Building C object lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiUtility.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/GP/CMakeFiles/usgp.dir/gpiUtility.c.o -MF CMakeFiles/usgp.dir/gpiUtility.c.o.d -o CMakeFiles/usgp.dir/gpiUtility.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.c: In function ‘gpiSetError’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.c:34:9: warning: ‘__builtin_strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
-   34 |         strncpy(dest, src, len);
-      |         ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.c: In function ‘gpiSetErrorString’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/GP/gpiUtility.c:34:9: warning: ‘__builtin_strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
-[ 50%] Linking C static library libusgp.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cmake -P CMakeFiles/usgp.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/GP && /usr/bin/cmake -E cmake_link_script CMakeFiles/usgp.dir/link.txt --verbose=1
-/usr/bin/ar qc libusgp.a CMakeFiles/usgp.dir/gp.c.o CMakeFiles/usgp.dir/gpi.c.o CMakeFiles/usgp.dir/gpiBuddy.c.o CMakeFiles/usgp.dir/gpiBuffer.c.o CMakeFiles/usgp.dir/gpiCallback.c.o CMakeFiles/usgp.dir/gpiConnect.c.o CMakeFiles/usgp.dir/gpiInfo.c.o CMakeFiles/usgp.dir/gpiKeys.c.o CMakeFiles/usgp.dir/gpiOperation.c.o CMakeFiles/usgp.dir/gpiPeer.c.o CMakeFiles/usgp.dir/gpiProfile.c.o CMakeFiles/usgp.dir/gpiSearch.c.o CMakeFiles/usgp.dir/gpiTransfer.c.o CMakeFiles/usgp.dir/gpiUnique.c.o CMakeFiles/usgp.dir/gpiUtility.c.o
-/usr/bin/ranlib libusgp.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/GP/CMakeFiles/usgp.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 50%] Built target usgp
 /usr/bin/gmake  -f lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/build.make lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/depend
@@ -490,47 +199,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/build.make lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 50%] Building C object lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/gbucket.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gstats && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/gbucket.c.o -MF CMakeFiles/usstats.dir/gbucket.c.o.d -o CMakeFiles/usstats.dir/gbucket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gbucket.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gbucket.c: In function ‘BucketAvg’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gbucket.c:213:58: warning: operation on ‘pbucket->nvals’ may be undefined [-Wsequence-point]
-  213 | #define AVG(cur, new, num) ((((cur) * (num)) + (new)) / (++num))
-      |                                                         ~^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gbucket.c:221:45: note: in expansion of macro ‘AVG’
-  221 |                 return DoSet(pbucket, bint( AVG((*(int *)DoGet(pbucket)), (*(int *)value), pbucket->nvals)));
-      |                                             ^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gbucket.c:213:58: warning: operation on ‘pbucket->nvals’ may be undefined [-Wsequence-point]
-  213 | #define AVG(cur, new, num) ((((cur) * (num)) + (new)) / (++num))
-      |                                                         ~^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gbucket.c:223:47: note: in expansion of macro ‘AVG’
-  223 |                 return DoSet(pbucket, bfloat( AVG((*(double *)DoGet(pbucket)), (*(double *)value), pbucket->nvals)));
-      |                                               ^~~
-[ 50%] Building C object lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/gstats.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gstats && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/gstats.c.o -MF CMakeFiles/usstats.dir/gstats.c.o.d -o CMakeFiles/usstats.dir/gstats.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c: In function ‘InitStatsThink’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c:302:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  302 |                 {
-      |                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c:332:9: note: here
-  332 |         case init_awaitchallenge:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c:384:25: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  384 |                         memset(rcvbuffer, 0, (unsigned int)rcvmax);
-      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c:388:9: note: here
-  388 |         case init_awaitsessionkey:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c:424:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  424 |                         stats_initstate = init_complete;
-      |                         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/gstats/gstats.c:428:9: note: here
-  428 |         case init_complete:
-      |         ^~~~
-[ 50%] Linking C static library libusstats.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gstats && /usr/bin/cmake -P CMakeFiles/usstats.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/gstats && /usr/bin/cmake -E cmake_link_script CMakeFiles/usstats.dir/link.txt --verbose=1
-/usr/bin/ar qc libusstats.a CMakeFiles/usstats.dir/gbucket.c.o CMakeFiles/usstats.dir/gstats.c.o
-/usr/bin/ranlib libusstats.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/gstats/CMakeFiles/usstats.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 50%] Built target usstats
 /usr/bin/gmake  -f lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/build.make lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/depend
@@ -539,13 +208,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/build.make lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 50%] Building C object lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/pingerMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/pinger && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/pingerMain.c.o -MF CMakeFiles/uspinger.dir/pingerMain.c.o.d -o CMakeFiles/uspinger.dir/pingerMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/pinger/pingerMain.c
-[ 50%] Linking C static library libuspinger.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/pinger && /usr/bin/cmake -P CMakeFiles/uspinger.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/pinger && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspinger.dir/link.txt --verbose=1
-/usr/bin/ar qc libuspinger.a CMakeFiles/uspinger.dir/pingerMain.c.o
-/usr/bin/ranlib libuspinger.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/pinger/CMakeFiles/uspinger.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 50%] Built target uspinger
 /usr/bin/gmake  -f lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
@@ -554,73 +217,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 50%] Building C object lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_crypt.c
-[ 50%] Building C object lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_queryengine.c
-[ 50%] Building C object lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_server.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_server.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_server.c
-[ 50%] Building C object lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverbrowsing.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverbrowsing.c: In function ‘WaitForTriggerUpdate’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverbrowsing.c:271:49: warning: comparison between ‘SBServerListState’ and ‘enum <anonymous>’ [-Wenum-compare]
-  271 |                 if (viaMaster && sb->list.state == sb_disconnected) //we were supposed to get from master, and it's disconnected
-      |                                                 ^~
-[ 50%] Building C object lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c: In function ‘ProcessMainListData’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1201:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1201 |                 GOADecrypt(&(slist->cryptkey), (unsigned char *)inbuf, inlen);
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1203:9: note: here
- 1203 |         case pi_fixedheader:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1228:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1228 |                 slist->expectedelements = -1;
-      |                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1231:9: note: here
- 1231 |         case pi_keylist:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1263:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1263 |                 slist->expectedelements = -1;
-      |                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1264:9: note: here
- 1264 |         case pi_uniquevaluelist:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1286:31: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1286 |                 slist->pstate = pi_servers;
-      |                 ~~~~~~~~~~~~~~^~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1287:9: note: here
- 1287 |         case pi_servers :
-      |         ^~~~
-In function ‘IncomingListParseServer’,
-    inlined from ‘ProcessMainListData’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1292:17,
-    inlined from ‘ProcessIncomingData’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1610:9,
-    inlined from ‘SBListThink’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1801:10:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1080:18: warning: ‘port’ may be used uninitialized [-Wmaybe-uninitialized]
- 1080 |         server = SBAllocServer(slist, ip, port);
-      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c: In function ‘SBListThink’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1055:24: note: ‘port’ was declared here
- 1055 |         unsigned short port;
-      |                        ^~~~
-In function ‘SBServerListFindServerByIP’,
-    inlined from ‘ProcessPushServer’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1508:18,
-    inlined from ‘ProcessAdHocData’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1552:11,
-    inlined from ‘ProcessIncomingData’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1615:10,
-    inlined from ‘SBListThink’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1801:10:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:213:64: warning: ‘port’ may be used uninitialized [-Wmaybe-uninitialized]
-  213 |                 if (SBServerGetPublicInetAddress(server) == ip && SBServerGetPublicQueryPortNBO(server) == port)
-      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c: In function ‘SBListThink’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/serverbrowsing/sb_serverlist.c:1499:24: note: ‘port’ was declared here
- 1499 |         unsigned short port;
-      |                        ^~~~
-[ 50%] Linking C static library libusserverbrowsing.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cmake -P CMakeFiles/usserverbrowsing.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/serverbrowsing && /usr/bin/cmake -E cmake_link_script CMakeFiles/usserverbrowsing.dir/link.txt --verbose=1
-/usr/bin/ar qc libusserverbrowsing.a CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o CMakeFiles/usserverbrowsing.dir/sb_server.c.o CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
-/usr/bin/ranlib libusserverbrowsing.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 50%] Built target usserverbrowsing
 /usr/bin/gmake  -f lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/build.make lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/depend
@@ -629,46 +226,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/build.make lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 50%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o -MF CMakeFiles/uspeer.dir/peerAutoMatch.c.o.d -o CMakeFiles/uspeer.dir/peerAutoMatch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerAutoMatch.c
-[ 50%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o -MF CMakeFiles/uspeer.dir/peerCallbacks.c.o.d -o CMakeFiles/uspeer.dir/peerCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerCallbacks.c
-[ 50%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o -MF CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o.d -o CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerGlobalCallbacks.c
-[ 50%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerHost.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerHost.c.o -MF CMakeFiles/uspeer.dir/peerHost.c.o.d -o CMakeFiles/uspeer.dir/peerHost.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerHost.c
-[ 50%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o -MF CMakeFiles/uspeer.dir/peerKeys.c.o.d -o CMakeFiles/uspeer.dir/peerKeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerKeys.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerMain.c.o -MF CMakeFiles/uspeer.dir/peerMain.c.o.d -o CMakeFiles/uspeer.dir/peerMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerMain.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o -MF CMakeFiles/uspeer.dir/peerMangle.c.o.d -o CMakeFiles/uspeer.dir/peerMangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerMangle.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o -MF CMakeFiles/uspeer.dir/peerOperations.c.o.d -o CMakeFiles/uspeer.dir/peerOperations.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerOperations.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerPing.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerPing.c.o -MF CMakeFiles/uspeer.dir/peerPing.c.o.d -o CMakeFiles/uspeer.dir/peerPing.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerPing.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerPlayers.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerPing.c:15:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerPing.c: In function ‘piGetXping’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerMain.h:67:37: warning: ‘__builtin_strncpy’ specified bound 64 equals destination size [-Wstringop-truncation]
-   67 | #define strzcpy(dest, src, len)   { strncpy(dest, src, (len)); (dest)[(len) - 1] = '\0'; }
-      |                                     ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerPing.c:982:9: note: in expansion of macro ‘strzcpy’
-  982 |         strzcpy(xpingMatch.nicks[1], nick2, PI_NICK_MAX_LEN);
-      |         ^~~~~~~
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o -MF CMakeFiles/uspeer.dir/peerPlayers.c.o.d -o CMakeFiles/uspeer.dir/peerPlayers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerPlayers.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerQR.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerQR.c.o -MF CMakeFiles/uspeer.dir/peerQR.c.o.d -o CMakeFiles/uspeer.dir/peerQR.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerQR.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o -MF CMakeFiles/uspeer.dir/peerRooms.c.o.d -o CMakeFiles/uspeer.dir/peerRooms.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerRooms.c
-[ 51%] Building C object lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerSB.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/peerSB.c.o -MF CMakeFiles/uspeer.dir/peerSB.c.o.d -o CMakeFiles/uspeer.dir/peerSB.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Peer/peerSB.c
-[ 51%] Linking C static library libuspeer.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cmake -P CMakeFiles/uspeer.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Peer && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspeer.dir/link.txt --verbose=1
-/usr/bin/ar qc libuspeer.a CMakeFiles/uspeer.dir/peerAutoMatch.c.o CMakeFiles/uspeer.dir/peerCallbacks.c.o CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o CMakeFiles/uspeer.dir/peerHost.c.o CMakeFiles/uspeer.dir/peerKeys.c.o CMakeFiles/uspeer.dir/peerMain.c.o CMakeFiles/uspeer.dir/peerMangle.c.o CMakeFiles/uspeer.dir/peerOperations.c.o CMakeFiles/uspeer.dir/peerPing.c.o CMakeFiles/uspeer.dir/peerPlayers.c.o CMakeFiles/uspeer.dir/peerQR.c.o CMakeFiles/uspeer.dir/peerRooms.c.o CMakeFiles/uspeer.dir/peerSB.c.o
-/usr/bin/ranlib libuspeer.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/Peer/CMakeFiles/uspeer.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 51%] Built target uspeer
 /usr/bin/gmake  -f lib/UniSpySDK/pt/CMakeFiles/uspt.dir/build.make lib/UniSpySDK/pt/CMakeFiles/uspt.dir/depend
@@ -677,28 +235,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/pt/CMakeFiles/uspt.dir/build.make lib/UniSpySDK/pt/CMakeFiles/uspt.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Building C object lib/UniSpySDK/pt/CMakeFiles/uspt.dir/ptMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/pt && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/pt/CMakeFiles/uspt.dir/ptMain.c.o -MF CMakeFiles/uspt.dir/ptMain.c.o.d -o CMakeFiles/uspt.dir/ptMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/pt/ptMain.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/pt/ptMain.c: In function ‘ptLookupFilePlanetInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/pt/ptMain.c:692:20: warning: ‘?file=’ directive output may be truncated writing 6 bytes into a region of size between 1 and 2048 [-Wformat-truncation=]
-  692 |                 "%s?file=%d&gamename=%s", gPTAFilePlanetURL, fileID, __GSIACGamename);
-      |                    ^~~~~~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/pt/ptMain.c:10:
-In function ‘snprintf’,
-    inlined from ‘ptLookupFilePlanetInfo’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/pt/ptMain.c:691:2:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 18 and 2138 bytes into a destination of size 2048
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-[ 51%] Linking C static library libuspt.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/pt && /usr/bin/cmake -P CMakeFiles/uspt.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/pt && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspt.dir/link.txt --verbose=1
-/usr/bin/ar qc libuspt.a CMakeFiles/uspt.dir/ptMain.c.o
-/usr/bin/ranlib libuspt.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/pt/CMakeFiles/uspt.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 51%] Built target uspt
 /usr/bin/gmake  -f lib/UniSpySDK/sake/CMakeFiles/ussake.dir/build.make lib/UniSpySDK/sake/CMakeFiles/ussake.dir/depend
@@ -707,21 +244,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/sake/CMakeFiles/ussake.dir/build.make lib/UniSpySDK/sake/CMakeFiles/ussake.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Building C object lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeMain.c.o -MF CMakeFiles/ussake.dir/sakeMain.c.o.d -o CMakeFiles/ussake.dir/sakeMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sake/sakeMain.c
-[ 51%] Building C object lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequest.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequest.c.o -MF CMakeFiles/ussake.dir/sakeRequest.c.o.d -o CMakeFiles/ussake.dir/sakeRequest.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sake/sakeRequest.c
-[ 51%] Building C object lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o -MF CMakeFiles/ussake.dir/sakeRequestMisc.c.o.d -o CMakeFiles/ussake.dir/sakeRequestMisc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sake/sakeRequestMisc.c
-[ 51%] Building C object lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o -MF CMakeFiles/ussake.dir/sakeRequestModify.c.o.d -o CMakeFiles/ussake.dir/sakeRequestModify.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sake/sakeRequestModify.c
-[ 51%] Building C object lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o -MF CMakeFiles/ussake.dir/sakeRequestRead.c.o.d -o CMakeFiles/ussake.dir/sakeRequestRead.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sake/sakeRequestRead.c
-[ 51%] Linking C static library libussake.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cmake -P CMakeFiles/ussake.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sake && /usr/bin/cmake -E cmake_link_script CMakeFiles/ussake.dir/link.txt --verbose=1
-/usr/bin/ar qc libussake.a CMakeFiles/ussake.dir/sakeMain.c.o CMakeFiles/ussake.dir/sakeRequest.c.o CMakeFiles/ussake.dir/sakeRequestMisc.c.o CMakeFiles/ussake.dir/sakeRequestModify.c.o CMakeFiles/ussake.dir/sakeRequestRead.c.o
-/usr/bin/ranlib libussake.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/sake/CMakeFiles/ussake.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 51%] Built target ussake
 /usr/bin/gmake  -f lib/UniSpySDK/sc/CMakeFiles/ussc.dir/build.make lib/UniSpySDK/sc/CMakeFiles/ussc.dir/depend
@@ -730,83 +253,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/sc/CMakeFiles/ussc.dir/build.make lib/UniSpySDK/sc/CMakeFiles/ussc.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Building C object lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciInterface.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciInterface.c.o -MF CMakeFiles/ussc.dir/sciInterface.c.o.d -o CMakeFiles/ussc.dir/sciInterface.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sc.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sci.h:18,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c: In function ‘sciInterfaceCreate’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/../common/gsPlatform.h:341:39: warning: ‘.comp.pubsvs.gamespy.com/Com...’ directive output may be truncated writing 67 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:24:66: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   24 | #define SC_SERVICE_URL_FORMAT                                    GSI_HTTP_PROTOCOL_URL "%s.comp.pubsvs." GSI_DOMAIN_NAME "/CompetitionService/CompetitionService.asmx"
-      |                                                                  ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:73:72: note: in expansion of macro ‘SC_SERVICE_URL_FORMAT’
-   73 |                         snprintf(scServiceURL, SC_SERVICE_MAX_URL_LEN, SC_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                        ^~~~~~~~~~~~~~~~~~~~~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/../common/gsPlatform.h:86:
-In function ‘snprintf’,
-    inlined from ‘sciInterfaceCreate’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:73:4:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 76 and 139 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c: In function ‘sciInterfaceCreate’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/../common/gsPlatform.h:341:39: warning: ‘.comp.pubsvs.gamespy.com/Atl...’ directive output may be truncated writing 58 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:25:50: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   25 | #define SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.comp.pubsvs." GSI_DOMAIN_NAME "/AtlasDataServices/GameConfig.asmx"
-      |                                                  ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:82:86: note: in expansion of macro ‘SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT’
-   82 |                         snprintf(scGameConfigDataServiceURL, SC_SERVICE_MAX_URL_LEN, SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:25:75: note: format string is defined here
-   25 | #define SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.comp.pubsvs." GSI_DOMAIN_NAME "/AtlasDataServices/GameConfig.asmx"
-      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘sciInterfaceCreate’ at /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciInterface.c:82:4:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 67 and 130 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-[ 51%] Building C object lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciMain.c.o -MF CMakeFiles/ussc.dir/sciMain.c.o.d -o CMakeFiles/ussc.dir/sciMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciMain.c
-[ 51%] Building C object lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciReport.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciReport.c.o -MF CMakeFiles/ussc.dir/sciReport.c.o.d -o CMakeFiles/ussc.dir/sciReport.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.c:17:41: warning: argument 1 of type ‘gsi_u8[40]’ {aka ‘unsigned char[40]’} with mismatched bound [-Warray-parameter=]
-   17 | SCResult SC_CALL sciCreateReport(gsi_u8 theSessionGuid[SC_SESSION_GUID_SIZE],
-      |                                  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.h:121:33: note: previously declared as ‘gsi_u8[16]’ {aka ‘unsigned char[16]’}
-  121 | SCResult sciCreateReport(gsi_u8 theSessionGuid[16],
-      |                          ~~~~~~~^~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.c: In function ‘sciReportAddStringValue’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.c:932:9: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
-  932 |         strncpy(&theReport->mBuffer.mData[theReport->mBuffer.mPos], theValue, strlen(theValue));
-      |         ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciReport.c:932:9: note: length computed here
-  932 |         strncpy(&theReport->mBuffer.mData[theReport->mBuffer.mPos], theValue, strlen(theValue));
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 51%] Building C object lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciSerialize.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciSerialize.c.o -MF CMakeFiles/ussc.dir/sciSerialize.c.o.d -o CMakeFiles/ussc.dir/sciSerialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciSerialize.c
-[ 52%] Building C object lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciWebServices.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sc/CMakeFiles/ussc.dir/sciWebServices.c.o -MF CMakeFiles/ussc.dir/sciWebServices.c.o.d -o CMakeFiles/ussc.dir/sciWebServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sc/sciWebServices.c
-[ 52%] Linking C static library libussc.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cmake -P CMakeFiles/ussc.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sc && /usr/bin/cmake -E cmake_link_script CMakeFiles/ussc.dir/link.txt --verbose=1
-/usr/bin/ar qc libussc.a CMakeFiles/ussc.dir/sciInterface.c.o CMakeFiles/ussc.dir/sciMain.c.o CMakeFiles/ussc.dir/sciReport.c.o CMakeFiles/ussc.dir/sciSerialize.c.o CMakeFiles/ussc.dir/sciWebServices.c.o
-/usr/bin/ranlib libussc.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/sc/CMakeFiles/ussc.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 52%] Built target ussc
 /usr/bin/gmake  -f lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/depend
@@ -815,557 +262,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 52%] Building C object lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o -MF CMakeFiles/usd2g.dir/d2gDeserialize.c.o.d -o CMakeFiles/usd2g.dir/d2gDeserialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gDeserialize.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gDeserialize.c: In function ‘d2giParseOrderItemFromResponse’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gDeserialize.c:568:25: warning: variable ‘pCatalogItem’ set but not used [-Wunused-but-set-variable]
-  568 |         D2GCatalogItem *pCatalogItem = NULL;
-      |                         ^~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gDeserialize.c: In function ‘d2giParseLoadCatalogItemsFromResponse’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gDeserialize.c:1206:58: warning: argument to ‘sizeof’ in ‘memset’ call is the same pointer type ‘D2GCatalogItemList *’ as the destination; expected ‘D2GCatalogItemList’ or an explicit length [-Wsizeof-pointer-memaccess]
- 1206 |         memset(getAllItemsResponse->mItemList, 0, sizeof(D2GCatalogItemList *));
-      |                                                          ^~~~~~~~~~~~~~~~~~
-[ 52%] Building C object lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o -MF CMakeFiles/usd2g.dir/d2gDownloads.c.o.d -o CMakeFiles/usd2g.dir/d2gDownloads.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gDownloads.c
-[ 52%] Building C object lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gMain.c.o -MF CMakeFiles/usd2g.dir/d2gMain.c.o.d -o CMakeFiles/usd2g.dir/d2gMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c: In function ‘d2gCreateCatalog’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:251:55: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  251 |                 d2gCatalog->mAccessToken = goawstrdup(accessToken);
-      |                                                       ^~~~~~~~~~~
-      |                                                       |
-      |                                                       short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/ghttp.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/ghttpMain.h:15,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/ghttpSoap.h:13,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/Direct2Game.h:11,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:12:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:251:42: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  251 |                 d2gCatalog->mAccessToken = goawstrdup(accessToken);
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:252:55: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  252 |                 d2gCatalog->mRegion      = goawstrdup(region);
-      |                                                       ^~~~~~
-      |                                                       |
-      |                                                       short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:252:42: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  252 |                 d2gCatalog->mRegion      = goawstrdup(region);
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c: In function ‘d2gCloneOrderTotal’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1421:84: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1421 |         tempOrderTotal->mOrder.mRootOrderGuid = goawstrdup(sourceOrderTotal->mOrder.mRootOrderGuid);
-      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
-      |                                                                                    |
-      |                                                                                    short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1421:47: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1421 |         tempOrderTotal->mOrder.mRootOrderGuid = goawstrdup(sourceOrderTotal->mOrder.mRootOrderGuid);
-      |                                               ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1422:79: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1422 |         tempOrderTotal->mOrder.mSubTotal = goawstrdup(sourceOrderTotal->mOrder.mSubTotal);
-      |                                                       ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
-      |                                                                               |
-      |                                                                               short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1422:42: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1422 |         tempOrderTotal->mOrder.mSubTotal = goawstrdup(sourceOrderTotal->mOrder.mSubTotal);
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1423:76: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1423 |         tempOrderTotal->mOrder.mTax   = goawstrdup(sourceOrderTotal->mOrder.mTax);
-      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                            |
-      |                                                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1423:39: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1423 |         tempOrderTotal->mOrder.mTax   = goawstrdup(sourceOrderTotal->mOrder.mTax);
-      |                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1424:76: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1424 |         tempOrderTotal->mOrder.mTotal = goawstrdup(sourceOrderTotal->mOrder.mTotal);
-      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                            |
-      |                                                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1424:39: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1424 |         tempOrderTotal->mOrder.mTotal = goawstrdup(sourceOrderTotal->mOrder.mTotal);
-      |                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1426:102: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1426 |         tempOrderTotal->mOrder.mValidation.mMessage = goawstrdup(sourceOrderTotal->mOrder.mValidation.mMessage);
-      |                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
-      |                                                                                                      |
-      |                                                                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1426:53: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1426 |         tempOrderTotal->mOrder.mValidation.mMessage = goawstrdup(sourceOrderTotal->mOrder.mValidation.mMessage);
-      |                                                     ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1428:101: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1428 |         tempOrderTotal->mOrder.mGeoInfo.mCultureCode  = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCultureCode);
-      |                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-      |                                                                                                     |
-      |                                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1428:55: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1428 |         tempOrderTotal->mOrder.mGeoInfo.mCultureCode  = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCultureCode);
-      |                                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1429:101: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1429 |         tempOrderTotal->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
-      |                                                                                                     |
-      |                                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1429:55: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1429 |         tempOrderTotal->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c: In function ‘d2gCloneOrderPurchase’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1528:88: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1528 |         anOrderPurchase->mOrder.mRootOrderGuid = goawstrdup(sourceOrderPurchase->mOrder.mRootOrderGuid);
-      |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
-      |                                                                                        |
-      |                                                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1528:48: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1528 |         anOrderPurchase->mOrder.mRootOrderGuid = goawstrdup(sourceOrderPurchase->mOrder.mRootOrderGuid);
-      |                                                ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1529:83: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1529 |         anOrderPurchase->mOrder.mSubTotal = goawstrdup(sourceOrderPurchase->mOrder.mSubTotal);
-      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
-      |                                                                                   |
-      |                                                                                   short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1529:43: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1529 |         anOrderPurchase->mOrder.mSubTotal = goawstrdup(sourceOrderPurchase->mOrder.mSubTotal);
-      |                                           ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1530:81: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1530 |         anOrderPurchase->mOrder.mTax    = goawstrdup(sourceOrderPurchase->mOrder.mTax);
-      |                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                 |
-      |                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1530:41: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1530 |         anOrderPurchase->mOrder.mTax    = goawstrdup(sourceOrderPurchase->mOrder.mTax);
-      |                                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1531:81: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1531 |         anOrderPurchase->mOrder.mTotal  = goawstrdup(sourceOrderPurchase->mOrder.mTotal);
-      |                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                                 |
-      |                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1531:41: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1531 |         anOrderPurchase->mOrder.mTotal  = goawstrdup(sourceOrderPurchase->mOrder.mTotal);
-      |                                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1533:100: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1533 |     anOrderPurchase->mOrder.mGeoInfo.mCultureCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCultureCode);
-      |                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-      |                                                                                                    |
-      |                                                                                                    short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1533:51: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1533 |     anOrderPurchase->mOrder.mGeoInfo.mCultureCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCultureCode);
-      |                                                   ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1534:101: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1534 |     anOrderPurchase->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
-      |                                                                                                     |
-      |                                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1534:52: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1534 |     anOrderPurchase->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                    ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1537:106: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1537 |         anOrderPurchase->mOrder.mValidation.mMessage = goawstrdup(sourceOrderPurchase->mOrder.mValidation.mMessage);
-      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
-      |                                                                                                          |
-      |                                                                                                          short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1537:54: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1537 |         anOrderPurchase->mOrder.mValidation.mMessage = goawstrdup(sourceOrderPurchase->mOrder.mValidation.mMessage);
-      |                                                      ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c: In function ‘d2gGetExtraItemInfoKeyValueByKeyName’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1969:28: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1969 |                 if (wcscmp(keyI, extraInfoKey) == 0 && valueI != NULL)
-      |                            ^~~~
-      |                            |
-      |                            const short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:87:
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1969:34: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1969 |                 if (wcscmp(keyI, extraInfoKey) == 0 && valueI != NULL)
-      |                                  ^~~~~~~~~~~~
-      |                                  |
-      |                                  const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1971:54: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1971 |                         *extraInfoValue = goawstrdup(valueI);
-      |                                                      ^~~~~~
-      |                                                      |
-      |                                                      const short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:1971:41: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1971 |                         *extraInfoValue = goawstrdup(valueI);
-      |                                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c: In function ‘d2gFilterCatalogItemListByKeyName’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:2033:92: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2033 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0)
-      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                            |
-      |                                                                                            short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:2033:99: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2033 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0)
-      |                                                                                                   ^~~~~~~~~~~~
-      |                                                                                                   |
-      |                                                                                                   const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c: In function ‘d2gFilterCatalogItemListByKeyNameValue’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:2141:92: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2141 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0 &&
-      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                            |
-      |                                                                                            short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:2141:99: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2141 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0 &&
-      |                                                                                                   ^~~~~~~~~~~~
-      |                                                                                                   |
-      |                                                                                                   const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:2142:96: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2142 |                                         wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mValue, extraInfoValue) == 0)
-      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                                                |
-      |                                                                                                short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gMain.c:2142:105: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2142 |                                         wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mValue, extraInfoValue) == 0)
-      |                                                                                                         ^~~~~~~~~~~~~~
-      |                                                                                                         |
-      |                                                                                                         const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-[ 52%] Building C object lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gServices.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gServices.c.o -MF CMakeFiles/usd2g.dir/d2gServices.c.o.d -o CMakeFiles/usd2g.dir/d2gServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gServices.c
-[ 52%] Building C object lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o -MF CMakeFiles/usd2g.dir/d2gUtil.c.o.d -o CMakeFiles/usd2g.dir/d2gUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giCompareWFloat’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:740:44: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  740 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) <= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                            ^~~~~~~~~~~~~~~~~~~~
-      |                                            |
-      |                                            short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsCommon.h:43,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsResultCodes.h:9,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:11:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:740:88: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  740 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) <= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                                                                        ^~~~~~~~~~~~~~~~~~~
-      |                                                                                        |
-      |                                                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:744:44: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  744 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) >= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                            ^~~~~~~~~~~~~~~~~~~~
-      |                                            |
-      |                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:744:88: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  744 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) >= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                                                                        ^~~~~~~~~~~~~~~~~~~
-      |                                                                                        |
-      |                                                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giCompareWStr’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:758:32: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  758 |                 return (wcscmp(*(UCS2String *)ptrA, *(UCS2String *) ptrB) <= 0);
-      |                                ^~~~~~~~~~~~~~~~~~~
-      |                                |
-      |                                short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:87,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsCommon.h:40:
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:758:53: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  758 |                 return (wcscmp(*(UCS2String *)ptrA, *(UCS2String *) ptrB) <= 0);
-      |                                                     ^~~~~~~~~~~~~~~~~~~~
-      |                                                     |
-      |                                                     short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:762:32: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  762 |                 return (wcscmp(*(UCS2String *)ptrA,*(UCS2String *) ptrB) >= 0);
-      |                                ^~~~~~~~~~~~~~~~~~~
-      |                                |
-      |                                short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:762:52: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  762 |                 return (wcscmp(*(UCS2String *)ptrA,*(UCS2String *) ptrB) >= 0);
-      |                                                    ^~~~~~~~~~~~~~~~~~~~
-      |                                                    |
-      |                                                    short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giFindOrAddCategory’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1305:32: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1305 |         int cmpResult = wcscmp(newCategory,currentCategory);
-      |                                ^~~~~~~~~~~
-      |                                |
-      |                                short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1305:44: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1305 |         int cmpResult = wcscmp(newCategory,currentCategory);
-      |                                            ^~~~~~~~~~~~~~~
-      |                                            |
-      |                                            short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giCloneOrderItem’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1472:75: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1472 |     dstOrderItem->mItem.mExternalItemCode = goawstrdup(srcOrderItem->mItem.mExternalItemCode);
-      |                                                        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
-      |                                                                           |
-      |                                                                           short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1472:43: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1472 |     dstOrderItem->mItem.mExternalItemCode = goawstrdup(srcOrderItem->mItem.mExternalItemCode);
-      |                                           ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1473:65: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1473 |     dstOrderItem->mItem.mName   = goawstrdup(srcOrderItem->mItem.mName);
-      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~~
-      |                                                                 |
-      |                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1473:33: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1473 |     dstOrderItem->mItem.mName   = goawstrdup(srcOrderItem->mItem.mName);
-      |                                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1474:65: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1474 |     dstOrderItem->mItem.mPrice  = goawstrdup(srcOrderItem->mItem.mPrice);
-      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                 |
-      |                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1474:33: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1474 |     dstOrderItem->mItem.mPrice  = goawstrdup(srcOrderItem->mItem.mPrice);
-      |                                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1475:65: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1475 |     dstOrderItem->mItem.mTax    = goawstrdup(srcOrderItem->mItem.mTax);
-      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                 |
-      |                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1475:33: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1475 |     dstOrderItem->mItem.mTax    = goawstrdup(srcOrderItem->mItem.mTax);
-      |                                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1478:78: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1478 |     dstOrderItem->mValidation.mMessage = goawstrdup(srcOrderItem->mValidation.mMessage);
-      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
-      |                                                                              |
-      |                                                                              short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1478:40: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1478 |     dstOrderItem->mValidation.mMessage = goawstrdup(srcOrderItem->mValidation.mMessage);
-      |                                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1481:77: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1481 |     dstOrderItem->mItemTotal.mSubTotal = goawstrdup(srcOrderItem->mItemTotal.mSubTotal);
-      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
-      |                                                                             |
-      |                                                                             short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1481:40: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1481 |     dstOrderItem->mItemTotal.mSubTotal = goawstrdup(srcOrderItem->mItemTotal.mSubTotal);
-      |                                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1482:77: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1482 |     dstOrderItem->mItemTotal.mTotal    = goawstrdup(srcOrderItem->mItemTotal.mTotal);
-      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                             |
-      |                                                                             short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1482:40: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1482 |     dstOrderItem->mItemTotal.mTotal    = goawstrdup(srcOrderItem->mItemTotal.mTotal);
-      |                                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giCloneDownloadList’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1541:102: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1541 |         dstDownloadItemList->mDownloads[i].mAssetType = goawstrdup(srcDownloadItemList->mDownloads[i].mAssetType);
-      |                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
-      |                                                                                                      |
-      |                                                                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1541:55: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1541 |         dstDownloadItemList->mDownloads[i].mAssetType = goawstrdup(srcDownloadItemList->mDownloads[i].mAssetType);
-      |                                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1559:97: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1559 |         dstDownloadItemList->mDownloads[i].mName = goawstrdup(srcDownloadItemList->mDownloads[i].mName);
-      |                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
-      |                                                                                                 |
-      |                                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1559:50: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1559 |         dstDownloadItemList->mDownloads[i].mName = goawstrdup(srcDownloadItemList->mDownloads[i].mName);
-      |                                                  ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giCloneLicenseList’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1621:85: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1621 |         dstLicenses->mLicenses[i].mLicenseKey = goawstrdup(srcLicenses->mLicenses[i].mLicenseKey);
-      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
-      |                                                                                     |
-      |                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1621:47: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1621 |         dstLicenses->mLicenses[i].mLicenseKey = goawstrdup(srcLicenses->mLicenses[i].mLicenseKey);
-      |                                               ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1639:86: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1639 |         dstLicenses->mLicenses[i].mLicenseName = goawstrdup(srcLicenses->mLicenses[i].mLicenseName);
-      |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-      |                                                                                      |
-      |                                                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1639:48: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1639 |         dstLicenses->mLicenses[i].mLicenseName = goawstrdup(srcLicenses->mLicenses[i].mLicenseName);
-      |                                                ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giLookUpExtraInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1847:24: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1847 |         if (wcscmp(info->mKey, key) == 0)
-      |                    ~~~~^~~~~~
-      |                        |
-      |                        short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1847:32: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1847 |         if (wcscmp(info->mKey, key) == 0)
-      |                                ^~~
-      |                                |
-      |                                const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giGetExtraInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1892:24: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1892 |         if (wcscmp(info->mKey, key) == 0)
-      |                    ~~~~^~~~~~
-      |                        |
-      |                        short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1892:32: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1892 |         if (wcscmp(info->mKey, key) == 0)
-      |                                ^~~
-      |                                |
-      |                                short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giFreeExtraInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:1931:54: warning: argument to ‘sizeof’ in ‘memcmp’ call is the same pointer type ‘short unsigned int *’ as the first source; expected ‘short unsigned int’ or an explicit length [-Wsizeof-pointer-memaccess]
- 1931 |         if (memcmp(elem->mKey,extraInfo->mKey, sizeof(extraInfo->mKey)) == 0)
-      |                                                      ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giDeleteManifestRecord’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:2256:17: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
- 2256 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:2256:17: note: length computed here
- 2256 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c: In function ‘d2giUpdateManifestRecord’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:2158:17: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
- 2158 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Direct2Game/d2gUtil.c:2158:17: note: length computed here
- 2158 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 52%] Linking C static library libusd2g.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cmake -P CMakeFiles/usd2g.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Direct2Game && /usr/bin/cmake -E cmake_link_script CMakeFiles/usd2g.dir/link.txt --verbose=1
-/usr/bin/ar qc libusd2g.a CMakeFiles/usd2g.dir/d2gDeserialize.c.o CMakeFiles/usd2g.dir/d2gDownloads.c.o CMakeFiles/usd2g.dir/d2gMain.c.o CMakeFiles/usd2g.dir/d2gServices.c.o CMakeFiles/usd2g.dir/d2gUtil.c.o
-/usr/bin/ranlib libusd2g.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/Direct2Game/CMakeFiles/usd2g.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 52%] Built target usd2g
 /usr/bin/gmake  -f lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/depend
@@ -1374,198 +271,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o -MF CMakeFiles/gsm.dir/src/add.c.o.d -o CMakeFiles/gsm.dir/src/add.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/add.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o -MF CMakeFiles/gsm.dir/src/code.c.o.d -o CMakeFiles/gsm.dir/src/code.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/code.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/code.c:9:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
-   12 | /*efine SIGHANDLER_T    int             /* signal handlers are void     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:13:41: warning: "/*" within comment [-Wcomment]
-   13 | /*efine HAS_SYSV_SIGNAL 1               /* sigs not blocked/reset?      */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:25:41: warning: "/*" within comment [-Wcomment]
-   25 | /*efine HAS__FSETMODE   1               /* _fsetmode -- set file mode   */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:28:41: warning: "/*" within comment [-Wcomment]
-   28 | /*efine HAS_STRINGS_H   1               /* /usr/include/strings.h       */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:35:41: warning: "/*" within comment [-Wcomment]
-   35 | /*efine HAS_UTIMES      1               /* use utimes() syscall instead */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
-   38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
-      |                                          
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o -MF CMakeFiles/gsm.dir/src/debug.c.o.d -o CMakeFiles/gsm.dir/src/debug.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/debug.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o -MF CMakeFiles/gsm.dir/src/decode.c.o.d -o CMakeFiles/gsm.dir/src/decode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/decode.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o -MF CMakeFiles/gsm.dir/src/long_term.c.o.d -o CMakeFiles/gsm.dir/src/long_term.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/long_term.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o -MF CMakeFiles/gsm.dir/src/lpc.c.o.d -o CMakeFiles/gsm.dir/src/lpc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/lpc.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o -MF CMakeFiles/gsm.dir/src/preprocess.c.o.d -o CMakeFiles/gsm.dir/src/preprocess.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c:12:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c: In function ‘Gsm_Preprocess’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:106:23: warning: operand of ‘?:’ changes signedness from ‘longword’ {aka ‘long int’} to ‘ulongword’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
-  106 |         : ((b) <= 0 ? (a) + (b)   \
-      |                       ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c:96:26: note: in expansion of macro ‘GSM_L_ADD’
-   96 |                 L_z2   = GSM_L_ADD( L_temp, L_s2 );
-      |                          ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:103:22: warning: operand of ‘?:’ changes signedness from ‘long int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
-  103 |         ( (a) <  0 ? ( (b) >= 0 ? (a) + (b)     \
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  104 |                  : (utmp = (ulongword)-((a) + 1) + (ulongword)-((b) + 1)) \
-      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  105 |                    >= MAX_LONGWORD ? MIN_LONGWORD : -(longword)utmp-2 )   \
-      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c:96:26: note: in expansion of macro ‘GSM_L_ADD’
-   96 |                 L_z2   = GSM_L_ADD( L_temp, L_s2 );
-      |                          ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:106:23: warning: operand of ‘?:’ changes signedness from ‘longword’ {aka ‘long int’} to ‘ulongword’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
-  106 |         : ((b) <= 0 ? (a) + (b)   \
-      |                       ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c:100:26: note: in expansion of macro ‘GSM_L_ADD’
-  100 |                 L_temp = GSM_L_ADD( L_z2, 16384 );
-      |                          ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:103:22: warning: operand of ‘?:’ changes signedness from ‘long int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
-  103 |         ( (a) <  0 ? ( (b) >= 0 ? (a) + (b)     \
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  104 |                  : (utmp = (ulongword)-((a) + 1) + (ulongword)-((b) + 1)) \
-      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  105 |                    >= MAX_LONGWORD ? MIN_LONGWORD : -(longword)utmp-2 )   \
-      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/preprocess.c:100:26: note: in expansion of macro ‘GSM_L_ADD’
-  100 |                 L_temp = GSM_L_ADD( L_z2, 16384 );
-      |                          ^~~~~~~~~
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o -MF CMakeFiles/gsm.dir/src/rpe.c.o.d -o CMakeFiles/gsm.dir/src/rpe.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c: In function ‘RPE_grid_positioning’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c:405:31: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  405 |                 case 3: *ep++ = 0;
-      |                         ~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c:406:17: note: here
-  406 |                 case 2:  do {
-      |                 ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c:407:39: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  407 |                                 *ep++ = 0;
-      |                                 ~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c:408:17: note: here
-  408 |                 case 1:         *ep++ = 0;
-      |                 ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c:408:39: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  408 |                 case 1:         *ep++ = 0;
-      |                                 ~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/rpe.c:409:17: note: here
-  409 |                 case 0:         *ep++ = *xMp++;
-      |                 ^~~~
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o -MF CMakeFiles/gsm.dir/src/gsm_destroy.c.o.d -o CMakeFiles/gsm.dir/src/gsm_destroy.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_destroy.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_destroy.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
-   12 | /*efine SIGHANDLER_T    int             /* signal handlers are void     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:13:41: warning: "/*" within comment [-Wcomment]
-   13 | /*efine HAS_SYSV_SIGNAL 1               /* sigs not blocked/reset?      */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:25:41: warning: "/*" within comment [-Wcomment]
-   25 | /*efine HAS__FSETMODE   1               /* _fsetmode -- set file mode   */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:28:41: warning: "/*" within comment [-Wcomment]
-   28 | /*efine HAS_STRINGS_H   1               /* /usr/include/strings.h       */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:35:41: warning: "/*" within comment [-Wcomment]
-   35 | /*efine HAS_UTIMES      1               /* use utimes() syscall instead */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
-   38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
-      |                                          
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o -MF CMakeFiles/gsm.dir/src/gsm_decode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_decode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_decode.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o -MF CMakeFiles/gsm.dir/src/gsm_encode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_encode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_encode.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o -MF CMakeFiles/gsm.dir/src/gsm_explode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_explode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_explode.c
-[ 53%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o -MF CMakeFiles/gsm.dir/src/gsm_implode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_implode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_implode.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o -MF CMakeFiles/gsm.dir/src/gsm_create.c.o.d -o CMakeFiles/gsm.dir/src/gsm_create.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_create.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_create.c:9:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
-   12 | /*efine SIGHANDLER_T    int             /* signal handlers are void     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:13:41: warning: "/*" within comment [-Wcomment]
-   13 | /*efine HAS_SYSV_SIGNAL 1               /* sigs not blocked/reset?      */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:25:41: warning: "/*" within comment [-Wcomment]
-   25 | /*efine HAS__FSETMODE   1               /* _fsetmode -- set file mode   */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:28:41: warning: "/*" within comment [-Wcomment]
-   28 | /*efine HAS_STRINGS_H   1               /* /usr/include/strings.h       */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:35:41: warning: "/*" within comment [-Wcomment]
-   35 | /*efine HAS_UTIMES      1               /* use utimes() syscall instead */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
-   38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_create.c:7:25: warning: ‘ident’ defined but not used [-Wunused-const-variable=]
-    7 | static char const       ident[] = "$Header: /tmp_amd/presto/export/kbs/jutta/src/gsm/RCS/gsm_create.c,v 1.4 1996/07/02 09:59:05 jutta Exp $";
-      |                         ^~~~~
-[ 54%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o -MF CMakeFiles/gsm.dir/src/gsm_print.c.o.d -o CMakeFiles/gsm.dir/src/gsm_print.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_print.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o -MF CMakeFiles/gsm.dir/src/gsm_option.c.o.d -o CMakeFiles/gsm.dir/src/gsm_option.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/gsm_option.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o -MF CMakeFiles/gsm.dir/src/short_term.c.o.d -o CMakeFiles/gsm.dir/src/short_term.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:12:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c: In function ‘Decoding_of_the_coded_Log_Area_Ratios’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:63:9: note: in expansion of macro ‘STEP’
-   63 |         STEP(  -2560,  -16,  13107 );
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:66:9: note: in expansion of macro ‘STEP’
-   66 |         STEP(  -1792,   -8,  17476 );
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:67:9: note: in expansion of macro ‘STEP’
-   67 |         STEP(   -341,   -4,  31454 );
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/short_term.c:68:9: note: in expansion of macro ‘STEP’
-   68 |         STEP(  -1144,   -4,  29708 );
-      |         ^~~~
-[ 54%] Building C object lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o -MF CMakeFiles/gsm.dir/src/table.c.o.d -o CMakeFiles/gsm.dir/src/table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/src/table.c
-[ 54%] Linking C static library libgsm.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cmake -P CMakeFiles/gsm.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libgsm && /usr/bin/cmake -E cmake_link_script CMakeFiles/gsm.dir/link.txt --verbose=1
-/usr/bin/ar qc libgsm.a CMakeFiles/gsm.dir/src/add.c.o CMakeFiles/gsm.dir/src/code.c.o CMakeFiles/gsm.dir/src/debug.c.o CMakeFiles/gsm.dir/src/decode.c.o CMakeFiles/gsm.dir/src/long_term.c.o CMakeFiles/gsm.dir/src/lpc.c.o CMakeFiles/gsm.dir/src/preprocess.c.o CMakeFiles/gsm.dir/src/rpe.c.o CMakeFiles/gsm.dir/src/gsm_destroy.c.o CMakeFiles/gsm.dir/src/gsm_decode.c.o CMakeFiles/gsm.dir/src/gsm_encode.c.o CMakeFiles/gsm.dir/src/gsm_explode.c.o CMakeFiles/gsm.dir/src/gsm_implode.c.o CMakeFiles/gsm.dir/src/gsm_create.c.o CMakeFiles/gsm.dir/src/gsm_print.c.o CMakeFiles/gsm.dir/src/gsm_option.c.o CMakeFiles/gsm.dir/src/short_term.c.o CMakeFiles/gsm.dir/src/table.c.o
-/usr/bin/ranlib libgsm.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 54%] Built target gsm
 /usr/bin/gmake  -f lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/build.make lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/depend
@@ -1574,87 +280,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/build.make lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 54%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/cb_search.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/cb_search.c.o -MF CMakeFiles/speex.dir/libspeex/cb_search.c.o.d -o CMakeFiles/speex.dir/libspeex/cb_search.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/cb_search.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_10_32_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_10_32_table.c.o -MF CMakeFiles/speex.dir/libspeex/exc_10_32_table.c.o.d -o CMakeFiles/speex.dir/libspeex/exc_10_32_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/exc_10_32_table.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_8_128_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_8_128_table.c.o -MF CMakeFiles/speex.dir/libspeex/exc_8_128_table.c.o.d -o CMakeFiles/speex.dir/libspeex/exc_8_128_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/exc_8_128_table.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/filters.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/filters.c.o -MF CMakeFiles/speex.dir/libspeex/filters.c.o.d -o CMakeFiles/speex.dir/libspeex/filters.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/filters.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/gain_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/gain_table.c.o -MF CMakeFiles/speex.dir/libspeex/gain_table.c.o.d -o CMakeFiles/speex.dir/libspeex/gain_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/gain_table.c
-[ 54%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/hexc_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/hexc_table.c.o -MF CMakeFiles/speex.dir/libspeex/hexc_table.c.o.d -o CMakeFiles/speex.dir/libspeex/hexc_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/hexc_table.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/high_lsp_tables.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/high_lsp_tables.c.o -MF CMakeFiles/speex.dir/libspeex/high_lsp_tables.c.o.d -o CMakeFiles/speex.dir/libspeex/high_lsp_tables.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/high_lsp_tables.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/lsp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/lsp.c.o -MF CMakeFiles/speex.dir/libspeex/lsp.c.o.d -o CMakeFiles/speex.dir/libspeex/lsp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/lsp.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/ltp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/ltp.c.o -MF CMakeFiles/speex.dir/libspeex/ltp.c.o.d -o CMakeFiles/speex.dir/libspeex/ltp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/ltp.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/ltp.c: In function ‘forced_pitch_quant’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/ltp.c:806:4: warning: ‘<unknown>’ may be used uninitialized [-Wmaybe-uninitialized]
-  806 |    syn_percep_zero16(res, ak, awk1, awk2, res, nsf, p, stack);
-      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/ltp.c:40:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/filters.h:84:6: note: by argument 1 of type ‘const spx_word16_t *’ {aka ‘const float *’} to ‘syn_percep_zero16’ declared here
-   84 | void syn_percep_zero16(const spx_word16_t *xx, const spx_coef_t *ak, const spx_coef_t *awk1, const spx_coef_t *awk2, spx_word16_t *y, int N, int ord, char *stack);
-      |      ^~~~~~~~~~~~~~~~~
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/speex.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/speex.c.o -MF CMakeFiles/speex.dir/libspeex/speex.c.o.d -o CMakeFiles/speex.dir/libspeex/speex.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/speex.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/stereo.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/stereo.c.o -MF CMakeFiles/speex.dir/libspeex/stereo.c.o.d -o CMakeFiles/speex.dir/libspeex/stereo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/stereo.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/vbr.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/vbr.c.o -MF CMakeFiles/speex.dir/libspeex/vbr.c.o.d -o CMakeFiles/speex.dir/libspeex/vbr.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/vbr.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/vq.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/vq.c.o -MF CMakeFiles/speex.dir/libspeex/vq.c.o.d -o CMakeFiles/speex.dir/libspeex/vq.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/vq.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/bits.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/bits.c.o -MF CMakeFiles/speex.dir/libspeex/bits.c.o.d -o CMakeFiles/speex.dir/libspeex/bits.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/bits.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/bits.c: In function ‘speex_bits_unpack_signed’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/bits.c:278:16: warning: left shift of negative value [-Wshift-negative-value]
-  278 |       d |= (-1)<<nbBits;
-      |                ^~
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_10_16_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_10_16_table.c.o -MF CMakeFiles/speex.dir/libspeex/exc_10_16_table.c.o.d -o CMakeFiles/speex.dir/libspeex/exc_10_16_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/exc_10_16_table.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_20_32_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_20_32_table.c.o -MF CMakeFiles/speex.dir/libspeex/exc_20_32_table.c.o.d -o CMakeFiles/speex.dir/libspeex/exc_20_32_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/exc_20_32_table.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_5_256_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_5_256_table.c.o -MF CMakeFiles/speex.dir/libspeex/exc_5_256_table.c.o.d -o CMakeFiles/speex.dir/libspeex/exc_5_256_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/exc_5_256_table.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_5_64_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/exc_5_64_table.c.o -MF CMakeFiles/speex.dir/libspeex/exc_5_64_table.c.o.d -o CMakeFiles/speex.dir/libspeex/exc_5_64_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/exc_5_64_table.c
-[ 55%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/gain_table_lbr.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/gain_table_lbr.c.o -MF CMakeFiles/speex.dir/libspeex/gain_table_lbr.c.o.d -o CMakeFiles/speex.dir/libspeex/gain_table_lbr.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/gain_table_lbr.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/hexc_10_32_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/hexc_10_32_table.c.o -MF CMakeFiles/speex.dir/libspeex/hexc_10_32_table.c.o.d -o CMakeFiles/speex.dir/libspeex/hexc_10_32_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/hexc_10_32_table.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/lpc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/lpc.c.o -MF CMakeFiles/speex.dir/libspeex/lpc.c.o.d -o CMakeFiles/speex.dir/libspeex/lpc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/lpc.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/lsp_tables_nb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/lsp_tables_nb.c.o -MF CMakeFiles/speex.dir/libspeex/lsp_tables_nb.c.o.d -o CMakeFiles/speex.dir/libspeex/lsp_tables_nb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/lsp_tables_nb.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/modes.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/modes.c.o -MF CMakeFiles/speex.dir/libspeex/modes.c.o.d -o CMakeFiles/speex.dir/libspeex/modes.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/modes.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/modes_wb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/modes_wb.c.o -MF CMakeFiles/speex.dir/libspeex/modes_wb.c.o.d -o CMakeFiles/speex.dir/libspeex/modes_wb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/modes_wb.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/nb_celp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/nb_celp.c.o -MF CMakeFiles/speex.dir/libspeex/nb_celp.c.o.d -o CMakeFiles/speex.dir/libspeex/nb_celp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/nb_celp.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/quant_lsp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/quant_lsp.c.o -MF CMakeFiles/speex.dir/libspeex/quant_lsp.c.o.d -o CMakeFiles/speex.dir/libspeex/quant_lsp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/quant_lsp.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/sb_celp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/sb_celp.c.o -MF CMakeFiles/speex.dir/libspeex/sb_celp.c.o.d -o CMakeFiles/speex.dir/libspeex/sb_celp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/sb_celp.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/speex_callbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/speex_callbacks.c.o -MF CMakeFiles/speex.dir/libspeex/speex_callbacks.c.o.d -o CMakeFiles/speex.dir/libspeex/speex_callbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/speex_callbacks.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/speex_header.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/speex_header.c.o -MF CMakeFiles/speex.dir/libspeex/speex_header.c.o.d -o CMakeFiles/speex.dir/libspeex/speex_header.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/speex_header.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/window.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/window.c.o -MF CMakeFiles/speex.dir/libspeex/window.c.o.d -o CMakeFiles/speex.dir/libspeex/window.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/window.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/fftwrap.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/fftwrap.c.o -MF CMakeFiles/speex.dir/libspeex/fftwrap.c.o.d -o CMakeFiles/speex.dir/libspeex/fftwrap.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/fftwrap.c
-[ 56%] Building C object lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/smallft.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DHAVE_CONFIG_H -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -msse -MD -MT lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/libspeex/smallft.c.o -MF CMakeFiles/speex.dir/libspeex/smallft.c.o.d -o CMakeFiles/speex.dir/libspeex/smallft.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/libspeex/smallft.c
-[ 57%] Linking C static library libspeex.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cmake -P CMakeFiles/speex.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex && /usr/bin/cmake -E cmake_link_script CMakeFiles/speex.dir/link.txt --verbose=1
-/usr/bin/ar qc libspeex.a CMakeFiles/speex.dir/libspeex/cb_search.c.o CMakeFiles/speex.dir/libspeex/exc_10_32_table.c.o CMakeFiles/speex.dir/libspeex/exc_8_128_table.c.o CMakeFiles/speex.dir/libspeex/filters.c.o CMakeFiles/speex.dir/libspeex/gain_table.c.o CMakeFiles/speex.dir/libspeex/hexc_table.c.o CMakeFiles/speex.dir/libspeex/high_lsp_tables.c.o CMakeFiles/speex.dir/libspeex/lsp.c.o CMakeFiles/speex.dir/libspeex/ltp.c.o CMakeFiles/speex.dir/libspeex/speex.c.o CMakeFiles/speex.dir/libspeex/stereo.c.o CMakeFiles/speex.dir/libspeex/vbr.c.o CMakeFiles/speex.dir/libspeex/vq.c.o CMakeFiles/speex.dir/libspeex/bits.c.o CMakeFiles/speex.dir/libspeex/exc_10_16_table.c.o CMakeFiles/speex.dir/libspeex/exc_20_32_table.c.o CMakeFiles/speex.dir/libspeex/exc_5_256_table.c.o CMakeFiles/speex.dir/libspeex/exc_5_64_table.c.o CMakeFiles/speex.dir/libspeex/gain_table_lbr.c.o CMakeFiles/speex.dir/libspeex/hexc_10_32_table.c.o CMakeFiles/speex.dir/libspeex/lpc.c.o CMakeFiles/speex.dir/libspeex/lsp_tables_nb.c.o CMakeFiles/speex.dir/libspeex/modes.c.o CMakeFiles/speex.dir/libspeex/modes_wb.c.o CMakeFiles/speex.dir/libspeex/nb_celp.c.o CMakeFiles/speex.dir/libspeex/quant_lsp.c.o CMakeFiles/speex.dir/libspeex/sb_celp.c.o CMakeFiles/speex.dir/libspeex/speex_callbacks.c.o CMakeFiles/speex.dir/libspeex/speex_header.c.o CMakeFiles/speex.dir/libspeex/window.c.o CMakeFiles/speex.dir/libspeex/fftwrap.c.o CMakeFiles/speex.dir/libspeex/smallft.c.o
-/usr/bin/ranlib libspeex.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/Voice2/libspeex/CMakeFiles/speex.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 57%] Built target speex
 /usr/bin/gmake  -f lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/build.make lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/depend
@@ -1663,39 +289,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/build.make lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvCodec.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvCodec.c.o -MF CMakeFiles/usvoice2.dir/gvCodec.c.o.d -o CMakeFiles/usvoice2.dir/gvCodec.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvCodec.c
-[ 57%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvCustomDevice.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvCustomDevice.c.o -MF CMakeFiles/usvoice2.dir/gvCustomDevice.c.o.d -o CMakeFiles/usvoice2.dir/gvCustomDevice.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvCustomDevice.c
-[ 58%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvDevice.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvDevice.c.o -MF CMakeFiles/usvoice2.dir/gvDevice.c.o.d -o CMakeFiles/usvoice2.dir/gvDevice.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvDevice.c
-[ 58%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o -MF CMakeFiles/usvoice2.dir/gvFrame.c.o.d -o CMakeFiles/usvoice2.dir/gvFrame.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvFrame.c
-[ 58%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o -MF CMakeFiles/usvoice2.dir/gvMain.c.o.d -o CMakeFiles/usvoice2.dir/gvMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvMain.c
-[ 58%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o -MF CMakeFiles/usvoice2.dir/gvSource.c.o.d -o CMakeFiles/usvoice2.dir/gvSource.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSource.c
-[ 58%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o -MF CMakeFiles/usvoice2.dir/gvSpeex.c.o.d -o CMakeFiles/usvoice2.dir/gvSpeex.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c: In function ‘gviSpeexEncode’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c:144:13: warning: variable ‘bytesWritten’ set but not used [-Wunused-but-set-variable]
-  144 |         int bytesWritten;
-      |             ^~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c: In function ‘gviSpeexDecodeAdd’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c:164:13: warning: variable ‘rcode’ set but not used [-Wunused-but-set-variable]
-  164 |         int rcode;
-      |             ^~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c: In function ‘gviSpeexDecodeSet’:
-/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvSpeex.c:182:13: warning: variable ‘rcode’ set but not used [-Wunused-but-set-variable]
-  182 |         int rcode;
-      |             ^~~~~
-[ 58%] Building C object lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o -MF CMakeFiles/usvoice2.dir/gvUtil.c.o.d -o CMakeFiles/usvoice2.dir/gvUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/gvUtil.c
-[ 58%] Linking C static library libusvoice2.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cmake -P CMakeFiles/usvoice2.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2 && /usr/bin/cmake -E cmake_link_script CMakeFiles/usvoice2.dir/link.txt --verbose=1
-/usr/bin/ar qc libusvoice2.a CMakeFiles/usvoice2.dir/gvCodec.c.o CMakeFiles/usvoice2.dir/gvCustomDevice.c.o CMakeFiles/usvoice2.dir/gvDevice.c.o CMakeFiles/usvoice2.dir/gvFrame.c.o CMakeFiles/usvoice2.dir/gvMain.c.o CMakeFiles/usvoice2.dir/gvSource.c.o CMakeFiles/usvoice2.dir/gvSpeex.c.o CMakeFiles/usvoice2.dir/gvUtil.c.o
-/usr/bin/ranlib libusvoice2.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/Voice2/CMakeFiles/usvoice2.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 58%] Built target usvoice2
 /usr/bin/gmake  -f lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/depend
@@ -1704,13 +298,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Building C object lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sharedDll && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK -I/workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/Voice2/libspeex/include/speex -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libspeex/include -I/workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o -MF CMakeFiles/UniSpySDK.dir/dllmain.c.o.d -o CMakeFiles/UniSpySDK.dir/dllmain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/UniSpySDK/sharedDll/dllmain.c
-[ 58%] Linking C static library libUniSpySDK.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sharedDll && /usr/bin/cmake -P CMakeFiles/UniSpySDK.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/UniSpySDK/sharedDll && /usr/bin/cmake -E cmake_link_script CMakeFiles/UniSpySDK.dir/link.txt --verbose=1
-/usr/bin/ar qc libUniSpySDK.a CMakeFiles/UniSpySDK.dir/dllmain.c.o
-/usr/bin/ranlib libUniSpySDK.a
+gmake[2]: Nothing to be done for 'lib/UniSpySDK/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 58%] Built target UniSpySDK
 /usr/bin/gmake  -f lib/miles-sdk-stub/CMakeFiles/milescleanup.dir/build.make lib/miles-sdk-stub/CMakeFiles/milescleanup.dir/depend
@@ -2683,41 +1271,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Building C object lib/zlib/CMakeFiles/zlib.dir/adler32.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/adler32.c.o -MF CMakeFiles/zlib.dir/adler32.c.o.d -o CMakeFiles/zlib.dir/adler32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/adler32.c
-[ 58%] Building C object lib/zlib/CMakeFiles/zlib.dir/compress.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/compress.c.o -MF CMakeFiles/zlib.dir/compress.c.o.d -o CMakeFiles/zlib.dir/compress.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/compress.c
-[ 58%] Building C object lib/zlib/CMakeFiles/zlib.dir/crc32.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/crc32.c.o -MF CMakeFiles/zlib.dir/crc32.c.o.d -o CMakeFiles/zlib.dir/crc32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/crc32.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/gzio.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/gzio.c.o -MF CMakeFiles/zlib.dir/gzio.c.o.d -o CMakeFiles/zlib.dir/gzio.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/gzio.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/uncompr.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/uncompr.c.o -MF CMakeFiles/zlib.dir/uncompr.c.o.d -o CMakeFiles/zlib.dir/uncompr.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/uncompr.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/deflate.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/deflate.c.o -MF CMakeFiles/zlib.dir/deflate.c.o.d -o CMakeFiles/zlib.dir/deflate.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/deflate.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/trees.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/trees.c.o -MF CMakeFiles/zlib.dir/trees.c.o.d -o CMakeFiles/zlib.dir/trees.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/trees.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/zutil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/zutil.c.o -MF CMakeFiles/zlib.dir/zutil.c.o.d -o CMakeFiles/zlib.dir/zutil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/zutil.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/infblock.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/infblock.c.o -MF CMakeFiles/zlib.dir/infblock.c.o.d -o CMakeFiles/zlib.dir/infblock.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/infblock.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/infcodes.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/infcodes.c.o -MF CMakeFiles/zlib.dir/infcodes.c.o.d -o CMakeFiles/zlib.dir/infcodes.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/infcodes.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/inftrees.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/inftrees.c.o -MF CMakeFiles/zlib.dir/inftrees.c.o.d -o CMakeFiles/zlib.dir/inftrees.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/inftrees.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/infutil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/infutil.c.o -MF CMakeFiles/zlib.dir/infutil.c.o.d -o CMakeFiles/zlib.dir/infutil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/infutil.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/inflate.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/inflate.c.o -MF CMakeFiles/zlib.dir/inflate.c.o.d -o CMakeFiles/zlib.dir/inflate.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/inflate.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/inffast.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/inffast.c.o -MF CMakeFiles/zlib.dir/inffast.c.o.d -o CMakeFiles/zlib.dir/inffast.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/inffast.c
-[ 59%] Building C object lib/zlib/CMakeFiles/zlib.dir/maketree.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/maketree.c.o -MF CMakeFiles/zlib.dir/maketree.c.o.d -o CMakeFiles/zlib.dir/maketree.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/maketree.c
-[ 60%] Linking C static library libzlib.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cmake -P CMakeFiles/zlib.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cmake -E cmake_link_script CMakeFiles/zlib.dir/link.txt --verbose=1
-/usr/bin/ar qc libzlib.a CMakeFiles/zlib.dir/adler32.c.o CMakeFiles/zlib.dir/compress.c.o CMakeFiles/zlib.dir/crc32.c.o CMakeFiles/zlib.dir/gzio.c.o CMakeFiles/zlib.dir/uncompr.c.o CMakeFiles/zlib.dir/deflate.c.o CMakeFiles/zlib.dir/trees.c.o CMakeFiles/zlib.dir/zutil.c.o CMakeFiles/zlib.dir/infblock.c.o CMakeFiles/zlib.dir/infcodes.c.o CMakeFiles/zlib.dir/inftrees.c.o CMakeFiles/zlib.dir/infutil.c.o CMakeFiles/zlib.dir/inflate.c.o CMakeFiles/zlib.dir/inffast.c.o CMakeFiles/zlib.dir/maketree.c.o
-/usr/bin/ranlib libzlib.a
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 60%] Built target zlib
 /usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
@@ -2726,17 +1280,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Building CXX object lib/liblzhl/CMakeFiles/lzhl.dir/src/huff.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/c++  -I/workspace/CnC_Generals_Zero_Hour/lib/liblzhl/include -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT lib/liblzhl/CMakeFiles/lzhl.dir/src/huff.cpp.o -MF CMakeFiles/lzhl.dir/src/huff.cpp.o.d -o CMakeFiles/lzhl.dir/src/huff.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/liblzhl/src/huff.cpp
-[ 60%] Building CXX object lib/liblzhl/CMakeFiles/lzhl.dir/src/lz.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/c++  -I/workspace/CnC_Generals_Zero_Hour/lib/liblzhl/include -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT lib/liblzhl/CMakeFiles/lzhl.dir/src/lz.cpp.o -MF CMakeFiles/lzhl.dir/src/lz.cpp.o.d -o CMakeFiles/lzhl.dir/src/lz.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/liblzhl/src/lz.cpp
-[ 60%] Building CXX object lib/liblzhl/CMakeFiles/lzhl.dir/src/lzhl.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/c++  -I/workspace/CnC_Generals_Zero_Hour/lib/liblzhl/include -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT lib/liblzhl/CMakeFiles/lzhl.dir/src/lzhl.cpp.o -MF CMakeFiles/lzhl.dir/src/lzhl.cpp.o.d -o CMakeFiles/lzhl.dir/src/lzhl.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/liblzhl/src/lzhl.cpp
-[ 60%] Linking CXX static library liblzhl.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/cmake -P CMakeFiles/lzhl.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/cmake -E cmake_link_script CMakeFiles/lzhl.dir/link.txt --verbose=1
-/usr/bin/ar qc liblzhl.a CMakeFiles/lzhl.dir/src/huff.cpp.o CMakeFiles/lzhl.dir/src/lz.cpp.o CMakeFiles/lzhl.dir/src/lzhl.cpp.o
-/usr/bin/ranlib liblzhl.a
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 60%] Built target lzhl
 /usr/bin/gmake  -f src/CMakeFiles/LvglPlatform.dir/build.make src/CMakeFiles/LvglPlatform.dir/depend
@@ -2745,13 +1289,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f src/CMakeFiles/LvglPlatform.dir/build.make src/CMakeFiles/LvglPlatform.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Building CXX object src/CMakeFiles/LvglPlatform.dir/LvglPlatform/LvglPlatform.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/CMakeFiles/LvglPlatform.dir/LvglPlatform/LvglPlatform.cpp.o -MF CMakeFiles/LvglPlatform.dir/LvglPlatform/LvglPlatform.cpp.o.d -o CMakeFiles/LvglPlatform.dir/LvglPlatform/LvglPlatform.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/LvglPlatform/LvglPlatform.cpp
-[ 60%] Linking CXX static library libLvglPlatform.a
-cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/cmake -P CMakeFiles/LvglPlatform.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/cmake -E cmake_link_script CMakeFiles/LvglPlatform.dir/link.txt --verbose=1
-/usr/bin/ar qc libLvglPlatform.a CMakeFiles/LvglPlatform.dir/LvglPlatform/LvglPlatform.cpp.o
-/usr/bin/ranlib libLvglPlatform.a
+gmake[2]: Nothing to be done for 'src/CMakeFiles/LvglPlatform.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 60%] Built target LvglPlatform
 /usr/bin/gmake  -f src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/build.make src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/depend
@@ -2760,426 +1298,6 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/build.make src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/W3DDevice/GameLogic/W3DGameLogic.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/W3DDevice/GameLogic/W3DGameLogic.cpp.o -MF CMakeFiles/gameenginedevice.dir/W3DDevice/GameLogic/W3DGameLogic.cpp.o.d -o CMakeFiles/gameenginedevice.dir/W3DDevice/GameLogic/W3DGameLogic.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/W3DDevice/GameLogic/W3DGameLogic.cpp
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFile.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFile.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFile.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFile.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglBIGFile.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubsystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/LocalFileSystem.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglBIGFile.cpp:2:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:57,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/File.h:3,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/LocalFile.h:3,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglBIGFile.cpp:1:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h: In static member function ‘static void* File::operator new(size_t, FileMagicEnum)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  692 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h: In static member function ‘static void* File::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  705 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/RAMFile.h: In static member function ‘static void* RAMFile::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/RAMFile.h:77:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   77 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RAMFile, "RAMFile")
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/StreamingArchiveFile.h: In static member function ‘static void* StreamingArchiveFile::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/StreamingArchiveFile.h:77:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   77 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(StreamingArchiveFile, "StreamingArchiveFile")
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFileSystem.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFileSystem.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFileSystem.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglBIGFileSystem.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglBIGFileSystem.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubsystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/ArchiveFileSystem.h:55,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/ArchiveFile.h:36,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglBIGFileSystem.cpp:2:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h: In static member function ‘static void* File::operator new(size_t, FileMagicEnum)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  692 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h: In static member function ‘static void* File::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  705 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/AudioEventInfo.h: In static member function ‘static void* AudioEventInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/AudioEventInfo.h:87:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   87 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( AudioEventInfo, "AudioEventInfo" )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglGameEngine.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglGameEngine.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglGameEngine.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglGameEngine.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglGameEngine.cpp
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglLocalFileSystem.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglLocalFileSystem.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglLocalFileSystem.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglLocalFileSystem.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglLocalFileSystem.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubsystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/LocalFileSystem.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice/lvglDevice/Common/LvglLocalFileSystem.h:3,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglLocalFileSystem.cpp:1:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h: In static member function ‘static void* File::operator new(size_t, FileMagicEnum)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  692 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h: In static member function ‘static void* File::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  705 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglOSDisplay.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglOSDisplay.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglOSDisplay.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/LvglOSDisplay.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglOSDisplay.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubsystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameClient/GameText.h:54,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/LvglOSDisplay.cpp:4:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFile.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFile.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFile.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFile.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32BIGFile.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubsystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/ArchiveFileSystem.h:55,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/ArchiveFile.h:36,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice/lvglDevice/Common/Win32BIGFile.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32BIGFile.cpp:1:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFileSystem.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFileSystem.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFileSystem.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32BIGFileSystem.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32BIGFileSystem.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubsystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/ArchiveFileSystem.h:55,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice/lvglDevice/Common/Win32BIGFileSystem.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32BIGFileSystem.cpp:1:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32CDManager.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32CDManager.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32CDManager.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32CDManager.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32CDManager.cpp
-In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/STLTypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/../../Generals/Code/GameEngine/Include/Common/SubsystemInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/Common/SubSystemInterface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/CDManager.h:55,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice/lvglDevice/Common/Win32CDManager.h:3,
-                 from /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32CDManager.cpp:1:
-/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
-   32 | #warning \
-      |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
-      |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  650 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [ 60%] Building CXX object src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32GameEngine.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/src/GameEngineDevice && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/GameEngine -I/workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice -I/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include -I/workspace/CnC_Generals_Zero_Hour/include/Precompiled -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles-sdk-stub/mss -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32GameEngine.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32GameEngine.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32GameEngine.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/GameEngineDevice/lvglDevice/Common/Win32GameEngine.cpp
 In file included from /usr/include/c++/13/backward/hash_map:60,
@@ -3193,13 +1311,530 @@ In file included from /usr/include/c++/13/backward/hash_map:60,
 /usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
    32 | #warning \
       |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/ConnectionManager.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetworkInterface.h:35,
-                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice/lvglDevice/Common/Win32GameEngine.h:4:
-/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/Connection.h:43:10: fatal error: GameNetwork/transport.h: No such file or directory
-   43 | #include "GameNetwork/transport.h"
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
-compilation terminated.
+In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/INI.h:37:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:747:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  747 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
+      |                                                                                                  ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/MessageStream.h: In static member function ‘static void* GameMessageArgument::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/MessageStream.h:86:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   86 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(GameMessageArgument, "GameMessageArgument")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/MessageStream.h: In static member function ‘static void* GameMessage::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/MessageStream.h:103:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  103 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(GameMessage, "GameMessage")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:41:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   41 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetCommandMsg, "NetCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetGameCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:79:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   79 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetGameCommandMsg, "NetGameCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetAckBothCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:106:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  106 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetAckBothCommandMsg, "NetAckBothCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetAckStage1CommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:130:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  130 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetAckStage1CommandMsg, "NetAckStage1CommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetAckStage2CommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:154:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  154 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetAckStage2CommandMsg, "NetAckStage2CommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetFrameCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:174:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  174 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetFrameCommandMsg, "NetFrameCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetPlayerLeaveCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:189:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  189 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetPlayerLeaveCommandMsg, "NetPlayerLeaveCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetRunAheadMetricsCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:204:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  204 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetRunAheadMetricsCommandMsg, "NetRunAheadMetricsCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetRunAheadCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:222:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  222 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetRunAheadCommandMsg, "NetRunAheadCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDestroyPlayerCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:241:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  241 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDestroyPlayerCommandMsg, "NetDestroyPlayerCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetKeepAliveCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:256:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  256 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetKeepAliveCommandMsg, "NetKeepAliveCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDisconnectKeepAliveCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:265:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  265 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDisconnectKeepAliveCommandMsg, "NetDisconnectKeepAliveCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDisconnectPlayerCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:274:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  274 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDisconnectPlayerCommandMsg, "NetDisconnectPlayerCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetPacketRouterQueryCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:293:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  293 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetPacketRouterQueryCommandMsg, "NetPacketRouterQueryCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetPacketRouterAckCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:302:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  302 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetPacketRouterAckCommandMsg, "NetPacketRouterAckCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDisconnectChatCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:311:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  311 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDisconnectChatCommandMsg, "NetDisconnectChatCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetChatCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:326:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  326 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetChatCommandMsg, "NetChatCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDisconnectVoteCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:345:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  345 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDisconnectVoteCommandMsg, "NetDisconnectVoteCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetProgressCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:364:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  364 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetProgressCommandMsg, "NetProgressCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetWrapperCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:378:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  378 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetWrapperCommandMsg, "NetWrapperCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetFileCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:417:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  417 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetFileCommandMsg, "NetFileCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetFileAnnounceCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:443:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  443 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetFileAnnounceCommandMsg, "NetFileAnnounceCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetFileProgressCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:469:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  469 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetFileProgressCommandMsg, "NetFileProgressCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDisconnectFrameCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:488:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  488 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDisconnectFrameCommandMsg, "NetDisconnectFrameCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetDisconnectScreenOffCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:502:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  502 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetDisconnectScreenOffCommandMsg, "NetDisconnectScreenOffCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h: In static member function ‘static void* NetFrameResendRequestCommandMsg::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandMsg.h:516:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+  516 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetFrameResendRequestCommandMsg, "NetFrameResendRequestCommandMsg")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandRef.h: In static member function ‘static void* NetCommandRef::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandRef.h:47:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   47 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetCommandRef, "NetCommandRef")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandList.h: In static member function ‘static void* NetCommandList::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetCommandList.h:49:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   49 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetCommandList, "NetCommandList")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/User.h: In static member function ‘static void* User::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/User.h:39:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   39 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(User, "User")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetPacket.h: In static member function ‘static void* NetPacket::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/NetPacket.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetPacket, "NetPacket")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/Connection.h: In static member function ‘static void* Connection::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/Connection.h:50:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   50 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(Connection, "Connection")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/FrameDataManager.h: In static member function ‘static void* FrameDataManager::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:650:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  650 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:676:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  676 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameNetwork/FrameDataManager.h:36:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   36 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(FrameDataManager, "FrameDataManager")
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:41,
+                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngineDevice/lvglDevice/Common/Win32GameEngine.h:5:
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: At global scope:
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:45:6: error: use of enum ‘StaticGameLODLevel’ without previous declaration
+   45 | enum StaticGameLODLevel;
+      |      ^~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:115:17: error: ‘StaticGameLODLevel’ does not name a type
+  115 |         virtual StaticGameLODLevel getMinimumRequiredGameLOD() const { return (StaticGameLODLevel)0;}
+      |                 ^~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: In static member function ‘static void* Module::operator new(size_t, ModuleMagicEnum)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  692 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:182:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  182 |         MEMORY_POOL_GLUE_ABC( Module )                                          ///< this abstract class needs memory pool hooks
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: In static member function ‘static void* Module::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  705 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:182:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  182 |         MEMORY_POOL_GLUE_ABC( Module )                                          ///< this abstract class needs memory pool hooks
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: In static member function ‘static void* ObjectModule::operator new(size_t, ObjectModuleMagicEnum)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  692 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:243:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  243 |         MEMORY_POOL_GLUE_ABC( ObjectModule )                    ///< this abstract class needs memory pool hooks
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: In static member function ‘static void* ObjectModule::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  705 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:243:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  243 |         MEMORY_POOL_GLUE_ABC( ObjectModule )                    ///< this abstract class needs memory pool hooks
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: In static member function ‘static void* DrawableModule::operator new(size_t, DrawableModuleMagicEnum)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  692 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:288:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  288 |         MEMORY_POOL_GLUE_ABC( DrawableModule )          ///< this abstract class needs memory pool hooks
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h: In static member function ‘static void* DrawableModule::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  705 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/Module.h:288:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  288 |         MEMORY_POOL_GLUE_ABC( DrawableModule )          ///< this abstract class needs memory pool hooks
+      |         ^~~~~~~~~~~~~~~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/Generals/Code/GameEngine/Include/Common/DisabledTypes.h:37,
+                 from /workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h:37:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/BitFlags.h: In static member function ‘static Int BitFlags<NUMBITS>::getSingleBitFromName(const char*)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/BitFlags.h:252:23: error: there are no arguments to ‘stricmp’ that depend on a template parameter, so a declaration of ‘stricmp’ must be available [-fpermissive]
+  252 |                   if( stricmp( *name, token ) == 0 )
+      |                       ^~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/BitFlags.h:252:23: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/BehaviorModule.h: In static member function ‘static void* BehaviorModule::operator new(size_t, BehaviorModuleMagicEnum)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  692 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/BehaviorModule.h:146:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  146 |         MEMORY_POOL_GLUE_ABC( BehaviorModule )
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/BehaviorModule.h: In static member function ‘static void* BehaviorModule::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  705 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/BehaviorModule.h:146:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  146 |         MEMORY_POOL_GLUE_ABC( BehaviorModule )
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h: At global scope:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h:65:6: error: use of enum ‘CommandOption’ without previous declaration
+   65 | enum CommandOption;
+      |      ^~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h: In static member function ‘static void* UpdateModule::operator new(size_t, UpdateModuleMagicEnum)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:692:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  692 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h:136:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  136 |         MEMORY_POOL_GLUE_ABC( UpdateModule )
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h: In static member function ‘static void* UpdateModule::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/Common/GameMemory.h:705:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  705 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h:136:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+  136 |         MEMORY_POOL_GLUE_ABC( UpdateModule )
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h: At global scope:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/Module/UpdateModule.h:269:17: error: ‘CommandOption’ does not name a type; did you mean ‘CommandButton’?
+  269 |         virtual CommandOption getCommandOption() const = 0;
+      |                 ^~~~~~~~~~~~~
+      |                 CommandButton
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:68:6: error: use of enum ‘BuildableStatus’ without previous declaration
+   68 | enum BuildableStatus;
+      |      ^~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:69:6: error: use of enum ‘ObjectStatusBits’ without previous declaration
+   69 | enum ObjectStatusBits;
+      |      ^~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:95:14: error: ‘hash_map’ in namespace ‘std’ does not name a template type
+   95 | typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
+      |              ^~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:96:9: error: ‘ObjectPtrHash’ does not name a type
+   96 | typedef ObjectPtrHash::const_iterator ObjectPtrIter;
+      |         ^~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:142:66: error: ‘BuildableStatus’ has not been declared
+  142 |         void setBuildableStatusOverride(const ThingTemplate* tt, BuildableStatus bs);
+      |                                                                  ^~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:143:67: error: ‘BuildableStatus’ has not been declared
+  143 |         Bool findBuildableStatusOverride(const ThingTemplate* tt, BuildableStatus& bs) const;
+      |                                                                   ^~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:150:66: error: ‘ObjectStatusBits’ has not been declared
+  150 |         Object *friend_createObject( const ThingTemplate *thing, ObjectStatusBits statusBits, Team *team );
+      |                                                                  ^~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:267:22: error: ‘hash_map’ in namespace ‘std’ does not name a template type
+  267 |         typedef std::hash_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString> > BuildableMap;
+      |                      ^~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:268:9: error: ‘BuildableMap’ does not name a type
+  268 |         BuildableMap m_thingTemplateBuildableOverrides;
+      |         ^~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:273:22: error: ‘hash_map’ in namespace ‘std’ does not name a template type
+  273 |         typedef std::hash_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ControlBarOverrideMap;
+      |                      ^~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:274:9: error: ‘ControlBarOverrideMap’ does not name a type
+  274 |         ControlBarOverrideMap m_controlBarOverrides;
+      |         ^~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:304:9: error: ‘ObjectPtrHash’ does not name a type
+  304 |         ObjectPtrHash m_objHash;                                                                                                                                ///< Used for ObjectID lookups
+      |         ^~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h: In member function ‘Object* GameLogic::findObjectByID(ObjectID)’:
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:399:9: error: ‘ObjectPtrHash’ has not been declared
+  399 |         ObjectPtrHash::iterator it = m_objHash.find(id);
+      |         ^~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:400:13: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+  400 |         if (it == m_objHash.end())
+      |             ^~
+      |             int
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:400:19: error: ‘m_objHash’ was not declared in this scope; did you mean ‘m_objList’?
+  400 |         if (it == m_objHash.end())
+      |                   ^~~~~~~~~
+      |                   m_objList
+/workspace/CnC_Generals_Zero_Hour/include/GameEngine/GameLogic/GameLogic.h:403:18: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+  403 |         return (*it).second;
+      |                  ^~
+      |                  int
 gmake[2]: *** [src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/build.make:205: src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/lvglDevice/Common/Win32GameEngine.cpp.o] Error 1
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 gmake[1]: *** [CMakeFiles/Makefile2:1598: src/GameEngineDevice/CMakeFiles/gameenginedevice.dir/all] Error 2


### PR DESCRIPTION
## Summary
- add missing `GameNetwork/transport.h` shim for Linux builds
- document the new shim in `MIGRATION.md`
- update build log

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ObjectPtrHash not declared)*

------
https://chatgpt.com/codex/tasks/task_e_685739329964832580019bfbf3cb7eb5