### PR TITLE
Fix wwlib headers and include paths

### DIFF
--- a/log/build.log
+++ b/log/build.log
@@ -26,7 +26,7 @@
 -- Looking for IceConnectionNumber in ICE - found
 -- Found Git: /usr/bin/git (found version "2.43.0") 
 -- Git version 2.43.0 found at '/usr/bin/git'.
--- Git using branch 'main', commit d68043504a7aae1c116b0d4a719704d131b7a77a/'snake case renames'.
+-- Git using branch 'main', commit 57b64d48a2f075b38a40ed5f9bd474720180388a/'snake case renames'.
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
 -- Found Threads: TRUE  
@@ -44,8 +44,8 @@
 
 -- Configuring core sources
 -- Configuring migrated engine modules
--- Configuring done (1.6s)
--- Generating done (0.1s)
+-- Configuring done (1.7s)
+-- Generating done (0.2s)
 -- Build files have been written to: /workspace/CnC_Generals_Zero_Hour/build
 /usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
 /usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
@@ -72,7 +72,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c
 [  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o
+[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c
 [  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c
@@ -94,7 +94,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c
 [  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o
+[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c
 [  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c
@@ -158,7 +158,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_list_border.c
 [  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o
+[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_logo.c
 [  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c
@@ -180,7 +180,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/lv_demo_music_main.c
 [  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_arc_bg.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o
+[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c
 [  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c
@@ -244,7 +244,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_refr.c
 [  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/display/lv_display.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o
+[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/dma2d/lv_draw_dma2d.c
 [  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c
@@ -266,7 +266,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_line.c
 [  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_mask.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o
+[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_rect.c
 [ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_triangle.c
@@ -308,7 +308,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c
 [ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o
+[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c
 [ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c
@@ -330,7 +330,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c
 [ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o
+[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c
 [ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c
@@ -352,7 +352,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c
 [ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_path.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o
+[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c
 [ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/opengles/lv_draw_opengles.c
@@ -374,7 +374,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c
 [ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o
+[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c
 [ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sdl/lv_draw_sdl.c
@@ -394,7 +394,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
 [ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o
+[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c
 [ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw.c
@@ -416,7 +416,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_line.c
 [ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_mask.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o
+[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c
 [ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_transform.c
@@ -438,7 +438,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c
 [ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o
+[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c
 [ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -460,7 +460,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_math.c
 [ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_path.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o
+[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c
 [ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c
@@ -480,7 +480,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
 [ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st7735/lv_st7735.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o
+[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st7789/lv_st7789.c
 [ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st7796/lv_st7796.c
@@ -502,7 +502,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/libinput/lv_libinput.c
 [ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/libinput/lv_xkb.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o
+[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_cache.c
 [ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_entry.c
@@ -524,7 +524,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_keyboard.c
 [ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_mouse.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o
+[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c
 [ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_window.c
@@ -546,7 +546,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wayland_smm.c
 [ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_cache.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o
+[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_dmabuf.c
 [ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_keyboard.c
@@ -566,7 +566,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_window.c
 [ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_window_decorations.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o
+[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c
 [ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/windows/lv_windows_context.c
@@ -588,7 +588,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_fmt_txt.c
 [ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_10.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o
+[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_12.c
 [ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_14.c
@@ -610,7 +610,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_28.c
 [ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_28_compressed.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o
+[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_30.c
 [ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_32.c
@@ -630,9 +630,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_46.c
 [ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_48.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o
+[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_8.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o
+[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_simsun_14_cjk.c
 [ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_simsun_16_cjk.c
@@ -652,7 +652,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/indev/lv_indev_scroll.c
 [ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/layouts/flex/lv_flex.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o
+[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/layouts/grid/lv_grid.c
 [ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/layouts/lv_layout.c
@@ -674,7 +674,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmltok_impl.c
 [ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmltok_ns.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o
+[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/ffmpeg/lv_ffmpeg.c
 [ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/freetype/lv_freetype.c
@@ -696,7 +696,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_fatfs.c
 [ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_littlefs.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o
+[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_memfs.c
 [ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_posix.c
@@ -716,9 +716,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/libpng/lv_libpng.c
 [ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/lodepng/lodepng.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o
+[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/lodepng/lv_lodepng.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o
+[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/lz4/lz4.c
 [ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/qrcode/lv_qrcode.c
@@ -738,7 +738,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg_render.c
 [ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg_token.c
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o
+[ 31%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgAccessor.cpp
 [ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgAnimation.cpp
@@ -760,7 +760,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp
 [ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o
+[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp
 [ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp
@@ -782,7 +782,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgPicture.cpp
 [ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgRawLoader.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o
+[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgRender.cpp
 [ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSaver.cpp
@@ -802,9 +802,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp
 [ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgUtil.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o
+[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwCanvas.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o
+[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwFill.cpp
 [ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwImage.cpp
@@ -824,7 +824,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwShape.cpp
 [ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwStroke.cpp
-[ 36%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o
+[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp
 [ 36%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgText.cpp
@@ -846,7 +846,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/class/lv_cache_lru_rb.c
 [ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/instance/lv_image_cache.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o
+[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/instance/lv_image_header_cache.c
 [ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/lv_cache.c
@@ -866,9 +866,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_bidi.c
 [ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_circle_buf.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o
+[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_color.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o
+[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_color_op.c
 [ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_event.c
@@ -888,9 +888,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_math.c
 [ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_matrix.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o
+[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_palette.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o
+[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_profiler_builtin.c
 [ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_rb.c
@@ -910,9 +910,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_tree.c
 [ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_utils.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o
+[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_cmsis_rtos2.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o
+[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_freertos.c
 [ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_linux.c
@@ -932,7 +932,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_windows.c
 [ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/file_explorer/lv_file_explorer.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o
+[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/font_manager/lv_font_manager.c
 [ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/font_manager/lv_font_manager_recycle.c
@@ -952,9 +952,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/observer/lv_observer.c
 [ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/snapshot/lv_snapshot.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o
+[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/sysmon/lv_sysmon.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o
+[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_display.c
 [ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_helpers.c
@@ -974,9 +974,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_base_types.c
 [ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_component.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o
+[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o
+[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_style.c
 [ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_update.c
@@ -996,9 +996,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c
 [ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o
+[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o
+[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c
 [ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c
@@ -1018,7 +1018,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c
 [ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o
+[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c
 [ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_table_parser.c
@@ -1038,9 +1038,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/clib/lv_mem_core_clib.c
 [ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/clib/lv_sprintf_clib.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o
+[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/clib/lv_string_clib.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o
+[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/lv_mem.c
 [ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c
@@ -1060,9 +1060,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/themes/mono/lv_theme_mono.c
 [ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/themes/simple/lv_theme_simple.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o
+[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/tick/lv_tick.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o
+[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/3dtexture/lv_3dtexture.c
 [ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/animimage/lv_animimage.c
@@ -1082,9 +1082,9 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c
 [ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o
+[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/canvas/lv_canvas.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o
+[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/chart/lv_chart.c
 [ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/checkbox/lv_checkbox.c
@@ -1102,214 +1102,214 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/led/lv_led.c
 [ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/line/lv_line.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o
+[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/list/lv_list.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o
+[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/lottie/lv_lottie.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/menu/lv_menu.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/msgbox/lv_msgbox.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/objx_templ/lv_objx_templ.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_animimage_properties.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_dropdown_properties.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_image_properties.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_keyboard_properties.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_label_properties.c
-[ 49%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o
+[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_obj_properties.c
 [ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_roller_properties.c
 [ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_slider_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_style_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_textarea_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/roller/lv_roller.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/scale/lv_scale.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/slider/lv_slider.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/span/lv_span.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/spinbox/lv_spinbox.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/spinner/lv_spinner.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o
+[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/switch/lv_switch.c
 [ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/table/lv_table.c
 [ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/tabview/lv_tabview.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o
+[ 52%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/textarea/lv_textarea.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o
+[ 52%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/tileview/lv_tileview.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o
+[ 52%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/win/lv_win.c
-[ 51%] Linking CXX static library liblvgl.a
+[ 52%] Linking CXX static library liblvgl.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -P CMakeFiles/lvgl.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -E cmake_link_script CMakeFiles/lvgl.dir/link.txt --verbose=1
 /usr/bin/ar qc liblvgl.a CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_avatar.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/lv_demo_benchmark.c.o CMakeFiles/lvgl.dir/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c.o CMakeFiles/lvgl.dir/lvgl/demos/lv_demos.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_list.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/lv_demo_render.c.o CMakeFiles/lvgl.dir/lvgl/demos/stress/lv_demo_stress.c.o CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c.o CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_clothes.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_needle.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_lvgl_logo.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/lv_demo_widgets.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_group.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_class.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_draw.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_event.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_id_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_pos.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_property.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_scroll.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style_gen.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_tree.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_3d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_buf.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_image.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_vector.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_image_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_grad.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_letter.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_vector.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/drm/lv_linux_drm.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/fb/lv_linux_fbdev.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ft81x/lv_ft81x.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ili9341/lv_ili9341.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp.o CMakeFiles/lvgl.dir/lvgl/src/drivers/evdev/lv_evdev.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_glfw_window.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_debug.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_driver.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_texture.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/qnx/lv_qnx.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_context.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_display.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_private.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_seat.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shell.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shm.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_touch.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_display.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_input.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_display.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_input.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_binfont_loader.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14_aligned.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_16.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_18.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_20.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_22.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_24.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_26.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_34.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_36.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_38.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_40.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_42.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_44.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_16.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_8.c.o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev.c.o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_gesture.c.o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/code128.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/lv_barcode.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/bin_decoder/lv_bin_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/bmp/lv_bmp.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlparse.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlrole.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_glyph.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_image.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_outline.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_ftsystem.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_cbfs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_stdio.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_uefi.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_win32.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/gif/gifdec.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/gif/lv_gif.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/qrcodegen.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/rle/lv_rle.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/rlottie/lv_rlottie.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCapi.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCompressor.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgFill.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgGlCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgInitializer.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModel.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModifier.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParser.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgMath.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPaint.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgScene.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgShape.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgStr.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgPath.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMath.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMemPool.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRaster.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRenderer.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRle.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgWgCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgXmlParser.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/lv_tjpgd.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/tjpgd.c.o CMakeFiles/lvgl.dir/lvgl/src/lv_init.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_ll.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache_entry.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim_timeline.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_area.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_array.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_async.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_fs.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_grad.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_iter.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_ll.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_log.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_lru.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style_gen.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_templ.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text_ap.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_timer.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_mqx.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os_none.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_pthread.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_sdl2.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment.c.o CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment_manager.c.o CMakeFiles/lvgl.dir/lvgl/src/others/gridnav/lv_gridnav.c.o CMakeFiles/lvgl.dir/lvgl/src/others/ime/lv_ime_pinyin.c.o CMakeFiles/lvgl.dir/lvgl/src/others/imgfont/lv_imgfont.c.o CMakeFiles/lvgl.dir/lvgl/src/others/monkey/lv_monkey.c.o CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev_gesture.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_screenshot_compare.c.o CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c.o CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_widget.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_button_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_event_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_image_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_label_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_string_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_tlsf.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_string_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/default/lv_theme_default.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/lv_theme.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/arc/lv_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/bar/lv_bar.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/button/lv_button.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_chinese.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/dropdown/lv_dropdown.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/image/lv_image.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/imagebutton/lv_imagebutton.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/keyboard/lv_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/label/lv_label.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o
 /usr/bin/ranlib liblvgl.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Built target lvgl
+[ 52%] Built target lvgl
 /usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Building C object lib/CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o
+[ 52%] Building C object lib/CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -O3 -DNDEBUG -MD -MT lib/CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o -MF CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o.d -o CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/miniaudio/miniaudio.c
-[ 51%] Linking C static library libminiaudio.a
+[ 53%] Linking C static library libminiaudio.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -P CMakeFiles/miniaudio.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -E cmake_link_script CMakeFiles/miniaudio.dir/link.txt --verbose=1
 /usr/bin/ar qc libminiaudio.a CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o
 /usr/bin/ranlib libminiaudio.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Built target miniaudio
+[ 53%] Built target miniaudio
 /usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Auth.c.o
+[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Auth.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Auth.c.o -MF CMakeFiles/usgt2.dir/gt2Auth.c.o.d -o CMakeFiles/usgt2.dir/gt2Auth.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Auth.c
-[ 51%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Buffer.c.o
+[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Buffer.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Buffer.c.o -MF CMakeFiles/usgt2.dir/gt2Buffer.c.o.d -o CMakeFiles/usgt2.dir/gt2Buffer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Buffer.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Callback.c.o
+[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Callback.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Callback.c.o -MF CMakeFiles/usgt2.dir/gt2Callback.c.o.d -o CMakeFiles/usgt2.dir/gt2Callback.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Callback.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Connection.c.o
+[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Connection.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Connection.c.o -MF CMakeFiles/usgt2.dir/gt2Connection.c.o.d -o CMakeFiles/usgt2.dir/gt2Connection.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Connection.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Encode.c.o
+[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Encode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Encode.c.o -MF CMakeFiles/usgt2.dir/gt2Encode.c.o.d -o CMakeFiles/usgt2.dir/gt2Encode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Encode.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Filter.c.o
+[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Filter.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Filter.c.o -MF CMakeFiles/usgt2.dir/gt2Filter.c.o.d -o CMakeFiles/usgt2.dir/gt2Filter.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Filter.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Main.c.o
+[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Main.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Main.c.o -MF CMakeFiles/usgt2.dir/gt2Main.c.o.d -o CMakeFiles/usgt2.dir/gt2Main.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Main.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Message.c.o
+[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Message.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Message.c.o -MF CMakeFiles/usgt2.dir/gt2Message.c.o.d -o CMakeFiles/usgt2.dir/gt2Message.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Message.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Socket.c.o
+[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Socket.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Socket.c.o -MF CMakeFiles/usgt2.dir/gt2Socket.c.o.d -o CMakeFiles/usgt2.dir/gt2Socket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Socket.c
-[ 52%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Utility.c.o
+[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Utility.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Utility.c.o -MF CMakeFiles/usgt2.dir/gt2Utility.c.o.d -o CMakeFiles/usgt2.dir/gt2Utility.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Utility.c
-[ 52%] Linking C static library libusgt2.a
+[ 54%] Linking C static library libusgt2.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cmake -P CMakeFiles/usgt2.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cmake -E cmake_link_script CMakeFiles/usgt2.dir/link.txt --verbose=1
 /usr/bin/ar qc libusgt2.a CMakeFiles/usgt2.dir/gt2Auth.c.o CMakeFiles/usgt2.dir/gt2Buffer.c.o CMakeFiles/usgt2.dir/gt2Callback.c.o CMakeFiles/usgt2.dir/gt2Connection.c.o CMakeFiles/usgt2.dir/gt2Encode.c.o CMakeFiles/usgt2.dir/gt2Filter.c.o CMakeFiles/usgt2.dir/gt2Main.c.o CMakeFiles/usgt2.dir/gt2Message.c.o CMakeFiles/usgt2.dir/gt2Socket.c.o CMakeFiles/usgt2.dir/gt2Utility.c.o
 /usr/bin/ranlib libusgt2.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 52%] Built target usgt2
+[ 54%] Built target usgt2
 /usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 52%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/darray.c.o
+[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/darray.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/darray.c.o -MF CMakeFiles/uscommon.dir/darray.c.o.d -o CMakeFiles/uscommon.dir/darray.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/darray.c
-[ 52%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAssert.c.o
+[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAssert.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAssert.c.o -MF CMakeFiles/uscommon.dir/gsAssert.c.o.d -o CMakeFiles/uscommon.dir/gsAssert.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsAssert.c
-[ 52%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAvailable.c.o
+[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAvailable.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAvailable.c.o -MF CMakeFiles/uscommon.dir/gsAvailable.c.o.d -o CMakeFiles/uscommon.dir/gsAvailable.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsAvailable.c
-[ 52%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCore.c.o
+[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCore.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCore.c.o -MF CMakeFiles/uscommon.dir/gsCore.c.o.d -o CMakeFiles/uscommon.dir/gsCore.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsCore.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCrypt.c.o
+[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCrypt.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCrypt.c.o -MF CMakeFiles/uscommon.dir/gsCrypt.c.o.d -o CMakeFiles/uscommon.dir/gsCrypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsCrypt.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsDebug.c.o
+[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsDebug.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsDebug.c.o -MF CMakeFiles/uscommon.dir/gsDebug.c.o.d -o CMakeFiles/uscommon.dir/gsDebug.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsDebug.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsLargeInt.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsLargeInt.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsLargeInt.c.o -MF CMakeFiles/uscommon.dir/gsLargeInt.c.o.d -o CMakeFiles/uscommon.dir/gsLargeInt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsLargeInt.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsMemory.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsMemory.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsMemory.c.o -MF CMakeFiles/uscommon.dir/gsMemory.c.o.d -o CMakeFiles/uscommon.dir/gsMemory.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsMemory.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatform.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatform.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatform.c.o -MF CMakeFiles/uscommon.dir/gsPlatform.c.o.d -o CMakeFiles/uscommon.dir/gsPlatform.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatform.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformSocket.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformSocket.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformSocket.c.o -MF CMakeFiles/uscommon.dir/gsPlatformSocket.c.o.d -o CMakeFiles/uscommon.dir/gsPlatformSocket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatformSocket.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformThread.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformThread.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformThread.c.o -MF CMakeFiles/uscommon.dir/gsPlatformThread.c.o.d -o CMakeFiles/uscommon.dir/gsPlatformThread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatformThread.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformUtil.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformUtil.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformUtil.c.o -MF CMakeFiles/uscommon.dir/gsPlatformUtil.c.o.d -o CMakeFiles/uscommon.dir/gsPlatformUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatformUtil.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsRC4.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsRC4.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsRC4.c.o -MF CMakeFiles/uscommon.dir/gsRC4.c.o.d -o CMakeFiles/uscommon.dir/gsRC4.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsRC4.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsResultCodes.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsResultCodes.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsResultCodes.c.o -MF CMakeFiles/uscommon.dir/gsResultCodes.c.o.d -o CMakeFiles/uscommon.dir/gsResultCodes.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsResultCodes.c
-[ 53%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSHA1.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSHA1.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSHA1.c.o -MF CMakeFiles/uscommon.dir/gsSHA1.c.o.d -o CMakeFiles/uscommon.dir/gsSHA1.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsSHA1.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSSL.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSSL.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSSL.c.o -MF CMakeFiles/uscommon.dir/gsSSL.c.o.d -o CMakeFiles/uscommon.dir/gsSSL.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsSSL.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsStringUtil.c.o
+[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsStringUtil.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsStringUtil.c.o -MF CMakeFiles/uscommon.dir/gsStringUtil.c.o.d -o CMakeFiles/uscommon.dir/gsStringUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsStringUtil.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsXML.c.o
+[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsXML.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsXML.c.o -MF CMakeFiles/uscommon.dir/gsXML.c.o.d -o CMakeFiles/uscommon.dir/gsXML.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsXML.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/hashtable.c.o
+[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/hashtable.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/hashtable.c.o -MF CMakeFiles/uscommon.dir/hashtable.c.o.d -o CMakeFiles/uscommon.dir/hashtable.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/hashtable.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/md5c.c.o
+[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/md5c.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/md5c.c.o -MF CMakeFiles/uscommon.dir/md5c.c.o.d -o CMakeFiles/uscommon.dir/md5c.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/md5c.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsUdpEngine.c.o
+[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsUdpEngine.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsUdpEngine.c.o -MF CMakeFiles/uscommon.dir/gsUdpEngine.c.o.d -o CMakeFiles/uscommon.dir/gsUdpEngine.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsUdpEngine.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o
+[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o -MF CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o.d -o CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/linux/LinuxCommon.c
-[ 54%] Linking C static library libuscommon.a
+[ 56%] Linking C static library libuscommon.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cmake -P CMakeFiles/uscommon.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cmake -E cmake_link_script CMakeFiles/uscommon.dir/link.txt --verbose=1
 /usr/bin/ar qc libuscommon.a CMakeFiles/uscommon.dir/darray.c.o CMakeFiles/uscommon.dir/gsAssert.c.o CMakeFiles/uscommon.dir/gsAvailable.c.o CMakeFiles/uscommon.dir/gsCore.c.o CMakeFiles/uscommon.dir/gsCrypt.c.o CMakeFiles/uscommon.dir/gsDebug.c.o CMakeFiles/uscommon.dir/gsLargeInt.c.o CMakeFiles/uscommon.dir/gsMemory.c.o CMakeFiles/uscommon.dir/gsPlatform.c.o CMakeFiles/uscommon.dir/gsPlatformSocket.c.o CMakeFiles/uscommon.dir/gsPlatformThread.c.o CMakeFiles/uscommon.dir/gsPlatformUtil.c.o CMakeFiles/uscommon.dir/gsRC4.c.o CMakeFiles/uscommon.dir/gsResultCodes.c.o CMakeFiles/uscommon.dir/gsSHA1.c.o CMakeFiles/uscommon.dir/gsSSL.c.o CMakeFiles/uscommon.dir/gsStringUtil.c.o CMakeFiles/uscommon.dir/gsXML.c.o CMakeFiles/uscommon.dir/hashtable.c.o CMakeFiles/uscommon.dir/md5c.c.o CMakeFiles/uscommon.dir/gsUdpEngine.c.o CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o
 /usr/bin/ranlib libuscommon.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 54%] Built target uscommon
+[ 56%] Built target uscommon
 /usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 54%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpBuffer.c.o
+[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpBuffer.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpBuffer.c.o -MF CMakeFiles/ushttp.dir/ghttpBuffer.c.o.d -o CMakeFiles/ushttp.dir/ghttpBuffer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpBuffer.c
-[ 54%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCallbacks.c.o
+[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCallbacks.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCallbacks.c.o -MF CMakeFiles/ushttp.dir/ghttpCallbacks.c.o.d -o CMakeFiles/ushttp.dir/ghttpCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpCallbacks.c
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCommon.c.o
+[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCommon.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCommon.c.o -MF CMakeFiles/ushttp.dir/ghttpCommon.c.o.d -o CMakeFiles/ushttp.dir/ghttpCommon.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpCommon.c
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpConnection.c.o
+[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpConnection.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpConnection.c.o -MF CMakeFiles/ushttp.dir/ghttpConnection.c.o.d -o CMakeFiles/ushttp.dir/ghttpConnection.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpConnection.c
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpEncryption.c.o
+[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpEncryption.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpEncryption.c.o -MF CMakeFiles/ushttp.dir/ghttpEncryption.c.o.d -o CMakeFiles/ushttp.dir/ghttpEncryption.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpEncryption.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpEncryption.c: In function ‘verify_callback’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpEncryption.c:212:55: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
   212 |                                 "  Error = %d\n", err);
       |                                                       ^
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpMain.c.o
+[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpMain.c.o -MF CMakeFiles/ushttp.dir/ghttpMain.c.o.d -o CMakeFiles/ushttp.dir/ghttpMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpMain.c
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpPost.c.o
+[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpPost.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpPost.c.o -MF CMakeFiles/ushttp.dir/ghttpPost.c.o.d -o CMakeFiles/ushttp.dir/ghttpPost.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpPost.c
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpProcess.c.o
+[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpProcess.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpProcess.c.o -MF CMakeFiles/ushttp.dir/ghttpProcess.c.o.d -o CMakeFiles/ushttp.dir/ghttpProcess.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpProcess.c
-[ 55%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpSoap.c.o
+[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpSoap.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpSoap.c.o -MF CMakeFiles/ushttp.dir/ghttpSoap.c.o.d -o CMakeFiles/ushttp.dir/ghttpSoap.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpSoap.c
-[ 55%] Linking C static library libushttp.a
+[ 57%] Linking C static library libushttp.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cmake -P CMakeFiles/ushttp.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cmake -E cmake_link_script CMakeFiles/ushttp.dir/link.txt --verbose=1
 /usr/bin/ar qc libushttp.a CMakeFiles/ushttp.dir/ghttpBuffer.c.o CMakeFiles/ushttp.dir/ghttpCallbacks.c.o CMakeFiles/ushttp.dir/ghttpCommon.c.o CMakeFiles/ushttp.dir/ghttpConnection.c.o CMakeFiles/ushttp.dir/ghttpEncryption.c.o CMakeFiles/ushttp.dir/ghttpMain.c.o CMakeFiles/ushttp.dir/ghttpPost.c.o CMakeFiles/ushttp.dir/ghttpProcess.c.o CMakeFiles/ushttp.dir/ghttpSoap.c.o
 /usr/bin/ranlib libushttp.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 55%] Built target ushttp
+[ 57%] Built target ushttp
 /usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 55%] Building C object lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/AuthService.c.o
+[ 57%] Building C object lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/AuthService.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/AuthService.c.o -MF CMakeFiles/uswebservice.dir/AuthService.c.o.d -o CMakeFiles/uswebservice.dir/AuthService.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsCommon.h:40,
                  from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsCore.h:16,
@@ -1343,7 +1343,7 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservi
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1258:9: note: in expansion of macro ‘READ_NTS’
  1258 |         READ_NTS(certOut->mCdKeyHash, WS_LOGIN_KEYHASH_LEN);
       |         ^~~~~~~~
-[ 55%] Building C object lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/RacingService.c.o
+[ 57%] Building C object lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/RacingService.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/RacingService.c.o -MF CMakeFiles/uswebservice.dir/RacingService.c.o.d -o CMakeFiles/uswebservice.dir/RacingService.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsCommon.h:40,
                  from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/ghttp.h:16,
@@ -1542,20 +1542,20 @@ In function ‘snprintf’,
       |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    56 |                                    __va_arg_pack ());
       |                                    ~~~~~~~~~~~~~~~~~
-[ 56%] Linking C static library libuswebservice.a
+[ 57%] Linking C static library libuswebservice.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cmake -P CMakeFiles/uswebservice.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cmake -E cmake_link_script CMakeFiles/uswebservice.dir/link.txt --verbose=1
 /usr/bin/ar qc libuswebservice.a CMakeFiles/uswebservice.dir/AuthService.c.o CMakeFiles/uswebservice.dir/RacingService.c.o
 /usr/bin/ranlib libuswebservice.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 56%] Built target uswebservice
+[ 57%] Built target uswebservice
 /usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 56%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbMain.c.o
+[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbMain.c.o -MF CMakeFiles/usbrigades.dir/gsbMain.c.o.d -o CMakeFiles/usbrigades.dir/gsbMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c: In function ‘gsbCloneRole’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1001:41: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
@@ -1630,11 +1630,11 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades
 /usr/include/wchar.h:247:38: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
   247 | extern size_t wcslen (const wchar_t *__s) __THROW __attribute_pure__;
       |                       ~~~~~~~~~~~~~~~^~~
-[ 56%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbSerialize.c.o
+[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbSerialize.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbSerialize.c.o -MF CMakeFiles/usbrigades.dir/gsbSerialize.c.o.d -o CMakeFiles/usbrigades.dir/gsbSerialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbSerialize.c
-[ 56%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbServices.c.o
+[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbServices.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbServices.c.o -MF CMakeFiles/usbrigades.dir/gsbServices.c.o.d -o CMakeFiles/usbrigades.dir/gsbServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbServices.c
-[ 56%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbUtil.c.o
+[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbUtil.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbUtil.c.o -MF CMakeFiles/usbrigades.dir/gsbUtil.c.o.d -o CMakeFiles/usbrigades.dir/gsbUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsCommon.h:42,
                  from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsResultCodes.h:9,
@@ -1771,13 +1771,13 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:843:39: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
   843 |     destEntitlement->mEntitlementName = goawstrdup(srcEntitlement->mEntitlementName);
       |                                       ^
-[ 56%] Linking C static library libusbrigades.a
+[ 57%] Linking C static library libusbrigades.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cmake -P CMakeFiles/usbrigades.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cmake -E cmake_link_script CMakeFiles/usbrigades.dir/link.txt --verbose=1
 /usr/bin/ar qc libusbrigades.a CMakeFiles/usbrigades.dir/gsbMain.c.o CMakeFiles/usbrigades.dir/gsbSerialize.c.o CMakeFiles/usbrigades.dir/gsbServices.c.o CMakeFiles/usbrigades.dir/gsbUtil.c.o
 /usr/bin/ranlib libusbrigades.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 56%] Built target usbrigades
+[ 57%] Built target usbrigades
 /usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
@@ -1788,30 +1788,30 @@ gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCallbacks.c.o -MF CMakeFiles/uschat.dir/chatCallbacks.c.o.d -o CMakeFiles/uschat.dir/chatCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatCallbacks.c
 [ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatChannel.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatChannel.c.o -MF CMakeFiles/uschat.dir/chatChannel.c.o.d -o CMakeFiles/uschat.dir/chatChannel.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatChannel.c
-[ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCrypt.c.o
+[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCrypt.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCrypt.c.o -MF CMakeFiles/uschat.dir/chatCrypt.c.o.d -o CMakeFiles/uschat.dir/chatCrypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatCrypt.c
-[ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatHandlers.c.o
+[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatHandlers.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatHandlers.c.o -MF CMakeFiles/uschat.dir/chatHandlers.c.o.d -o CMakeFiles/uschat.dir/chatHandlers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatHandlers.c
-[ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatMain.c.o
+[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatMain.c.o -MF CMakeFiles/uschat.dir/chatMain.c.o.d -o CMakeFiles/uschat.dir/chatMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatMain.c
-[ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatSocket.c.o
+[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatSocket.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatSocket.c.o -MF CMakeFiles/uschat.dir/chatSocket.c.o.d -o CMakeFiles/uschat.dir/chatSocket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatSocket.c
-[ 57%] Linking C static library libuschat.a
+[ 58%] Linking C static library libuschat.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cmake -P CMakeFiles/uschat.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cmake -E cmake_link_script CMakeFiles/uschat.dir/link.txt --verbose=1
 /usr/bin/ar qc libuschat.a CMakeFiles/uschat.dir/chatCallbacks.c.o CMakeFiles/uschat.dir/chatChannel.c.o CMakeFiles/uschat.dir/chatCrypt.c.o CMakeFiles/uschat.dir/chatHandlers.c.o CMakeFiles/uschat.dir/chatMain.c.o CMakeFiles/uschat.dir/chatSocket.c.o
 /usr/bin/ranlib libuschat.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Built target uschat
+[ 58%] Built target uschat
 /usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Building C object lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/NATify.c.o
+[ 58%] Building C object lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/NATify.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/NATify.c.o -MF CMakeFiles/usnatneg.dir/NATify.c.o.d -o CMakeFiles/usnatneg.dir/NATify.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/NATify.c
-[ 57%] Building C object lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/natneg.c.o
+[ 58%] Building C object lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/natneg.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/natneg.c.o -MF CMakeFiles/usnatneg.dir/natneg.c.o.d -o CMakeFiles/usnatneg.dir/natneg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c: In function ‘ResolveServers’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:70: warning: ‘%s’ directive output may be truncated writing 19 bytes into a region of size between 0 and 63 [-Wformat-truncation=]
@@ -2116,9 +2116,9 @@ In function ‘sprintf’,
       |                                   ~~~~~~~~~~~~~~~~~
 [ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiInfo.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiInfo.c.o -MF CMakeFiles/usgp.dir/gpiInfo.c.o.d -o CMakeFiles/usgp.dir/gpiInfo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiInfo.c
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiKeys.c.o
+[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiKeys.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiKeys.c.o -MF CMakeFiles/usgp.dir/gpiKeys.c.o.d -o CMakeFiles/usgp.dir/gpiKeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiKeys.c
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiOperation.c.o
+[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiOperation.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiOperation.c.o -MF CMakeFiles/usgp.dir/gpiOperation.c.o.d -o CMakeFiles/usgp.dir/gpiOperation.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiOperation.c
 [ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiPeer.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiPeer.c.o -MF CMakeFiles/usgp.dir/gpiPeer.c.o.d -o CMakeFiles/usgp.dir/gpiPeer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiPeer.c
@@ -2291,17 +2291,17 @@ gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 59%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_crypt.c
-[ 59%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o
+[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_queryengine.c
-[ 59%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o
+[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_server.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_server.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_server.c
-[ 59%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o
+[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverbrowsing.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverbrowsing.c: In function ‘WaitForTriggerUpdate’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverbrowsing.c:271:49: warning: comparison between ‘SBServerListState’ and ‘enum <anonymous>’ [-Wenum-compare]
   271 |                 if (viaMaster && sb->list.state == sb_disconnected) //we were supposed to get from master, and it's disconnected
       |                                                 ^~
-[ 59%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
+[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c: In function ‘ProcessMainListData’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1201:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
@@ -2351,36 +2351,36 @@ In function ‘SBServerListFindServerByIP’,
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1499:24: note: ‘port’ was declared here
  1499 |         unsigned short port;
       |                        ^~~~
-[ 59%] Linking C static library libusserverbrowsing.a
+[ 60%] Linking C static library libusserverbrowsing.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cmake -P CMakeFiles/usserverbrowsing.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cmake -E cmake_link_script CMakeFiles/usserverbrowsing.dir/link.txt --verbose=1
 /usr/bin/ar qc libusserverbrowsing.a CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o CMakeFiles/usserverbrowsing.dir/sb_server.c.o CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
 /usr/bin/ranlib libusserverbrowsing.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Built target usserverbrowsing
+[ 60%] Built target usserverbrowsing
 /usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o
+[ 60%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o -MF CMakeFiles/uspeer.dir/peerAutoMatch.c.o.d -o CMakeFiles/uspeer.dir/peerAutoMatch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerAutoMatch.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o -MF CMakeFiles/uspeer.dir/peerCallbacks.c.o.d -o CMakeFiles/uspeer.dir/peerCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerCallbacks.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o -MF CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o.d -o CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerGlobalCallbacks.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerHost.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerHost.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerHost.c.o -MF CMakeFiles/uspeer.dir/peerHost.c.o.d -o CMakeFiles/uspeer.dir/peerHost.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerHost.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o -MF CMakeFiles/uspeer.dir/peerKeys.c.o.d -o CMakeFiles/uspeer.dir/peerKeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerKeys.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMain.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMain.c.o -MF CMakeFiles/uspeer.dir/peerMain.c.o.d -o CMakeFiles/uspeer.dir/peerMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerMain.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o -MF CMakeFiles/uspeer.dir/peerMangle.c.o.d -o CMakeFiles/uspeer.dir/peerMangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerMangle.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o -MF CMakeFiles/uspeer.dir/peerOperations.c.o.d -o CMakeFiles/uspeer.dir/peerOperations.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerOperations.c
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPing.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPing.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPing.c.o -MF CMakeFiles/uspeer.dir/peerPing.c.o.d -o CMakeFiles/uspeer.dir/peerPing.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPlayers.h:16,
                  from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c:15:
@@ -2391,28 +2391,28 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/pee
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c:982:9: note: in expansion of macro ‘strzcpy’
   982 |         strzcpy(xpingMatch.nicks[1], nick2, PI_NICK_MAX_LEN);
       |         ^~~~~~~
-[ 59%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o -MF CMakeFiles/uspeer.dir/peerPlayers.c.o.d -o CMakeFiles/uspeer.dir/peerPlayers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPlayers.c
-[ 60%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerQR.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerQR.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerQR.c.o -MF CMakeFiles/uspeer.dir/peerQR.c.o.d -o CMakeFiles/uspeer.dir/peerQR.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerQR.c
-[ 60%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o
+[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o -MF CMakeFiles/uspeer.dir/peerRooms.c.o.d -o CMakeFiles/uspeer.dir/peerRooms.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerRooms.c
-[ 60%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerSB.c.o
+[ 62%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerSB.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerSB.c.o -MF CMakeFiles/uspeer.dir/peerSB.c.o.d -o CMakeFiles/uspeer.dir/peerSB.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerSB.c
-[ 60%] Linking C static library libuspeer.a
+[ 62%] Linking C static library libuspeer.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cmake -P CMakeFiles/uspeer.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspeer.dir/link.txt --verbose=1
 /usr/bin/ar qc libuspeer.a CMakeFiles/uspeer.dir/peerAutoMatch.c.o CMakeFiles/uspeer.dir/peerCallbacks.c.o CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o CMakeFiles/uspeer.dir/peerHost.c.o CMakeFiles/uspeer.dir/peerKeys.c.o CMakeFiles/uspeer.dir/peerMain.c.o CMakeFiles/uspeer.dir/peerMangle.c.o CMakeFiles/uspeer.dir/peerOperations.c.o CMakeFiles/uspeer.dir/peerPing.c.o CMakeFiles/uspeer.dir/peerPlayers.c.o CMakeFiles/uspeer.dir/peerQR.c.o CMakeFiles/uspeer.dir/peerRooms.c.o CMakeFiles/uspeer.dir/peerSB.c.o
 /usr/bin/ranlib libuspeer.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Built target uspeer
+[ 62%] Built target uspeer
 /usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Building C object lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/ptMain.c.o
+[ 62%] Building C object lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/ptMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/ptMain.c.o -MF CMakeFiles/uspt.dir/ptMain.c.o.d -o CMakeFiles/uspt.dir/ptMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c: In function ‘ptLookupFilePlanetInfo’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c:692:20: warning: ‘?file=’ directive output may be truncated writing 6 bytes into a region of size between 1 and 2048 [-Wformat-truncation=]
@@ -2429,43 +2429,43 @@ In function ‘snprintf’,
       |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    56 |                                    __va_arg_pack ());
       |                                    ~~~~~~~~~~~~~~~~~
-[ 60%] Linking C static library libuspt.a
+[ 62%] Linking C static library libuspt.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt && /usr/bin/cmake -P CMakeFiles/uspt.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspt.dir/link.txt --verbose=1
 /usr/bin/ar qc libuspt.a CMakeFiles/uspt.dir/ptMain.c.o
 /usr/bin/ranlib libuspt.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Built target uspt
+[ 62%] Built target uspt
 /usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 61%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeMain.c.o
+[ 62%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeMain.c.o -MF CMakeFiles/ussake.dir/sakeMain.c.o.d -o CMakeFiles/ussake.dir/sakeMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeMain.c
-[ 61%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequest.c.o
+[ 62%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequest.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequest.c.o -MF CMakeFiles/ussake.dir/sakeRequest.c.o.d -o CMakeFiles/ussake.dir/sakeRequest.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequest.c
-[ 61%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o -MF CMakeFiles/ussake.dir/sakeRequestMisc.c.o.d -o CMakeFiles/ussake.dir/sakeRequestMisc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequestMisc.c
-[ 61%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o -MF CMakeFiles/ussake.dir/sakeRequestModify.c.o.d -o CMakeFiles/ussake.dir/sakeRequestModify.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequestModify.c
-[ 61%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o -MF CMakeFiles/ussake.dir/sakeRequestRead.c.o.d -o CMakeFiles/ussake.dir/sakeRequestRead.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequestRead.c
-[ 61%] Linking C static library libussake.a
+[ 63%] Linking C static library libussake.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cmake -P CMakeFiles/ussake.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cmake -E cmake_link_script CMakeFiles/ussake.dir/link.txt --verbose=1
 /usr/bin/ar qc libussake.a CMakeFiles/ussake.dir/sakeMain.c.o CMakeFiles/ussake.dir/sakeRequest.c.o CMakeFiles/ussake.dir/sakeRequestMisc.c.o CMakeFiles/ussake.dir/sakeRequestModify.c.o CMakeFiles/ussake.dir/sakeRequestRead.c.o
 /usr/bin/ranlib libussake.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 61%] Built target ussake
+[ 63%] Built target ussake
 /usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 61%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciInterface.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciInterface.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciInterface.c.o -MF CMakeFiles/ussc.dir/sciInterface.c.o.d -o CMakeFiles/ussc.dir/sciInterface.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/../common/gsCommon.h:40,
                  from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sc.h:16,
@@ -2515,9 +2515,9 @@ In function ‘snprintf’,
       |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    56 |                                    __va_arg_pack ());
       |                                    ~~~~~~~~~~~~~~~~~
-[ 61%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciMain.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciMain.c.o -MF CMakeFiles/ussc.dir/sciMain.c.o.d -o CMakeFiles/ussc.dir/sciMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciMain.c
-[ 61%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciReport.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciReport.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciReport.c.o -MF CMakeFiles/ussc.dir/sciReport.c.o.d -o CMakeFiles/ussc.dir/sciReport.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c:17:41: warning: argument 1 of type ‘gsi_u8[40]’ {aka ‘unsigned char[40]’} with mismatched bound [-Warray-parameter=]
    17 | SCResult SC_CALL sciCreateReport(gsi_u8 theSessionGuid[SC_SESSION_GUID_SIZE],
@@ -2533,24 +2533,24 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciRe
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c:932:9: note: length computed here
   932 |         strncpy(&theReport->mBuffer.mData[theReport->mBuffer.mPos], theValue, strlen(theValue));
       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 61%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciSerialize.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciSerialize.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciSerialize.c.o -MF CMakeFiles/ussc.dir/sciSerialize.c.o.d -o CMakeFiles/ussc.dir/sciSerialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciSerialize.c
-[ 62%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciWebServices.c.o
+[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciWebServices.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciWebServices.c.o -MF CMakeFiles/ussc.dir/sciWebServices.c.o.d -o CMakeFiles/ussc.dir/sciWebServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciWebServices.c
-[ 62%] Linking C static library libussc.a
+[ 63%] Linking C static library libussc.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cmake -P CMakeFiles/ussc.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cmake -E cmake_link_script CMakeFiles/ussc.dir/link.txt --verbose=1
 /usr/bin/ar qc libussc.a CMakeFiles/ussc.dir/sciInterface.c.o CMakeFiles/ussc.dir/sciMain.c.o CMakeFiles/ussc.dir/sciReport.c.o CMakeFiles/ussc.dir/sciSerialize.c.o CMakeFiles/ussc.dir/sciWebServices.c.o
 /usr/bin/ranlib libussc.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 62%] Built target ussc
+[ 63%] Built target ussc
 /usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 62%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o
+[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o -MF CMakeFiles/usd2g.dir/d2gDeserialize.c.o.d -o CMakeFiles/usd2g.dir/d2gDeserialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c: In function ‘d2giParseOrderItemFromResponse’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c:568:25: warning: variable ‘pCatalogItem’ set but not used [-Wunused-but-set-variable]
@@ -2560,7 +2560,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/b
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c:1206:58: warning: argument to ‘sizeof’ in ‘memset’ call is the same pointer type ‘D2GCatalogItemList *’ as the destination; expected ‘D2GCatalogItemList’ or an explicit length [-Wsizeof-pointer-memaccess]
  1206 |         memset(getAllItemsResponse->mItemList, 0, sizeof(D2GCatalogItemList *));
       |                                                          ^~~~~~~~~~~~~~~~~~
-[ 62%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o
+[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o -MF CMakeFiles/usd2g.dir/d2gDownloads.c.o.d -o CMakeFiles/usd2g.dir/d2gDownloads.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDownloads.c
 [ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gMain.c.o -MF CMakeFiles/usd2g.dir/d2gMain.c.o.d -o CMakeFiles/usd2g.dir/d2gMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c
@@ -2830,7 +2830,7 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2G
       |                                         ~~~~~~~~~~~~~~~^~~~
 [ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gServices.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gServices.c.o -MF CMakeFiles/usd2g.dir/d2gServices.c.o.d -o CMakeFiles/usd2g.dir/d2gServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gServices.c
-[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o
+[ 64%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o -MF CMakeFiles/usd2g.dir/d2gUtil.c.o.d -o CMakeFiles/usd2g.dir/d2gUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giCompareWFloat’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:740:44: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
@@ -3096,22 +3096,22 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2G
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:2158:17: note: length computed here
  2158 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 63%] Linking C static library libusd2g.a
+[ 64%] Linking C static library libusd2g.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cmake -P CMakeFiles/usd2g.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cmake -E cmake_link_script CMakeFiles/usd2g.dir/link.txt --verbose=1
 /usr/bin/ar qc libusd2g.a CMakeFiles/usd2g.dir/d2gDeserialize.c.o CMakeFiles/usd2g.dir/d2gDownloads.c.o CMakeFiles/usd2g.dir/d2gMain.c.o CMakeFiles/usd2g.dir/d2gServices.c.o CMakeFiles/usd2g.dir/d2gUtil.c.o
 /usr/bin/ranlib libusd2g.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 63%] Built target usd2g
+[ 64%] Built target usd2g
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 63%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o
+[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o -MF CMakeFiles/gsm.dir/src/add.c.o.d -o CMakeFiles/gsm.dir/src/add.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/add.c
-[ 63%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o
+[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o -MF CMakeFiles/gsm.dir/src/code.c.o.d -o CMakeFiles/gsm.dir/src/code.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/code.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/code.c:9:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
@@ -3132,15 +3132,15 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/l
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
    38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
       |                                          
-[ 63%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o
+[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o -MF CMakeFiles/gsm.dir/src/debug.c.o.d -o CMakeFiles/gsm.dir/src/debug.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/debug.c
-[ 63%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o
+[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o -MF CMakeFiles/gsm.dir/src/decode.c.o.d -o CMakeFiles/gsm.dir/src/decode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/decode.c
-[ 63%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o
+[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o -MF CMakeFiles/gsm.dir/src/long_term.c.o.d -o CMakeFiles/gsm.dir/src/long_term.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/long_term.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o -MF CMakeFiles/gsm.dir/src/lpc.c.o.d -o CMakeFiles/gsm.dir/src/lpc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/lpc.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o -MF CMakeFiles/gsm.dir/src/preprocess.c.o.d -o CMakeFiles/gsm.dir/src/preprocess.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:12:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c: In function ‘Gsm_Preprocess’:
@@ -3176,7 +3176,7 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/l
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:100:26: note: in expansion of macro ‘GSM_L_ADD’
   100 |                 L_temp = GSM_L_ADD( L_z2, 16384 );
       |                          ^~~~~~~~~
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o -MF CMakeFiles/gsm.dir/src/rpe.c.o.d -o CMakeFiles/gsm.dir/src/rpe.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c: In function ‘RPE_grid_positioning’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:405:31: warning: this statement may fall through [-Wimplicit-fallthrough=]
@@ -3197,7 +3197,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:409:17: note: here
   409 |                 case 0:         *ep++ = *xMp++;
       |                 ^~~~
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o -MF CMakeFiles/gsm.dir/src/gsm_destroy.c.o.d -o CMakeFiles/gsm.dir/src/gsm_destroy.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_destroy.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_destroy.c:10:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
@@ -3218,15 +3218,15 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/l
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
    38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
       |                                          
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o -MF CMakeFiles/gsm.dir/src/gsm_decode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_decode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_decode.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o -MF CMakeFiles/gsm.dir/src/gsm_encode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_encode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_encode.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o -MF CMakeFiles/gsm.dir/src/gsm_explode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_explode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_explode.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o -MF CMakeFiles/gsm.dir/src/gsm_implode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_implode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_implode.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o -MF CMakeFiles/gsm.dir/src/gsm_create.c.o.d -o CMakeFiles/gsm.dir/src/gsm_create.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_create.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_create.c:9:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
@@ -3250,11 +3250,11 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/l
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_create.c:7:25: warning: ‘ident’ defined but not used [-Wunused-const-variable=]
     7 | static char const       ident[] = "$Header: /tmp_amd/presto/export/kbs/jutta/src/gsm/RCS/gsm_create.c,v 1.4 1996/07/02 09:59:05 jutta Exp $";
       |                         ^~~~~
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o -MF CMakeFiles/gsm.dir/src/gsm_print.c.o.d -o CMakeFiles/gsm.dir/src/gsm_print.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_print.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o
+[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o -MF CMakeFiles/gsm.dir/src/gsm_option.c.o.d -o CMakeFiles/gsm.dir/src/gsm_option.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_option.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o
+[ 66%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o -MF CMakeFiles/gsm.dir/src/short_term.c.o.d -o CMakeFiles/gsm.dir/src/short_term.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:12:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c: In function ‘Decoding_of_the_coded_Log_Area_Ratios’:
@@ -3294,15 +3294,15 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/l
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:68:9: note: in expansion of macro ‘STEP’
    68 |         STEP(  -1144,   -4,  29708 );
       |         ^~~~
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o
+[ 66%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o -MF CMakeFiles/gsm.dir/src/table.c.o.d -o CMakeFiles/gsm.dir/src/table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/table.c
-[ 65%] Linking C static library libgsm.a
+[ 66%] Linking C static library libgsm.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cmake -P CMakeFiles/gsm.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cmake -E cmake_link_script CMakeFiles/gsm.dir/link.txt --verbose=1
 /usr/bin/ar qc libgsm.a CMakeFiles/gsm.dir/src/add.c.o CMakeFiles/gsm.dir/src/code.c.o CMakeFiles/gsm.dir/src/debug.c.o CMakeFiles/gsm.dir/src/decode.c.o CMakeFiles/gsm.dir/src/long_term.c.o CMakeFiles/gsm.dir/src/lpc.c.o CMakeFiles/gsm.dir/src/preprocess.c.o CMakeFiles/gsm.dir/src/rpe.c.o CMakeFiles/gsm.dir/src/gsm_destroy.c.o CMakeFiles/gsm.dir/src/gsm_decode.c.o CMakeFiles/gsm.dir/src/gsm_encode.c.o CMakeFiles/gsm.dir/src/gsm_explode.c.o CMakeFiles/gsm.dir/src/gsm_implode.c.o CMakeFiles/gsm.dir/src/gsm_create.c.o CMakeFiles/gsm.dir/src/gsm_print.c.o CMakeFiles/gsm.dir/src/gsm_option.c.o CMakeFiles/gsm.dir/src/short_term.c.o CMakeFiles/gsm.dir/src/table.c.o
 /usr/bin/ranlib libgsm.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 65%] Built target gsm
+[ 66%] Built target gsm
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
@@ -3315,13 +3315,13 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvCustomDevice.c.o -MF CMakeFiles/usvoice2.dir/gvCustomDevice.c.o.d -o CMakeFiles/usvoice2.dir/gvCustomDevice.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvCustomDevice.c
 [ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvDevice.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvDevice.c.o -MF CMakeFiles/usvoice2.dir/gvDevice.c.o.d -o CMakeFiles/usvoice2.dir/gvDevice.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvDevice.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o
+[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o -MF CMakeFiles/usvoice2.dir/gvFrame.c.o.d -o CMakeFiles/usvoice2.dir/gvFrame.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvFrame.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o
+[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o -MF CMakeFiles/usvoice2.dir/gvMain.c.o.d -o CMakeFiles/usvoice2.dir/gvMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvMain.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o
+[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o -MF CMakeFiles/usvoice2.dir/gvSource.c.o.d -o CMakeFiles/usvoice2.dir/gvSource.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSource.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o
+[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o -MF CMakeFiles/usvoice2.dir/gvSpeex.c.o.d -o CMakeFiles/usvoice2.dir/gvSpeex.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c: In function ‘gviSpeexEncode’:
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c:144:13: warning: variable ‘bytesWritten’ set but not used [-Wunused-but-set-variable]
@@ -3335,37 +3335,37 @@ cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc
 /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c:182:13: warning: variable ‘rcode’ set but not used [-Wunused-but-set-variable]
   182 |         int rcode;
       |             ^~~~~
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o
+[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o -MF CMakeFiles/usvoice2.dir/gvUtil.c.o.d -o CMakeFiles/usvoice2.dir/gvUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvUtil.c
-[ 66%] Linking C static library libusvoice2.a
+[ 67%] Linking C static library libusvoice2.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cmake -P CMakeFiles/usvoice2.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cmake -E cmake_link_script CMakeFiles/usvoice2.dir/link.txt --verbose=1
 /usr/bin/ar qc libusvoice2.a CMakeFiles/usvoice2.dir/gvCodec.c.o CMakeFiles/usvoice2.dir/gvCustomDevice.c.o CMakeFiles/usvoice2.dir/gvDevice.c.o CMakeFiles/usvoice2.dir/gvFrame.c.o CMakeFiles/usvoice2.dir/gvMain.c.o CMakeFiles/usvoice2.dir/gvSource.c.o CMakeFiles/usvoice2.dir/gvSpeex.c.o CMakeFiles/usvoice2.dir/gvUtil.c.o
 /usr/bin/ranlib libusvoice2.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Built target usvoice2
+[ 67%] Built target usvoice2
 /usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Building C object lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o
+[ 67%] Building C object lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o -MF CMakeFiles/UniSpySDK.dir/dllmain.c.o.d -o CMakeFiles/UniSpySDK.dir/dllmain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll/dllmain.c
-[ 66%] Linking C static library libUniSpySDK.a
+[ 67%] Linking C static library libUniSpySDK.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll && /usr/bin/cmake -P CMakeFiles/UniSpySDK.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll && /usr/bin/cmake -E cmake_link_script CMakeFiles/UniSpySDK.dir/link.txt --verbose=1
 /usr/bin/ar qc libUniSpySDK.a CMakeFiles/UniSpySDK.dir/dllmain.c.o
 /usr/bin/ranlib libUniSpySDK.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Built target UniSpySDK
+[ 67%] Built target UniSpySDK
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Building C object lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/cleanup.c.o
+[ 67%] Building C object lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/cleanup.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cc   -g -MD -MT lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/cleanup.c.o -MF CMakeFiles/milescleanup.dir/cleanup.c.o.d -o CMakeFiles/milescleanup.dir/cleanup.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/cleanup.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/cleanup.c:1:
 /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:138:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
@@ -3686,20 +3686,20 @@ In file included from /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/clean
 /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:284:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
   284 | IMPORTS unsigned long __stdcall AIL_get_timer_highest_delay(void);
       | ^~~~~~~
-[ 66%] Linking C static library libmilescleanup.a
+[ 67%] Linking C static library libmilescleanup.a
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cmake -P CMakeFiles/milescleanup.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cmake -E cmake_link_script CMakeFiles/milescleanup.dir/link.txt --verbose=1
 /usr/bin/ar qc libmilescleanup.a CMakeFiles/milescleanup.dir/cleanup.c.o
 /usr/bin/ranlib libmilescleanup.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Built target milescleanup
+[ 67%] Built target milescleanup
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Building C object lib/miles_sdk_stub/CMakeFiles/milesstub.dir/miles.c.o
+[ 67%] Building C object lib/miles_sdk_stub/CMakeFiles/milesstub.dir/miles.c.o
 cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cc -DBUILD_STUBS -Dmilesstub_EXPORTS -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -g -fPIC -MD -MT lib/miles_sdk_stub/CMakeFiles/milesstub.dir/miles.c.o -MF CMakeFiles/milesstub.dir/miles.c.o.d -o CMakeFiles/milesstub.dir/miles.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c
 In file included from /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:16:
 /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:138:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
@@ -4393,25 +4393,28 @@ gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 69%] Building CXX object src/CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o -MF CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o.d -o CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/lvgl_platform/lvgl_platform.cpp
-[ 69%] Linking CXX static library liblvgl_platform.a
+[ 70%] Linking CXX static library liblvgl_platform.a
 cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/cmake -P CMakeFiles/lvgl_platform.dir/cmake_clean_target.cmake
 cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/cmake -E cmake_link_script CMakeFiles/lvgl_platform.dir/link.txt --verbose=1
 /usr/bin/ar qc liblvgl_platform.a CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o
 /usr/bin/ranlib liblvgl_platform.a
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Built target lvgl_platform
+[ 70%] Built target lvgl_platform
 /usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
 cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o
 cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp
 In file included from /usr/include/c++/13/backward/hash_map:60,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:74,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/filesystem.h:54,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/localfilesystem.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/localfilesystem.h:34,
                  from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp:2:
 /usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
    32 | #warning \
@@ -4438,50 +4441,36 @@ In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/comm
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
    84 |         MEMORY_POOL_GLUE_ABC(File)
       |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h: At global scope:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:68:6: error: use of enum ‘NameKeyType’ without previous declaration
-   68 | enum NameKeyType;
-      |      ^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:113:19: error: ‘NameKeyType’ was not declared in this scope
-  113 | typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
-      |                   ^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:113:48: error: ‘NameKeyType’ was not declared in this scope
-  113 | typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
-      |                                                ^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:113:59: error: template argument 1 is invalid
-  113 | typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
-      |                                                           ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:113:61: error: template argument 1 is invalid
-  113 | typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
-      |                                                             ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:113:61: error: template argument 3 is invalid
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:113:61: error: template argument 4 is invalid
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:114:19: error: ‘NameKeyType’ was not declared in this scope
-  114 | typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
-      |                   ^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:114:58: error: ‘NameKeyType’ was not declared in this scope
-  114 | typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
-      |                                                          ^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:114:69: error: template argument 1 is invalid
-  114 | typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
-      |                                                                     ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:114:71: error: template argument 1 is invalid
-  114 | typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
-      |                                                                       ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:114:71: error: template argument 3 is invalid
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:114:71: error: template argument 4 is invalid
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:153:32: error: ‘NameKeyType’ was not declared in this scope
-  153 |         template<> struct hash<NameKeyType>
-      |                                ^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/stltypedefs.h:153:43: error: template argument 1 is invalid
-  153 |         template<> struct hash<NameKeyType>
-      |                                           ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/filesystem.h:121:1: error: expected class-name before ‘{’ token
-  121 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/localfilesystem.h:40:1: error: expected class-name before ‘{’ token
-   40 | {
-      | ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ramfile.h: In static member function ‘static void* RAMFile::operator new(size_t)’:
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
   651 |                 return 0; \
@@ -4502,292 +4491,27 @@ In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/comm
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/streamingarchivefile.h:77:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
    77 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(StreamingArchiveFile, "StreamingArchiveFile")
       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefile.h:36,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/lvgl_device/common/win32_big_file.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp:7:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefilesystem.h: At global scope:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefilesystem.h:150:1: error: expected class-name before ‘{’ token
-  150 | {
-      | ^
-gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:79: src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o] Error 1
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[1]: *** [CMakeFiles/Makefile2:1943: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
-gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake: *** [Makefile:94: all] Error 2
-/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
-/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
-/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
-/usr/bin/gmake  -f CMakeFiles/Makefile2 all
-gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Built target lvgl
-/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 51%] Built target miniaudio
-/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 52%] Built target usgt2
-/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 54%] Built target uscommon
-/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 55%] Built target ushttp
-/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 56%] Built target uswebservice
-/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 56%] Built target usbrigades
-/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Built target uschat
-/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Built target usnatneg
-/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Built target usqr2
-/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Built target uscdkey
-/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Built target usgp
-/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Built target usstats
-/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Built target uspinger
-/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Built target usserverbrowsing
-/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Built target uspeer
-/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Built target uspt
-/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 61%] Built target ussake
-/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 62%] Built target ussc
-/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 63%] Built target usd2g
-/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 65%] Built target gsm
-/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Built target usvoice2
-/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Built target UniSpySDK
-/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Built target milescleanup
-/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 67%] Built target milesstub
-/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Built target zlib
-/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Built target lzhl
-/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Built target lvgl_platform
-/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
-gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
-gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp
-In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/localfilesystem.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp:2:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35:10: fatal error: Common/INI.h: No such file or directory
-   35 | #include "common/ini.h"
-      |          ^~~~~~~~~~~~~~
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file_system.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefilesystem.h:55,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefile.h:36,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file_system.cpp:2:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file_system.cpp:5:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gameaudio.h:51:10: fatal error: game_engine/common/audioEventInfo.h: No such file or directory
+   51 | #include "game_engine/common/audioEventInfo.h"
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 compilation terminated.
-gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:79: src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o] Error 1
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:93: src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o] Error 1
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
-gmake[1]: *** [CMakeFiles/Makefile2:1943: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
 gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 gmake: *** [Makefile:94: all] Error 2

--- a/src/libraries/ww_vegas/CMakeLists.txt
+++ b/src/libraries/ww_vegas/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(miles_6)
+add_subdirectory(ww_lib)
 add_subdirectory(ww_3d2)
 add_subdirectory(ww_audio)
 add_subdirectory(ww_debug)

--- a/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
@@ -4,3 +4,5 @@ target_include_directories(ww3d2 PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/Libraries/WWVegas/WW3D2
     ${PROJECT_SOURCE_DIR}/src/tools/WW3D/pluglib)
+
+target_link_libraries(ww3d2 PUBLIC wwlib)

--- a/src/libraries/ww_vegas/ww_audio/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_audio/CMakeLists.txt
@@ -10,4 +10,4 @@ target_include_directories(wwaudio PUBLIC
     ${PROJECT_SOURCE_DIR}/lib/miles-sdk-stub/mss
 )
 
-target_link_libraries(wwaudio PUBLIC milesstub)
+target_link_libraries(wwaudio PUBLIC milesstub wwlib)

--- a/src/libraries/ww_vegas/ww_lib/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_lib/CMakeLists.txt
@@ -1,0 +1,14 @@
+file(GLOB WWLIB_SRCS CONFIGURE_DEPENDS *.cpp)
+add_library(wwlib STATIC ${WWLIB_SRCS})
+
+# Expose headers for dependent targets
+# Include root headers and this library's headers
+# Source path is provided for possible in-tree includes
+
+# Provide include directories publicly so dependents see ww_lib headers
+
+target_include_directories(wwlib PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_lib
+    ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_lib
+)

--- a/src/libraries/ww_vegas/ww_math/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_math/CMakeLists.txt
@@ -8,3 +8,5 @@ target_include_directories(wwmath PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/Libraries/WWVegas/WWMath
 )
+
+target_link_libraries(wwmath PUBLIC wwlib)


### PR DESCRIPTION
## Summary
- add missing wwlib build target and expose headers
- link vegas sublibraries against wwlib
- build output for verification

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: gameenginedevice missing audioEventInfo.h)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6f50f3c8325acdbdc7ea19579fb