### PR TITLE
Fix headers for Unix build

### DIFF
--- a/include/game_engine/common/GameMemory.h
+++ b/include/game_engine/common/GameMemory.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "gamememory.h"

--- a/include/game_engine/common/INI.h
+++ b/include/game_engine/common/INI.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "ini.h"

--- a/include/game_engine/common/Module.h
+++ b/include/game_engine/common/Module.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "module.h"

--- a/include/game_engine/common/ModuleFactory.h
+++ b/include/game_engine/common/ModuleFactory.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "modulefactory.h"

--- a/include/game_engine/common/NameKeyGenerator.h
+++ b/include/game_engine/common/NameKeyGenerator.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "namekeygenerator.h"

--- a/include/game_engine/common/Snapshot.h
+++ b/include/game_engine/common/Snapshot.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "snapshot.h"

--- a/include/game_engine/common/gameaudio.h
+++ b/include/game_engine/common/gameaudio.h
@@ -48,7 +48,7 @@
 #include "lib/base_type.h"
 #include "common/stl_type_defs.h"
 #include "game_engine/common/subsystem_interface.h"
-#include "game_engine/common/audioEventInfo.h"
+#include "game_engine/common/audio_event_info.h"
 
 
 // Forward Declarations

--- a/include/game_engine_device/w3d_device/common/W3DModuleFactory.h
+++ b/include/game_engine_device/w3d_device/common/W3DModuleFactory.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "w3dmodulefactory.h"

--- a/include/game_engine_device/w3d_device/game_client/Module/W3DDebrisDraw.h
+++ b/include/game_engine_device/w3d_device/game_client/Module/W3DDebrisDraw.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "w3ddebrisdraw.h"

--- a/include/libraries/ww_vegas/ww_lib/wwstring.h
+++ b/include/libraries/ww_vegas/ww_lib/wwstring.h
@@ -45,7 +45,7 @@
 #include "mutex.h"
 #include <string.h>
 #include <stdarg.h>
-#include <tchar.h>
+#include "tchar.h"
 #include <wwdebug.h>
 #ifdef _UNIX
 #include "osdep.h"

--- a/include/tchar.h
+++ b/include/tchar.h
@@ -1,0 +1,30 @@
+#ifndef PORTABLE_TCHAR_H
+#define PORTABLE_TCHAR_H
+
+#ifdef _WIN32
+# include <tchar.h>
+#else
+#include <string.h>
+#include <strings.h>
+#include <stdio.h>
+#include <ctype.h>
+
+typedef char TCHAR;
+
+#ifndef _T
+# define _T(x) x
+#endif
+
+#define _tfopen fopen
+#define _tcslen strlen
+#define _tcsclen strlen
+#define _tcscmp strcmp
+#define _tcsicmp strcasecmp
+#define _tcscpy strcpy
+#define _tcsncpy strncpy
+#define _tcscat strcat
+#define _tcschr strchr
+#define _tcsrchr strrchr
+#endif /* _WIN32 */
+
+#endif /* PORTABLE_TCHAR_H */

--- a/log/build.log
+++ b/log/build.log
@@ -1,41 +1,6 @@
--- The C compiler identification is GNU 13.3.0
--- The CXX compiler identification is GNU 13.3.0
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Check for working C compiler: /usr/bin/cc - skipped
--- Detecting C compile features
--- Detecting C compile features - done
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Check for working CXX compiler: /usr/bin/c++ - skipped
--- Detecting CXX compile features
--- Detecting CXX compile features - done
 -- Configuring bundled libraries
--- Found X11: /usr/include   
--- Looking for XOpenDisplay in /usr/lib/x86_64-linux-gnu/libX11.so;/usr/lib/x86_64-linux-gnu/libXext.so
--- Looking for XOpenDisplay in /usr/lib/x86_64-linux-gnu/libX11.so;/usr/lib/x86_64-linux-gnu/libXext.so - found
--- Looking for gethostbyname
--- Looking for gethostbyname - found
--- Looking for connect
--- Looking for connect - found
--- Looking for remove
--- Looking for remove - found
--- Looking for shmat
--- Looking for shmat - found
--- Looking for IceConnectionNumber in ICE
--- Looking for IceConnectionNumber in ICE - found
--- Found Git: /usr/bin/git (found version "2.43.0") 
 -- Git version 2.43.0 found at '/usr/bin/git'.
--- Git using branch 'main', commit 57b64d48a2f075b38a40ed5f9bd474720180388a/'snake case renames'.
--- Performing Test CMAKE_HAVE_LIBC_PTHREAD
--- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
--- Found Threads: TRUE  
--- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libcrypto.so (found version "3.0.13") found components: SSL 
--- Found Speex: /usr/lib/x86_64-linux-gnu/libspeex.so (found version "1.2.1") 
--- No build type selected, default to Debug
--- No build type selected, default to Release
--- Performing Test HAVE_LD_VERSION_SCRIPT
--- Performing Test HAVE_LD_VERSION_SCRIPT - Success
+-- Git using branch 'main', commit 1b2ef4a1f27ddc718e4d5187506957c30d7125fa/'snake case renames'.
 -- Enabled features:
 
 -- Disabled features:
@@ -44,7 +9,7 @@
 
 -- Configuring core sources
 -- Configuring migrated engine modules
--- Configuring done (1.7s)
+-- Configuring done (0.1s)
 -- Generating done (0.2s)
 -- Build files have been written to: /workspace/CnC_Generals_Zero_Hour/build
 /usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
@@ -58,1109 +23,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_avatar.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_avatar.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_avatar.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_avatar.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/img_benchmark_avatar.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c
-[  0%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/lv_demo_benchmark.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/benchmark/lv_demo_benchmark.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/benchmark/lv_demo_benchmark.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/lv_demo_benchmark.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/benchmark/lv_demo_benchmark.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/lv_demos.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/lv_demos.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/lv_demos.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/lv_demos.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/lv_demos.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c
-[  1%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c
-[  2%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c
-[  3%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_list_border.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c
-[  4%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_logo.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/lv_demo_music.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_list.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_list.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_list.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_list.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/lv_demo_music_list.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/music/lv_demo_music_main.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_arc_bg.c
-[  5%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/render/lv_demo_render.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/render/lv_demo_render.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/render/lv_demo_render.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/render/lv_demo_render.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/render/lv_demo_render.c
-[  6%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/stress/lv_demo_stress.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/stress/lv_demo_stress.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/stress/lv_demo_stress.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/stress/lv_demo_stress.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/stress/lv_demo_stress.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_clothes.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_clothes.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_clothes.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_clothes.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/widgets/assets/img_clothes.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_needle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_needle.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_needle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_needle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/widgets/assets/img_demo_widgets_needle.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_lvgl_logo.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_lvgl_logo.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_lvgl_logo.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_lvgl_logo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/widgets/assets/img_lvgl_logo.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/lv_demo_widgets.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/demos/widgets/lv_demo_widgets.c.o -MF CMakeFiles/lvgl.dir/lvgl/demos/widgets/lv_demo_widgets.c.o.d -o CMakeFiles/lvgl.dir/lvgl/demos/widgets/lv_demo_widgets.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/demos/widgets/lv_demo_widgets.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_group.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_group.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_group.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_group.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_group.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_class.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_class.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_class.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_class.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_class.c
-[  7%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_draw.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_draw.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_draw.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_draw.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_draw.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_event.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_event.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_event.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_event.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_event.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_id_builtin.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_id_builtin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_id_builtin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_id_builtin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_id_builtin.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_pos.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_pos.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_pos.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_pos.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_pos.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_property.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_property.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_property.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_property.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_property.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_scroll.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_scroll.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_scroll.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_scroll.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_scroll.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_style.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style_gen.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style_gen.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style_gen.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style_gen.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_style_gen.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_tree.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_tree.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_tree.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_tree.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_obj_tree.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/core/lv_refr.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/display/lv_display.c
-[  8%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/dma2d/lv_draw_dma2d.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_3d.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_3d.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_3d.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_3d.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_3d.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_arc.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_buf.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_buf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_buf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_buf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_buf.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_image.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_image.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_image.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_image.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_image.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_label.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_label.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_line.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_mask.c
-[  9%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_rect.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_triangle.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_vector.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_vector.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_vector.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_vector.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_draw_vector.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_image_decoder.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/lv_image_decoder.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/lv_image_decoder.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_image_decoder.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/lv_image_decoder.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
-[ 10%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c
-[ 11%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c
-[ 12%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_path.c
-[ 13%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/opengles/lv_draw_opengles.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
-[ 14%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sdl/lv_draw_sdl.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c
-[ 15%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_arc.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_border.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_border.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_fill.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_grad.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_grad.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_grad.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_grad.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_grad.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_img.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_letter.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_letter.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_letter.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_letter.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_letter.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_line.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_mask.c
-[ 16%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_transform.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_triangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_triangle.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_utils.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_vector.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_vector.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_vector.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_vector.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/sw/lv_draw_sw_vector.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c
-[ 17%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_math.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_path.c
-[ 18%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/drm/lv_linux_drm.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/drm/lv_linux_drm.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/drm/lv_linux_drm.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/drm/lv_linux_drm.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/drm/lv_linux_drm.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/fb/lv_linux_fbdev.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/fb/lv_linux_fbdev.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/fb/lv_linux_fbdev.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/fb/lv_linux_fbdev.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/fb/lv_linux_fbdev.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ft81x/lv_ft81x.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ft81x/lv_ft81x.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ft81x/lv_ft81x.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ft81x/lv_ft81x.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/ft81x/lv_ft81x.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ili9341/lv_ili9341.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ili9341/lv_ili9341.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ili9341/lv_ili9341.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ili9341/lv_ili9341.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/ili9341/lv_ili9341.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st7735/lv_st7735.c
-[ 19%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st7789/lv_st7789.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st7796/lv_st7796.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c
-[ 20%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/evdev/lv_evdev.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/evdev/lv_evdev.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/evdev/lv_evdev.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/evdev/lv_evdev.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/evdev/lv_evdev.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_glfw_window.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_glfw_window.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_glfw_window.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_glfw_window.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/glfw/lv_glfw_window.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_debug.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_debug.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_debug.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_debug.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/glfw/lv_opengles_debug.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_driver.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_driver.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_driver.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_driver.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/glfw/lv_opengles_driver.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_texture.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_texture.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_texture.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_texture.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/glfw/lv_opengles_texture.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/libinput/lv_libinput.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/libinput/lv_xkb.c
-[ 20%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_cache.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_entry.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/qnx/lv_qnx.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/qnx/lv_qnx.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/qnx/lv_qnx.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/qnx/lv_qnx.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/qnx/lv_qnx.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_keyboard.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_mouse.c
-[ 21%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/sdl/lv_sdl_window.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_context.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_context.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_context.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_context.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/uefi/lv_uefi_context.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_display.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/uefi/lv_uefi_display.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_private.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_private.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_private.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_private.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/uefi/lv_uefi_private.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wayland.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wayland_smm.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_cache.c
-[ 22%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_dmabuf.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_keyboard.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_pointer.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_seat.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_seat.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_seat.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_seat.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_seat.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shell.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shell.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shell.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shell.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_shell.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shm.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shm.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shm.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shm.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_shm.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_touch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_touch.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_touch.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_touch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_touch.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_window.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_window_decorations.c
-[ 23%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/windows/lv_windows_context.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_display.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/windows/lv_windows_display.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_input.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_input.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_input.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_input.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/windows/lv_windows_input.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_display.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/x11/lv_x11_display.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_input.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_input.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_input.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_input.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/drivers/x11/lv_x11_input.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_binfont_loader.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_binfont_loader.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_binfont_loader.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_binfont_loader.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_binfont_loader.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_fmt_txt.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_10.c
-[ 24%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_12.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_14.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14_aligned.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14_aligned.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14_aligned.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14_aligned.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_14_aligned.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_16.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_16.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_16.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_16.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_16.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_18.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_18.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_18.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_18.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_18.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_20.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_20.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_20.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_20.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_20.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_22.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_22.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_22.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_22.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_22.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_24.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_24.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_24.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_24.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_24.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_26.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_26.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_26.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_26.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_26.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_28.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_28_compressed.c
-[ 25%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_30.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_32.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_34.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_34.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_34.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_34.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_34.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_36.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_36.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_36.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_36.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_36.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_38.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_38.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_38.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_38.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_38.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_40.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_40.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_40.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_40.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_40.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_42.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_42.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_42.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_42.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_42.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_44.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_44.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_44.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_44.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_44.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_46.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_48.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_montserrat_8.c
-[ 26%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_simsun_14_cjk.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_simsun_16_cjk.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_16.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_16.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_16.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_16.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_unscii_16.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_8.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_8.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_8.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_8.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/font/lv_font_unscii_8.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/indev/lv_indev.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_gesture.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_gesture.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_gesture.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_gesture.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/indev/lv_indev_gesture.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/indev/lv_indev_scroll.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/layouts/flex/lv_flex.c
-[ 27%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/layouts/grid/lv_grid.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/layouts/lv_layout.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/code128.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/code128.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/code128.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/code128.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/barcode/code128.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/lv_barcode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/lv_barcode.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/lv_barcode.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/lv_barcode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/barcode/lv_barcode.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/bin_decoder/lv_bin_decoder.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/bin_decoder/lv_bin_decoder.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/bin_decoder/lv_bin_decoder.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/bin_decoder/lv_bin_decoder.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/bin_decoder/lv_bin_decoder.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/bmp/lv_bmp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/bmp/lv_bmp.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/bmp/lv_bmp.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/bmp/lv_bmp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/bmp/lv_bmp.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlparse.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlparse.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlparse.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlparse.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmlparse.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlrole.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlrole.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlrole.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlrole.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmlrole.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmltok.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmltok_impl.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/expat/xmltok_ns.c
-[ 28%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/ffmpeg/lv_ffmpeg.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/freetype/lv_freetype.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_glyph.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_glyph.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_glyph.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_glyph.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/freetype/lv_freetype_glyph.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_image.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_image.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_image.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_image.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/freetype/lv_freetype_image.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_outline.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_outline.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_outline.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_outline.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/freetype/lv_freetype_outline.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_ftsystem.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_ftsystem.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_ftsystem.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_ftsystem.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/freetype/lv_ftsystem.c
-[ 29%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp
-[ 29%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_cbfs.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_cbfs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_cbfs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_cbfs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_cbfs.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_fatfs.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_littlefs.c
-[ 29%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_memfs.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_posix.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_stdio.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_stdio.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_stdio.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_stdio.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_stdio.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_uefi.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_uefi.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_uefi.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_uefi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_uefi.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_win32.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_win32.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_win32.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_win32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/fsdrv/lv_fs_win32.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/gif/gifdec.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/gif/gifdec.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/gif/gifdec.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/gif/gifdec.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/gif/gifdec.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/gif/lv_gif.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/gif/lv_gif.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/gif/lv_gif.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/gif/lv_gif.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/gif/lv_gif.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/libpng/lv_libpng.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/lodepng/lodepng.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/lodepng/lv_lodepng.c
-[ 30%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/lz4/lz4.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/qrcode/lv_qrcode.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/qrcodegen.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/qrcodegen.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/qrcodegen.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/qrcodegen.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/qrcode/qrcodegen.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/rle/lv_rle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/rle/lv_rle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/rle/lv_rle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/rle/lv_rle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/rle/lv_rle.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/rlottie/lv_rlottie.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/rlottie/lv_rlottie.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/rlottie/lv_rlottie.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/rlottie/lv_rlottie.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/rlottie/lv_rlottie.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_decoder.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_decoder.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_decoder.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_decoder.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg_decoder.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg_parser.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg_render.c
-[ 31%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/svg/lv_svg_token.c
-[ 31%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgAccessor.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgAnimation.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCanvas.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCanvas.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCanvas.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCanvas.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgCanvas.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCapi.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCapi.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCapi.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCapi.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgCapi.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCompressor.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCompressor.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCompressor.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCompressor.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgCompressor.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgFill.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgFill.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgFill.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgFill.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgFill.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgGlCanvas.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgGlCanvas.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgGlCanvas.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgGlCanvas.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgGlCanvas.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgInitializer.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgInitializer.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgInitializer.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgInitializer.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgInitializer.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLoader.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLoader.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLoader.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLoader.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLoader.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp
-[ 32%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieLoader.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieLoader.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieLoader.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieLoader.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieLoader.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModel.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModel.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModel.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModel.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieModel.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModifier.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModifier.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModifier.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModifier.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieModifier.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParser.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParser.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParser.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParser.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieParser.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgMath.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgMath.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgMath.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgMath.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgMath.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPaint.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPaint.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPaint.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPaint.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgPaint.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgPicture.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgRawLoader.cpp
-[ 33%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgRender.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSaver.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgScene.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgScene.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgScene.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgScene.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgScene.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgShape.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgShape.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgShape.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgShape.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgShape.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgStr.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgStr.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgStr.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgStr.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgStr.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgLoader.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgLoader.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgLoader.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgLoader.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgLoader.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgPath.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgPath.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgPath.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgPath.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgPath.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSvgUtil.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwCanvas.cpp
-[ 34%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwFill.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwImage.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMath.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMath.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMath.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMath.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwMath.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMemPool.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMemPool.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMemPool.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMemPool.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwMemPool.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRaster.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRaster.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRaster.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRaster.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwRaster.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRenderer.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRenderer.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRenderer.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRenderer.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwRenderer.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRle.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRle.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRle.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRle.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwRle.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwShape.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgSwStroke.cpp
-[ 35%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp
-[ 36%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgText.cpp
-[ 36%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgWgCanvas.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgWgCanvas.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgWgCanvas.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgWgCanvas.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgWgCanvas.cpp
-[ 36%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgXmlParser.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgXmlParser.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgXmlParser.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgXmlParser.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/thorvg/tvgXmlParser.cpp
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/lv_tjpgd.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/lv_tjpgd.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/lv_tjpgd.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/lv_tjpgd.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/tjpgd/lv_tjpgd.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/tjpgd.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/tjpgd.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/tjpgd.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/tjpgd.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/libs/tjpgd/tjpgd.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/lv_init.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/lv_init.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/lv_init.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/lv_init.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/lv_init.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_ll.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_ll.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_ll.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_ll.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/class/lv_cache_lru_ll.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/class/lv_cache_lru_rb.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/instance/lv_image_cache.c
-[ 36%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/instance/lv_image_header_cache.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/lv_cache.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache_entry.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache_entry.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache_entry.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache_entry.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/cache/lv_cache_entry.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_anim.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim_timeline.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim_timeline.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim_timeline.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim_timeline.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_anim_timeline.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_area.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_area.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_area.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_area.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_area.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_array.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_array.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_array.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_array.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_array.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_async.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_async.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_async.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_async.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_async.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_bidi.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_circle_buf.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_color.c
-[ 37%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_color_op.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_event.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_fs.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_fs.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_fs.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_fs.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_fs.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_grad.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_grad.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_grad.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_grad.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_grad.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_iter.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_iter.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_iter.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_iter.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_iter.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_ll.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_ll.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_ll.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_ll.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_ll.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_log.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_log.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_log.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_log.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_log.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_lru.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_lru.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_lru.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_lru.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_lru.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_math.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_matrix.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_palette.c
-[ 38%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_profiler_builtin.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_rb.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_style.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style_gen.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style_gen.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style_gen.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style_gen.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_style_gen.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_templ.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_templ.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_templ.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_templ.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_templ.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_text.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text_ap.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text_ap.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text_ap.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text_ap.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_text_ap.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_timer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_timer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_timer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_timer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_timer.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_tree.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/misc/lv_utils.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_cmsis_rtos2.c
-[ 39%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_freertos.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_linux.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_mqx.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_mqx.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_mqx.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_mqx.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_mqx.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_os.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os_none.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os_none.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os_none.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os_none.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_os_none.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_pthread.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_pthread.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_pthread.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_pthread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_pthread.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_rtthread.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_rtthread.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_rtthread.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_rtthread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_rtthread.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_sdl2.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_sdl2.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_sdl2.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_sdl2.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_sdl2.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/osal/lv_windows.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/file_explorer/lv_file_explorer.c
-[ 40%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/font_manager/lv_font_manager.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/font_manager/lv_font_manager_recycle.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/fragment/lv_fragment.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment_manager.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment_manager.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment_manager.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment_manager.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/fragment/lv_fragment_manager.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/gridnav/lv_gridnav.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/gridnav/lv_gridnav.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/gridnav/lv_gridnav.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/gridnav/lv_gridnav.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/gridnav/lv_gridnav.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/ime/lv_ime_pinyin.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/ime/lv_ime_pinyin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/ime/lv_ime_pinyin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/ime/lv_ime_pinyin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/ime/lv_ime_pinyin.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/imgfont/lv_imgfont.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/imgfont/lv_imgfont.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/imgfont/lv_imgfont.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/imgfont/lv_imgfont.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/imgfont/lv_imgfont.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/monkey/lv_monkey.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/monkey/lv_monkey.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/monkey/lv_monkey.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/monkey/lv_monkey.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/monkey/lv_monkey.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/observer/lv_observer.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/snapshot/lv_snapshot.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/sysmon/lv_sysmon.c
-[ 41%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_display.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_helpers.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_indev.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev_gesture.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev_gesture.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev_gesture.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev_gesture.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_indev_gesture.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_screenshot_compare.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_screenshot_compare.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_screenshot_compare.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_screenshot_compare.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/test/lv_test_screenshot_compare.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c
-[ 42%] Building CXX object lib/CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_base_types.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_component.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_parser.c
-[ 42%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_style.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_update.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_utils.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_utils.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_utils.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_utils.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_utils.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_widget.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_widget.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_widget.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_widget.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/lv_xml_widget.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_button_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_button_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_button_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_button_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_button_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c
-[ 43%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_event_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_event_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_event_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_event_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_event_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_image_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_image_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_image_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_image_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_image_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_label_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_label_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_label_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_label_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_label_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c
-[ 44%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_table_parser.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_string_builtin.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_string_builtin.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_string_builtin.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_string_builtin.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/builtin/lv_string_builtin.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_tlsf.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_tlsf.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_tlsf.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_tlsf.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/builtin/lv_tlsf.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/clib/lv_mem_core_clib.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/clib/lv_sprintf_clib.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/clib/lv_string_clib.c
-[ 45%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/lv_mem.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_string_rtthread.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_string_rtthread.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_string_rtthread.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_string_rtthread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/rtthread/lv_string_rtthread.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/themes/default/lv_theme_default.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/themes/default/lv_theme_default.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/themes/default/lv_theme_default.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/themes/default/lv_theme_default.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/themes/default/lv_theme_default.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/themes/lv_theme.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/themes/lv_theme.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/themes/lv_theme.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/themes/lv_theme.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/themes/lv_theme.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/themes/mono/lv_theme_mono.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/themes/simple/lv_theme_simple.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/tick/lv_tick.c
-[ 46%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/3dtexture/lv_3dtexture.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/animimage/lv_animimage.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/arc/lv_arc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/arc/lv_arc.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/arc/lv_arc.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/arc/lv_arc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/arc/lv_arc.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/bar/lv_bar.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/bar/lv_bar.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/bar/lv_bar.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/bar/lv_bar.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/bar/lv_bar.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/button/lv_button.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/button/lv_button.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/button/lv_button.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/button/lv_button.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/button/lv_button.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/calendar/lv_calendar.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_chinese.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_chinese.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_chinese.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_chinese.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/calendar/lv_calendar_chinese.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/canvas/lv_canvas.c
-[ 47%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/chart/lv_chart.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/checkbox/lv_checkbox.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/dropdown/lv_dropdown.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/dropdown/lv_dropdown.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/dropdown/lv_dropdown.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/dropdown/lv_dropdown.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/dropdown/lv_dropdown.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/image/lv_image.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/image/lv_image.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/image/lv_image.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/image/lv_image.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/image/lv_image.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/imagebutton/lv_imagebutton.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/imagebutton/lv_imagebutton.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/imagebutton/lv_imagebutton.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/imagebutton/lv_imagebutton.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/imagebutton/lv_imagebutton.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/keyboard/lv_keyboard.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/keyboard/lv_keyboard.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/keyboard/lv_keyboard.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/keyboard/lv_keyboard.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/keyboard/lv_keyboard.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/label/lv_label.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/label/lv_label.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/label/lv_label.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/label/lv_label.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/label/lv_label.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/led/lv_led.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/line/lv_line.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/list/lv_list.c
-[ 48%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/lottie/lv_lottie.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/menu/lv_menu.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/msgbox/lv_msgbox.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/objx_templ/lv_objx_templ.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_animimage_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_dropdown_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_image_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_keyboard_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_label_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_obj_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_roller_properties.c
-[ 50%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_slider_properties.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_style_properties.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/property/lv_textarea_properties.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/roller/lv_roller.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/scale/lv_scale.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/slider/lv_slider.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/span/lv_span.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/spinbox/lv_spinbox.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/spinner/lv_spinner.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/switch/lv_switch.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/table/lv_table.c
-[ 51%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/tabview/lv_tabview.c
-[ 52%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/textarea/lv_textarea.c
-[ 52%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/tileview/lv_tileview.c
-[ 52%] Building C object lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -MD -MT lib/CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o -MF CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o.d -o CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/lvgl/src/widgets/win/lv_win.c
-[ 52%] Linking CXX static library liblvgl.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -P CMakeFiles/lvgl.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -E cmake_link_script CMakeFiles/lvgl.dir/link.txt --verbose=1
-/usr/bin/ar qc liblvgl.a CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_avatar.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_12_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_14_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_16_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_18_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_20_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_24_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/assets/lv_font_benchmark_montserrat_26_aligned.c.o CMakeFiles/lvgl.dir/lvgl/demos/benchmark/lv_demo_benchmark.c.o CMakeFiles/lvgl.dir/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c.o CMakeFiles/lvgl.dir/lvgl/demos/lv_demos.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_corner_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_pause_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_list_play_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_loop_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_next_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_pause_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_play_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_prev_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_btn_rnd_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_left_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_corner_right_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_1_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_2_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_cover_3_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_1_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_2_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_3_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_icon_4_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_list_border_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_logo.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_slider_knob_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_bottom_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/assets/img_lv_demo_music_wave_top_large.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_list.c.o CMakeFiles/lvgl.dir/lvgl/demos/music/lv_demo_music_main.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_arc_bg.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_argb8888_premultiplied.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_i1.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_l8.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565_swapped.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb565a8.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_rgb888.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/assets/img_render_lvgl_logo_xrgb8888.c.o CMakeFiles/lvgl.dir/lvgl/demos/render/lv_demo_render.c.o CMakeFiles/lvgl.dir/lvgl/demos/stress/lv_demo_stress.c.o CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/assets/img_demo_vector_avatar.c.o CMakeFiles/lvgl.dir/lvgl/demos/vector_graphic/lv_demo_vector_graphic.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_clothes.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_avatar.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_demo_widgets_needle.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/assets/img_lvgl_logo.c.o CMakeFiles/lvgl.dir/lvgl/demos/widgets/lv_demo_widgets.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_group.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_class.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_draw.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_event.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_id_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_pos.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_property.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_scroll.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_style_gen.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_obj_tree.c.o CMakeFiles/lvgl.dir/lvgl/src/core/lv_refr.c.o CMakeFiles/lvgl.dir/lvgl/src/display/lv_display.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/dma2d/lv_draw_dma2d_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_3d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_buf.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_image.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_mask.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_rect.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_draw_vector.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/lv_image_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nema_gfx/lv_nema_gfx_path.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_buf_g2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_draw_g2d_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_buf_map.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/g2d/lv_g2d_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_buf_pxp.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_draw_pxp_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_cfg.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_osa.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/pxp/lv_pxp_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_buf_vglite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_draw_vglite_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_buf.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_matrix.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_path.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/nxp/vglite/lv_vglite_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/opengles/lv_draw_opengles.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_image.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/renesas/dave2d/lv_draw_dave2d_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sdl/lv_draw_sdl.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_al88.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_l8.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_box_shadow.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_grad.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_letter.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_mask_rect.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_transform.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/sw/lv_draw_sw_vector.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_buf_vg_lite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_border.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_box_shadow.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_fill.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_img.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_label.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_layer.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_line.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_mask_rect.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_triangle.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_draw_vg_lite_vector.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_grad.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_math.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_path.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_pending.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_stroke.c.o CMakeFiles/lvgl.dir/lvgl/src/draw/vg_lite/lv_vg_lite_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/drm/lv_linux_drm.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/fb/lv_linux_fbdev.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ft81x/lv_ft81x.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/ili9341/lv_ili9341.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/lcd/lv_lcd_generic_mipi.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7735/lv_st7735.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7789/lv_st7789.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st7796/lv_st7796.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/st_ltdc/lv_st_ltdc.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/display/tft_espi/lv_tft_espi.cpp.o CMakeFiles/lvgl.dir/lvgl/src/drivers/evdev/lv_evdev.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_glfw_window.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_debug.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_driver.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/glfw/lv_opengles_texture.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_libinput.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/libinput/lv_xkb.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_entry.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_fbdev.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_image_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_lcd.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_libuv.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_profiler.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/nuttx/lv_nuttx_touchscreen.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/qnx/lv_qnx.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mouse.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/sdl/lv_sdl_window.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_context.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_display.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_pointer.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_indev_touch.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/uefi/lv_uefi_private.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wayland_smm.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_dmabuf.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_pointer_axis.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_seat.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shell.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_shm.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_touch.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_window_decorations.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/wayland/lv_wl_xdg_shell.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_context.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_display.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/windows/lv_windows_input.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_display.c.o CMakeFiles/lvgl.dir/lvgl/src/drivers/x11/lv_x11_input.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_binfont_loader.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_dejavu_16_persian_hebrew.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_fmt_txt.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_10.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_12.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_14_aligned.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_16.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_18.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_20.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_22.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_24.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_26.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_28_compressed.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_30.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_32.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_34.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_36.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_38.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_40.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_42.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_44.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_46.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_48.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_montserrat_8.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_14_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_simsun_16_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_14_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_source_han_sans_sc_16_cjk.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_16.c.o CMakeFiles/lvgl.dir/lvgl/src/font/lv_font_unscii_8.c.o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev.c.o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_gesture.c.o CMakeFiles/lvgl.dir/lvgl/src/indev/lv_indev_scroll.c.o CMakeFiles/lvgl.dir/lvgl/src/layouts/flex/lv_flex.c.o CMakeFiles/lvgl.dir/lvgl/src/layouts/grid/lv_grid.c.o CMakeFiles/lvgl.dir/lvgl/src/layouts/lv_layout.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/code128.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/barcode/lv_barcode.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/bin_decoder/lv_bin_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/bmp/lv_bmp.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlparse.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmlrole.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_impl.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/expat/xmltok_ns.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/ffmpeg/lv_ffmpeg.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_glyph.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_image.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_freetype_outline.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/freetype/lv_ftsystem.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_arduino_sd.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_cbfs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_fatfs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_littlefs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_memfs.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_posix.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_stdio.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_uefi.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/fsdrv/lv_fs_win32.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/gif/gifdec.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/gif/lv_gif.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/libpng/lv_libpng.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lodepng.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/lodepng/lv_lodepng.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/lz4/lz4.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/lv_qrcode.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/qrcode/qrcodegen.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/rle/lv_rle.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/rlottie/lv_rlottie.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_decoder.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_render.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/svg/lv_svg_token.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAccessor.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgAnimation.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCapi.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgCompressor.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgFill.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgGlCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgInitializer.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieAnimation.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieBuilder.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieExpressions.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieInterpolator.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModel.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieModifier.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParser.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgLottieParserHandler.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgMath.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPaint.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgPicture.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRawLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgRender.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSaver.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgScene.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgShape.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgStr.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgCssStyle.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgLoader.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgPath.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgSceneBuilder.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSvgUtil.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwFill.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwImage.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMath.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwMemPool.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwPostEffect.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRaster.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRenderer.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwRle.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwShape.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgSwStroke.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgTaskScheduler.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgText.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgWgCanvas.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/thorvg/tvgXmlParser.cpp.o CMakeFiles/lvgl.dir/lvgl/src/libs/tiny_ttf/lv_tiny_ttf.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/lv_tjpgd.c.o CMakeFiles/lvgl.dir/lvgl/src/libs/tjpgd/tjpgd.c.o CMakeFiles/lvgl.dir/lvgl/src/lv_init.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_ll.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/class/lv_cache_lru_rb.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/instance/lv_image_header_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/cache/lv_cache_entry.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_anim_timeline.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_area.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_array.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_async.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_bidi.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_circle_buf.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_color_op.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_event.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_fs.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_grad.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_iter.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_ll.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_log.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_lru.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_math.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_matrix.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_palette.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_profiler_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_rb.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_style_gen.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_templ.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_text_ap.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_timer.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_tree.c.o CMakeFiles/lvgl.dir/lvgl/src/misc/lv_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_cmsis_rtos2.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_freertos.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_linux.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_mqx.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_os_none.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_pthread.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_sdl2.c.o CMakeFiles/lvgl.dir/lvgl/src/osal/lv_windows.c.o CMakeFiles/lvgl.dir/lvgl/src/others/file_explorer/lv_file_explorer.c.o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager.c.o CMakeFiles/lvgl.dir/lvgl/src/others/font_manager/lv_font_manager_recycle.c.o CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment.c.o CMakeFiles/lvgl.dir/lvgl/src/others/fragment/lv_fragment_manager.c.o CMakeFiles/lvgl.dir/lvgl/src/others/gridnav/lv_gridnav.c.o CMakeFiles/lvgl.dir/lvgl/src/others/ime/lv_ime_pinyin.c.o CMakeFiles/lvgl.dir/lvgl/src/others/imgfont/lv_imgfont.c.o CMakeFiles/lvgl.dir/lvgl/src/others/monkey/lv_monkey.c.o CMakeFiles/lvgl.dir/lvgl/src/others/observer/lv_observer.c.o CMakeFiles/lvgl.dir/lvgl/src/others/snapshot/lv_snapshot.c.o CMakeFiles/lvgl.dir/lvgl/src/others/sysmon/lv_sysmon.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_display.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_helpers.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_indev_gesture.c.o CMakeFiles/lvgl.dir/lvgl/src/others/test/lv_test_screenshot_compare.c.o CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_matrix.c.o CMakeFiles/lvgl.dir/lvgl/src/others/vg_lite_tvg/vg_lite_tvg.cpp.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_base_types.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_component.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_style.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_update.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_utils.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/lv_xml_widget.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_arc_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_bar_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_button_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_buttonmatrix_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_calendar_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_canvas_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_chart_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_checkbox_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_dropdown_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_event_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_image_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_keyboard_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_label_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_obj_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_roller_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_scale_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_slider_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_spangroup_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_table_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_tabview_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/others/xml/parsers/lv_xml_textarea_parser.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_mem_core_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_sprintf_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_string_builtin.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/builtin/lv_tlsf.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_mem_core_clib.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_sprintf_clib.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/clib/lv_string_clib.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/lv_mem.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_mem_core_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_sprintf_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/rtthread/lv_string_rtthread.c.o CMakeFiles/lvgl.dir/lvgl/src/stdlib/uefi/lv_mem_core_uefi.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/default/lv_theme_default.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/lv_theme.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/mono/lv_theme_mono.c.o CMakeFiles/lvgl.dir/lvgl/src/themes/simple/lv_theme_simple.c.o CMakeFiles/lvgl.dir/lvgl/src/tick/lv_tick.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/3dtexture/lv_3dtexture.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/animimage/lv_animimage.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/arc/lv_arc.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/bar/lv_bar.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/button/lv_button.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/buttonmatrix/lv_buttonmatrix.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_chinese.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_arrow.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/calendar/lv_calendar_header_dropdown.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/canvas/lv_canvas.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/chart/lv_chart.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/checkbox/lv_checkbox.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/dropdown/lv_dropdown.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/image/lv_image.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/imagebutton/lv_imagebutton.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/keyboard/lv_keyboard.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/label/lv_label.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/led/lv_led.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/line/lv_line.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/list/lv_list.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/lottie/lv_lottie.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/menu/lv_menu.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/msgbox/lv_msgbox.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/objx_templ/lv_objx_templ.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_animimage_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_dropdown_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_image_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_keyboard_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_label_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_obj_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_roller_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_slider_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_style_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/property/lv_textarea_properties.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/roller/lv_roller.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/scale/lv_scale.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/slider/lv_slider.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/span/lv_span.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinbox/lv_spinbox.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/spinner/lv_spinner.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/switch/lv_switch.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/table/lv_table.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/tabview/lv_tabview.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/textarea/lv_textarea.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/tileview/lv_tileview.c.o CMakeFiles/lvgl.dir/lvgl/src/widgets/win/lv_win.c.o
-/usr/bin/ranlib liblvgl.a
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 52%] Built target lvgl
 /usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
@@ -1169,13 +32,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 52%] Building C object lib/CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cc  -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -O3 -DNDEBUG -MD -MT lib/CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o -MF CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o.d -o CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/miniaudio/miniaudio.c
-[ 53%] Linking C static library libminiaudio.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -P CMakeFiles/miniaudio.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib && /usr/bin/cmake -E cmake_link_script CMakeFiles/miniaudio.dir/link.txt --verbose=1
-/usr/bin/ar qc libminiaudio.a CMakeFiles/miniaudio.dir/miniaudio/miniaudio.c.o
-/usr/bin/ranlib libminiaudio.a
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 53%] Built target miniaudio
 /usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
@@ -1184,31 +41,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Auth.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Auth.c.o -MF CMakeFiles/usgt2.dir/gt2Auth.c.o.d -o CMakeFiles/usgt2.dir/gt2Auth.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Auth.c
-[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Buffer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Buffer.c.o -MF CMakeFiles/usgt2.dir/gt2Buffer.c.o.d -o CMakeFiles/usgt2.dir/gt2Buffer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Buffer.c
-[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Callback.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Callback.c.o -MF CMakeFiles/usgt2.dir/gt2Callback.c.o.d -o CMakeFiles/usgt2.dir/gt2Callback.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Callback.c
-[ 53%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Connection.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Connection.c.o -MF CMakeFiles/usgt2.dir/gt2Connection.c.o.d -o CMakeFiles/usgt2.dir/gt2Connection.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Connection.c
-[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Encode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Encode.c.o -MF CMakeFiles/usgt2.dir/gt2Encode.c.o.d -o CMakeFiles/usgt2.dir/gt2Encode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Encode.c
-[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Filter.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Filter.c.o -MF CMakeFiles/usgt2.dir/gt2Filter.c.o.d -o CMakeFiles/usgt2.dir/gt2Filter.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Filter.c
-[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Main.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Main.c.o -MF CMakeFiles/usgt2.dir/gt2Main.c.o.d -o CMakeFiles/usgt2.dir/gt2Main.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Main.c
-[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Message.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Message.c.o -MF CMakeFiles/usgt2.dir/gt2Message.c.o.d -o CMakeFiles/usgt2.dir/gt2Message.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Message.c
-[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Socket.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Socket.c.o -MF CMakeFiles/usgt2.dir/gt2Socket.c.o.d -o CMakeFiles/usgt2.dir/gt2Socket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Socket.c
-[ 54%] Building C object lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Utility.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/gt2Utility.c.o -MF CMakeFiles/usgt2.dir/gt2Utility.c.o.d -o CMakeFiles/usgt2.dir/gt2Utility.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2/gt2Utility.c
-[ 54%] Linking C static library libusgt2.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cmake -P CMakeFiles/usgt2.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 && /usr/bin/cmake -E cmake_link_script CMakeFiles/usgt2.dir/link.txt --verbose=1
-/usr/bin/ar qc libusgt2.a CMakeFiles/usgt2.dir/gt2Auth.c.o CMakeFiles/usgt2.dir/gt2Buffer.c.o CMakeFiles/usgt2.dir/gt2Callback.c.o CMakeFiles/usgt2.dir/gt2Connection.c.o CMakeFiles/usgt2.dir/gt2Encode.c.o CMakeFiles/usgt2.dir/gt2Filter.c.o CMakeFiles/usgt2.dir/gt2Main.c.o CMakeFiles/usgt2.dir/gt2Message.c.o CMakeFiles/usgt2.dir/gt2Socket.c.o CMakeFiles/usgt2.dir/gt2Utility.c.o
-/usr/bin/ranlib libusgt2.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 54%] Built target usgt2
 /usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
@@ -1217,55 +50,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/darray.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/darray.c.o -MF CMakeFiles/uscommon.dir/darray.c.o.d -o CMakeFiles/uscommon.dir/darray.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/darray.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAssert.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAssert.c.o -MF CMakeFiles/uscommon.dir/gsAssert.c.o.d -o CMakeFiles/uscommon.dir/gsAssert.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsAssert.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAvailable.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsAvailable.c.o -MF CMakeFiles/uscommon.dir/gsAvailable.c.o.d -o CMakeFiles/uscommon.dir/gsAvailable.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsAvailable.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCore.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCore.c.o -MF CMakeFiles/uscommon.dir/gsCore.c.o.d -o CMakeFiles/uscommon.dir/gsCore.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsCore.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCrypt.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsCrypt.c.o -MF CMakeFiles/uscommon.dir/gsCrypt.c.o.d -o CMakeFiles/uscommon.dir/gsCrypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsCrypt.c
-[ 54%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsDebug.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsDebug.c.o -MF CMakeFiles/uscommon.dir/gsDebug.c.o.d -o CMakeFiles/uscommon.dir/gsDebug.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsDebug.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsLargeInt.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsLargeInt.c.o -MF CMakeFiles/uscommon.dir/gsLargeInt.c.o.d -o CMakeFiles/uscommon.dir/gsLargeInt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsLargeInt.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsMemory.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsMemory.c.o -MF CMakeFiles/uscommon.dir/gsMemory.c.o.d -o CMakeFiles/uscommon.dir/gsMemory.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsMemory.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatform.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatform.c.o -MF CMakeFiles/uscommon.dir/gsPlatform.c.o.d -o CMakeFiles/uscommon.dir/gsPlatform.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatform.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformSocket.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformSocket.c.o -MF CMakeFiles/uscommon.dir/gsPlatformSocket.c.o.d -o CMakeFiles/uscommon.dir/gsPlatformSocket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatformSocket.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformThread.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformThread.c.o -MF CMakeFiles/uscommon.dir/gsPlatformThread.c.o.d -o CMakeFiles/uscommon.dir/gsPlatformThread.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatformThread.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsPlatformUtil.c.o -MF CMakeFiles/uscommon.dir/gsPlatformUtil.c.o.d -o CMakeFiles/uscommon.dir/gsPlatformUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsPlatformUtil.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsRC4.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsRC4.c.o -MF CMakeFiles/uscommon.dir/gsRC4.c.o.d -o CMakeFiles/uscommon.dir/gsRC4.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsRC4.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsResultCodes.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsResultCodes.c.o -MF CMakeFiles/uscommon.dir/gsResultCodes.c.o.d -o CMakeFiles/uscommon.dir/gsResultCodes.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsResultCodes.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSHA1.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSHA1.c.o -MF CMakeFiles/uscommon.dir/gsSHA1.c.o.d -o CMakeFiles/uscommon.dir/gsSHA1.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsSHA1.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSSL.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsSSL.c.o -MF CMakeFiles/uscommon.dir/gsSSL.c.o.d -o CMakeFiles/uscommon.dir/gsSSL.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsSSL.c
-[ 55%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsStringUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsStringUtil.c.o -MF CMakeFiles/uscommon.dir/gsStringUtil.c.o.d -o CMakeFiles/uscommon.dir/gsStringUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsStringUtil.c
-[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsXML.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsXML.c.o -MF CMakeFiles/uscommon.dir/gsXML.c.o.d -o CMakeFiles/uscommon.dir/gsXML.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsXML.c
-[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/hashtable.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/hashtable.c.o -MF CMakeFiles/uscommon.dir/hashtable.c.o.d -o CMakeFiles/uscommon.dir/hashtable.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/hashtable.c
-[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/md5c.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/md5c.c.o -MF CMakeFiles/uscommon.dir/md5c.c.o.d -o CMakeFiles/uscommon.dir/md5c.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/md5c.c
-[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsUdpEngine.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/gsUdpEngine.c.o -MF CMakeFiles/uscommon.dir/gsUdpEngine.c.o.d -o CMakeFiles/uscommon.dir/gsUdpEngine.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/gsUdpEngine.c
-[ 56%] Building C object lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o -MF CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o.d -o CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common/linux/LinuxCommon.c
-[ 56%] Linking C static library libuscommon.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cmake -P CMakeFiles/uscommon.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common && /usr/bin/cmake -E cmake_link_script CMakeFiles/uscommon.dir/link.txt --verbose=1
-/usr/bin/ar qc libuscommon.a CMakeFiles/uscommon.dir/darray.c.o CMakeFiles/uscommon.dir/gsAssert.c.o CMakeFiles/uscommon.dir/gsAvailable.c.o CMakeFiles/uscommon.dir/gsCore.c.o CMakeFiles/uscommon.dir/gsCrypt.c.o CMakeFiles/uscommon.dir/gsDebug.c.o CMakeFiles/uscommon.dir/gsLargeInt.c.o CMakeFiles/uscommon.dir/gsMemory.c.o CMakeFiles/uscommon.dir/gsPlatform.c.o CMakeFiles/uscommon.dir/gsPlatformSocket.c.o CMakeFiles/uscommon.dir/gsPlatformThread.c.o CMakeFiles/uscommon.dir/gsPlatformUtil.c.o CMakeFiles/uscommon.dir/gsRC4.c.o CMakeFiles/uscommon.dir/gsResultCodes.c.o CMakeFiles/uscommon.dir/gsSHA1.c.o CMakeFiles/uscommon.dir/gsSSL.c.o CMakeFiles/uscommon.dir/gsStringUtil.c.o CMakeFiles/uscommon.dir/gsXML.c.o CMakeFiles/uscommon.dir/hashtable.c.o CMakeFiles/uscommon.dir/md5c.c.o CMakeFiles/uscommon.dir/gsUdpEngine.c.o CMakeFiles/uscommon.dir/linux/LinuxCommon.c.o
-/usr/bin/ranlib libuscommon.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 56%] Built target uscommon
 /usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
@@ -1274,33 +59,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpBuffer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpBuffer.c.o -MF CMakeFiles/ushttp.dir/ghttpBuffer.c.o.d -o CMakeFiles/ushttp.dir/ghttpBuffer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpBuffer.c
-[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCallbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCallbacks.c.o -MF CMakeFiles/ushttp.dir/ghttpCallbacks.c.o.d -o CMakeFiles/ushttp.dir/ghttpCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpCallbacks.c
-[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCommon.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpCommon.c.o -MF CMakeFiles/ushttp.dir/ghttpCommon.c.o.d -o CMakeFiles/ushttp.dir/ghttpCommon.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpCommon.c
-[ 56%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpConnection.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpConnection.c.o -MF CMakeFiles/ushttp.dir/ghttpConnection.c.o.d -o CMakeFiles/ushttp.dir/ghttpConnection.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpConnection.c
-[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpEncryption.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpEncryption.c.o -MF CMakeFiles/ushttp.dir/ghttpEncryption.c.o.d -o CMakeFiles/ushttp.dir/ghttpEncryption.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpEncryption.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpEncryption.c: In function ‘verify_callback’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpEncryption.c:212:55: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
-  212 |                                 "  Error = %d\n", err);
-      |                                                       ^
-[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpMain.c.o -MF CMakeFiles/ushttp.dir/ghttpMain.c.o.d -o CMakeFiles/ushttp.dir/ghttpMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpMain.c
-[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpPost.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpPost.c.o -MF CMakeFiles/ushttp.dir/ghttpPost.c.o.d -o CMakeFiles/ushttp.dir/ghttpPost.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpPost.c
-[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpProcess.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpProcess.c.o -MF CMakeFiles/ushttp.dir/ghttpProcess.c.o.d -o CMakeFiles/ushttp.dir/ghttpProcess.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpProcess.c
-[ 57%] Building C object lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpSoap.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DOPENSSL=1 -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/ghttpSoap.c.o -MF CMakeFiles/ushttp.dir/ghttpSoap.c.o.d -o CMakeFiles/ushttp.dir/ghttpSoap.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp/ghttpSoap.c
-[ 57%] Linking C static library libushttp.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cmake -P CMakeFiles/ushttp.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp && /usr/bin/cmake -E cmake_link_script CMakeFiles/ushttp.dir/link.txt --verbose=1
-/usr/bin/ar qc libushttp.a CMakeFiles/ushttp.dir/ghttpBuffer.c.o CMakeFiles/ushttp.dir/ghttpCallbacks.c.o CMakeFiles/ushttp.dir/ghttpCommon.c.o CMakeFiles/ushttp.dir/ghttpConnection.c.o CMakeFiles/ushttp.dir/ghttpEncryption.c.o CMakeFiles/ushttp.dir/ghttpMain.c.o CMakeFiles/ushttp.dir/ghttpPost.c.o CMakeFiles/ushttp.dir/ghttpProcess.c.o CMakeFiles/ushttp.dir/ghttpSoap.c.o
-/usr/bin/ranlib libushttp.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 57%] Built target ushttp
 /usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
@@ -1309,244 +68,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Building C object lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/AuthService.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/AuthService.c.o -MF CMakeFiles/uswebservice.dir/AuthService.c.o.d -o CMakeFiles/uswebservice.dir/AuthService.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsCore.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.h:18,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:3:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c: In function ‘wsLoginCertReadBinary’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsPlatform.h:518:33: warning: ‘__builtin_strncpy’ specified bound 31 equals destination size [-Wstringop-truncation]
-  518 |         #define _tcsncpy        strncpy
-      |                                 ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1170:67: note: in expansion of macro ‘_tcsncpy’
- 1170 |                                                                   _tcsncpy(a, bufin, l); \
-      |                                                                   ^~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1256:9: note: in expansion of macro ‘READ_NTS’
- 1256 |         READ_NTS(certOut->mProfileNick, WS_LOGIN_NICK_LEN);
-      |         ^~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsPlatform.h:518:33: warning: ‘__builtin_strncpy’ specified bound 21 equals destination size [-Wstringop-truncation]
-  518 |         #define _tcsncpy        strncpy
-      |                                 ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1170:67: note: in expansion of macro ‘_tcsncpy’
- 1170 |                                                                   _tcsncpy(a, bufin, l); \
-      |                                                                   ^~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1257:9: note: in expansion of macro ‘READ_NTS’
- 1257 |         READ_NTS(certOut->mUniqueNick, WS_LOGIN_UNIQUENICK_LEN);
-      |         ^~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../common/gsPlatform.h:518:33: warning: ‘__builtin_strncpy’ specified bound 33 equals destination size [-Wstringop-truncation]
-  518 |         #define _tcsncpy        strncpy
-      |                                 ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1170:67: note: in expansion of macro ‘_tcsncpy’
- 1170 |                                                                   _tcsncpy(a, bufin, l); \
-      |                                                                   ^~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/AuthService.c:1258:9: note: in expansion of macro ‘READ_NTS’
- 1258 |         READ_NTS(certOut->mCdKeyHash, WS_LOGIN_KEYHASH_LEN);
-      |         ^~~~~~~~
-[ 57%] Building C object lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/RacingService.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/RacingService.c.o -MF CMakeFiles/uswebservice.dir/RacingService.c.o.d -o CMakeFiles/uswebservice.dir/RacingService.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/ghttp.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/ghttpMain.h:15,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/ghttpSoap.h:13,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.h:17,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:9:
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetRegionalData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:201:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingGetRegionalData’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/ghttpMain.h:14:
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetRegionalData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:201:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetContestData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:396:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingGetContestData’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetContestData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:396:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetTop10Rankings’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:569:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingGetTop10Rankings’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetTop10Rankings’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:569:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetRanksAboveAndBelow’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:619:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingGetRanksAboveAndBelow’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetRanksAboveAndBelow’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:619:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetFriendRankings’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:670:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingGetFriendRankings’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingGetFriendRankings’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:670:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingSubmitGhost’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:775:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingSubmitGhost’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingSubmitGhost’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:775:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-In function ‘wsiServiceAvailable’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingSubmitScores’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:882:7:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/../ghttp/../common/gsPlatform.h:341:39: warning: ‘.race.pubsvs.gamespy.com/Rac...’ directive output may be truncated writing 63 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:40: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                        ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:77: note: in expansion of macro ‘WS_RACING_SERVICE_URL_FORMAT’
-   76 |                         snprintf(wsRacingServiceURL, WS_RACING_MAX_URL_LEN, WS_RACING_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c: In function ‘wsRacingSubmitScores’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:45:65: note: format string is defined here
-   45 | #define WS_RACING_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.race.pubsvs." GSI_DOMAIN_NAME "/RaceService/NintendoRacingService.asmx"
-      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:76:4,
-    inlined from ‘wsiServiceAvailable’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:68:17,
-    inlined from ‘wsRacingSubmitScores’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices/RacingService.c:882:7:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 72 and 135 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-[ 57%] Linking C static library libuswebservice.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cmake -P CMakeFiles/uswebservice.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices && /usr/bin/cmake -E cmake_link_script CMakeFiles/uswebservice.dir/link.txt --verbose=1
-/usr/bin/ar qc libuswebservice.a CMakeFiles/uswebservice.dir/AuthService.c.o CMakeFiles/uswebservice.dir/RacingService.c.o
-/usr/bin/ranlib libuswebservice.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 57%] Built target uswebservice
 /usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
@@ -1555,227 +77,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbMain.c.o -MF CMakeFiles/usbrigades.dir/gsbMain.c.o.d -o CMakeFiles/usbrigades.dir/gsbMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c: In function ‘gsbCloneRole’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1001:41: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1001 |     role->mRoleName = goawstrdup(srcRole->mRoleName);
-      |                                  ~~~~~~~^~~~~~~~~~~
-      |                                         |
-      |                                         short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/ghttp.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/ghttpMain.h:15,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/ghttpSoap.h:13,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/brigades.h:18,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:14:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1001:21: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1001 |     role->mRoleName = goawstrdup(srcRole->mRoleName);
-      |                     ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c: In function ‘gsbCloneBrigade’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1067:54: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1067 |     brigade->mMessageOfTheDay = goawstrdup(srcBrigade->mMessageOfTheDay);
-      |                                            ~~~~~~~~~~^~~~~~~~~~~~~~~~~~
-      |                                                      |
-      |                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1067:31: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1067 |     brigade->mMessageOfTheDay = goawstrdup(srcBrigade->mMessageOfTheDay);
-      |                               ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1068:43: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1068 |     brigade->mName = goawstrdup(srcBrigade->mName);
-      |                                 ~~~~~~~~~~^~~~~~~
-      |                                           |
-      |                                           short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1068:20: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1068 |     brigade->mName = goawstrdup(srcBrigade->mName);
-      |                    ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1069:42: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1069 |     brigade->mTag = goawstrdup(srcBrigade->mTag);
-      |                                ~~~~~~~~~~^~~~~~
-      |                                          |
-      |                                          short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1069:19: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1069 |     brigade->mTag = goawstrdup(srcBrigade->mTag);
-      |                   ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1070:42: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1070 |     brigade->mUrl = goawstrdup(srcBrigade->mUrl);
-      |                                ~~~~~~~~~~^~~~~~
-      |                                          |
-      |                                          short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1070:19: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1070 |     brigade->mUrl = goawstrdup(srcBrigade->mUrl);
-      |                   ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c: In function ‘gsbSendMessageToBrigade’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbMain.c:1168:56: warning: passing argument 1 of ‘wcslen’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1168 |     gsi_u32             messageSize = (gsi_u32)(wcslen(message) * sizeof(UCS2Char));
-      |                                                        ^~~~~~~
-      |                                                        |
-      |                                                        short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../ghttp/../common/gsPlatform.h:87:
-/usr/include/wchar.h:247:38: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  247 | extern size_t wcslen (const wchar_t *__s) __THROW __attribute_pure__;
-      |                       ~~~~~~~~~~~~~~~^~~
-[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbSerialize.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbSerialize.c.o -MF CMakeFiles/usbrigades.dir/gsbSerialize.c.o.d -o CMakeFiles/usbrigades.dir/gsbSerialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbSerialize.c
-[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbServices.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbServices.c.o -MF CMakeFiles/usbrigades.dir/gsbServices.c.o.d -o CMakeFiles/usbrigades.dir/gsbServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbServices.c
-[ 57%] Building C object lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/gsbUtil.c.o -MF CMakeFiles/usbrigades.dir/gsbUtil.c.o.d -o CMakeFiles/usbrigades.dir/gsbUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsCommon.h:42,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsResultCodes.h:9,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c: In function ‘gsbiUploadThreadFunc’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:446:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  446 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:456:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  456 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:468:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  468 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:479:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  479 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:505:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  505 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c: In function ‘gsbiDownloadThreadFunc’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:609:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  609 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:624:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  624 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatformThread.h:139:42: warning: returning ‘int’ from a function with return type ‘void *’ makes pointer from integer without a cast [-Wint-conversion]
-  139 | #define GS_THREAD_RETURN_NEGATIVE return -1
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:635:17: note: in expansion of macro ‘GS_THREAD_RETURN_NEGATIVE’
-  635 |                 GS_THREAD_RETURN_NEGATIVE;
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c: In function ‘gsbiCloneBrigadeLogoList’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:724:82: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  724 |                 destLogoList->mLogos[i].mPath = goawstrdup(srcLogoList->mLogos[i].mPath);
-      |                                                            ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
-      |                                                                                  |
-      |                                                                                  short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsCommon.h:40:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:724:47: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  724 |                 destLogoList->mLogos[i].mPath = goawstrdup(srcLogoList->mLogos[i].mPath);
-      |                                               ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:728:81: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  728 |                 destLogoList->mLogos[i].mUrl = goawstrdup(srcLogoList->mLogos[i].mUrl);
-      |                                                           ~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                 |
-      |                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:728:46: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  728 |                 destLogoList->mLogos[i].mUrl = goawstrdup(srcLogoList->mLogos[i].mUrl);
-      |                                              ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c: In function ‘gsbiCloneBrigadeLogo’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:776:45: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  776 |         tempLogo->mPath = goawstrdup(srcLogo->mPath);
-      |                                      ~~~~~~~^~~~~~~
-      |                                             |
-      |                                             short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:776:25: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  776 |         tempLogo->mPath = goawstrdup(srcLogo->mPath);
-      |                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:777:44: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  777 |         tempLogo->mUrl = goawstrdup(srcLogo->mUrl);
-      |                                     ~~~~~~~^~~~~~
-      |                                            |
-      |                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:777:24: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  777 |         tempLogo->mUrl = goawstrdup(srcLogo->mUrl);
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c: In function ‘gsbiCloneBrigadeMemberContents’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:787:56: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  787 |         destMember->mDescription = goawstrdup(srcMember->mDescription);
-      |                                               ~~~~~~~~~^~~~~~~~~~~~~~
-      |                                                        |
-      |                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:787:34: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  787 |         destMember->mDescription = goawstrdup(srcMember->mDescription);
-      |                                  ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:794:50: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  794 |         destMember->mTitle = goawstrdup(srcMember->mTitle);
-      |                                         ~~~~~~~~~^~~~~~~~
-      |                                                  |
-      |                                                  short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:794:28: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  794 |         destMember->mTitle = goawstrdup(srcMember->mTitle);
-      |                            ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c: In function ‘gsbiCloneEntitlement’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:843:66: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  843 |     destEntitlement->mEntitlementName = goawstrdup(srcEntitlement->mEntitlementName);
-      |                                                    ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
-      |                                                                  |
-      |                                                                  short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades/gsbUtil.c:843:39: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  843 |     destEntitlement->mEntitlementName = goawstrdup(srcEntitlement->mEntitlementName);
-      |                                       ^
-[ 57%] Linking C static library libusbrigades.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cmake -P CMakeFiles/usbrigades.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades && /usr/bin/cmake -E cmake_link_script CMakeFiles/usbrigades.dir/link.txt --verbose=1
-/usr/bin/ar qc libusbrigades.a CMakeFiles/usbrigades.dir/gsbMain.c.o CMakeFiles/usbrigades.dir/gsbSerialize.c.o CMakeFiles/usbrigades.dir/gsbServices.c.o CMakeFiles/usbrigades.dir/gsbUtil.c.o
-/usr/bin/ranlib libusbrigades.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 57%] Built target usbrigades
 /usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
@@ -1784,23 +86,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCallbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCallbacks.c.o -MF CMakeFiles/uschat.dir/chatCallbacks.c.o.d -o CMakeFiles/uschat.dir/chatCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatCallbacks.c
-[ 57%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatChannel.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatChannel.c.o -MF CMakeFiles/uschat.dir/chatChannel.c.o.d -o CMakeFiles/uschat.dir/chatChannel.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatChannel.c
-[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCrypt.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatCrypt.c.o -MF CMakeFiles/uschat.dir/chatCrypt.c.o.d -o CMakeFiles/uschat.dir/chatCrypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatCrypt.c
-[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatHandlers.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatHandlers.c.o -MF CMakeFiles/uschat.dir/chatHandlers.c.o.d -o CMakeFiles/uschat.dir/chatHandlers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatHandlers.c
-[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatMain.c.o -MF CMakeFiles/uschat.dir/chatMain.c.o.d -o CMakeFiles/uschat.dir/chatMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatMain.c
-[ 58%] Building C object lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatSocket.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/chatSocket.c.o -MF CMakeFiles/uschat.dir/chatSocket.c.o.d -o CMakeFiles/uschat.dir/chatSocket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat/chatSocket.c
-[ 58%] Linking C static library libuschat.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cmake -P CMakeFiles/uschat.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat && /usr/bin/cmake -E cmake_link_script CMakeFiles/uschat.dir/link.txt --verbose=1
-/usr/bin/ar qc libuschat.a CMakeFiles/uschat.dir/chatCallbacks.c.o CMakeFiles/uschat.dir/chatChannel.c.o CMakeFiles/uschat.dir/chatCrypt.c.o CMakeFiles/uschat.dir/chatHandlers.c.o CMakeFiles/uschat.dir/chatMain.c.o CMakeFiles/uschat.dir/chatSocket.c.o
-/usr/bin/ranlib libuschat.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 58%] Built target uschat
 /usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
@@ -1809,72 +95,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Building C object lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/NATify.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/NATify.c.o -MF CMakeFiles/usnatneg.dir/NATify.c.o.d -o CMakeFiles/usnatneg.dir/NATify.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/NATify.c
-[ 58%] Building C object lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/natneg.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/natneg.c.o -MF CMakeFiles/usnatneg.dir/natneg.c.o.d -o CMakeFiles/usnatneg.dir/natneg.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c: In function ‘ResolveServers’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:70: warning: ‘%s’ directive output may be truncated writing 19 bytes into a region of size between 0 and 63 [-Wformat-truncation=]
-  459 |                 snprintf(hostnameBuffer, sizeof(hostnameBuffer), "%s.%s", __GSIACGamename, defaultHostname);
-      |                                                                      ^~
-......
-  478 |                 matchup1ip = ResolveServer(Matchup1Hostname, MATCHUP1_HOSTNAME);
-      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/../common/gsPlatform.h:86,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/nninternal.h:14,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:12:
-In function ‘snprintf’,
-    inlined from ‘ResolveServer’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:3,
-    inlined from ‘ResolveServers’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:478:16:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 21 and 84 bytes into a destination of size 64
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c: In function ‘ResolveServers’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:70: warning: ‘%s’ directive output may be truncated writing 19 bytes into a region of size between 0 and 63 [-Wformat-truncation=]
-  459 |                 snprintf(hostnameBuffer, sizeof(hostnameBuffer), "%s.%s", __GSIACGamename, defaultHostname);
-      |                                                                      ^~
-......
-  483 |                 matchup2ip = ResolveServer(Matchup2Hostname, MATCHUP2_HOSTNAME);
-      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘ResolveServer’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:3,
-    inlined from ‘ResolveServers’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:483:16:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 21 and 84 bytes into a destination of size 64
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c: In function ‘ResolveServers’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:70: warning: ‘%s’ directive output may be truncated writing 19 bytes into a region of size between 0 and 63 [-Wformat-truncation=]
-  459 |                 snprintf(hostnameBuffer, sizeof(hostnameBuffer), "%s.%s", __GSIACGamename, defaultHostname);
-      |                                                                      ^~
-......
-  488 |                 matchup3ip = ResolveServer(Matchup3Hostname, MATCHUP3_HOSTNAME);
-      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘ResolveServer’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:459:3,
-    inlined from ‘ResolveServers’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg/natneg.c:488:16:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 21 and 84 bytes into a destination of size 64
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-[ 58%] Linking C static library libusnatneg.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg && /usr/bin/cmake -P CMakeFiles/usnatneg.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg && /usr/bin/cmake -E cmake_link_script CMakeFiles/usnatneg.dir/link.txt --verbose=1
-/usr/bin/ar qc libusnatneg.a CMakeFiles/usnatneg.dir/NATify.c.o CMakeFiles/usnatneg.dir/natneg.c.o
-/usr/bin/ranlib libusnatneg.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 58%] Built target usnatneg
 /usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
@@ -1883,29 +104,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Building C object lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/qr2.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/qr2.c.o -MF CMakeFiles/usqr2.dir/qr2.c.o.d -o CMakeFiles/usqr2.dir/qr2.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.c:114:8: warning: missing initializer for field ‘gamename’ of ‘struct qr2_implementation_s’ [-Wmissing-field-initializers]
-  114 | struct qr2_implementation_s static_qr2_rec = {INVALID_SOCKET};
-      |        ^~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.c:16:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.h:699:14: note: ‘gamename’ declared here
-  699 |         char gamename[64];
-      |              ^~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.c: In function ‘gs_encode’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.c:807:17: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
-  807 |                 for (pos=0 ; pos <= 2 ; pos++, i++)
-      |                 ^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2.c:810:25: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
-  810 |                         kwart[0] = (unsigned char)(  (trip[0])       >> 2);
-      |                         ^~~~~
-[ 58%] Building C object lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/qr2regkeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/qr2regkeys.c.o -MF CMakeFiles/usqr2.dir/qr2regkeys.c.o.d -o CMakeFiles/usqr2.dir/qr2regkeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2/qr2regkeys.c
-[ 58%] Linking C static library libusqr2.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 && /usr/bin/cmake -P CMakeFiles/usqr2.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 && /usr/bin/cmake -E cmake_link_script CMakeFiles/usqr2.dir/link.txt --verbose=1
-/usr/bin/ar qc libusqr2.a CMakeFiles/usqr2.dir/qr2.c.o CMakeFiles/usqr2.dir/qr2regkeys.c.o
-/usr/bin/ranlib libusqr2.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 58%] Built target usqr2
 /usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
@@ -1914,36 +113,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Building C object lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/gcdkeyc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/gcdkeyc.c.o -MF CMakeFiles/uscdkey.dir/gcdkeyc.c.o.d -o CMakeFiles/uscdkey.dir/gcdkeyc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeyc.c
-[ 58%] Building C object lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/gcdkeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/gcdkeys.c.o -MF CMakeFiles/uscdkey.dir/gcdkeys.c.o.d -o CMakeFiles/uscdkey.dir/gcdkeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c: In function ‘gcd_think’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c:449:36: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  449 |                                 if (client->ntries <= VAL_RETRIES)
-      |                                    ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c:454:25: note: here
-  454 |                         case cs_gotok:
-      |                         ^~~~
-In function ‘get_sockaddrin’,
-    inlined from ‘init_incoming_socket’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c:566:2,
-    inlined from ‘gcd_init’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c:136:9:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c:882:54: warning: argument 1 null where non-null expected [-Wnonnull]
-  882 |         if (saddr->sin_addr.s_addr == INADDR_NONE && strcmp(host,broadcast_t) != 0)
-      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/../common/gsPlatform.h:84,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.h:14,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey/gcdkeys.c:12:
-/usr/include/string.h: In function ‘gcd_init’:
-/usr/include/string.h:156:12: note: in a call to function ‘strcmp’ declared ‘nonnull’
-  156 | extern int strcmp (const char *__s1, const char *__s2)
-      |            ^~~~~~
-[ 58%] Linking C static library libuscdkey.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey && /usr/bin/cmake -P CMakeFiles/uscdkey.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey && /usr/bin/cmake -E cmake_link_script CMakeFiles/uscdkey.dir/link.txt --verbose=1
-/usr/bin/ar qc libuscdkey.a CMakeFiles/uscdkey.dir/gcdkeyc.c.o CMakeFiles/uscdkey.dir/gcdkeys.c.o
-/usr/bin/ranlib libuscdkey.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 58%] Built target uscdkey
 /usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
@@ -1952,271 +122,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gp.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gp.c.o -MF CMakeFiles/usgp.dir/gp.c.o.d -o CMakeFiles/usgp.dir/gp.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:671:14: warning: argument 2 of type ‘const char[31]’ with mismatched bound [-Warray-parameter=]
-  671 |   const char desirednick[GP_NICK_LEN],
-      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.h:21,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:14:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.h:1787:24: note: previously declared as ‘const char[21]’
- 1787 |         const gsi_char desirednick[GP_UNIQUENICK_LEN],
-      |         ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c: In function ‘gpConnectA’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 21 bytes from a region of size 1 [-Wstringop-overread]
-  158 |         return gpiConnect(connection, nick, "", email, password, "", "", "", NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:158:16: note: referencing argument 9 of type ‘const char[65]’
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.h:65:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c: In function ‘gpConnectNewUserA’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-  245 |         return gpiConnect(connection, nick, uniquenick, email, password, "", "", "", cdkey, firewall, GPITrue, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:245:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c: In function ‘gpConnectUniqueNickA’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-  312 |         return gpiConnect(connection, "", uniquenick, "", password, "", "", "", NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 2 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 51 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:312:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c: In function ‘gpConnectPreAuthenticatedA’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-  371 |         return gpiConnect(connection, "", "", "", "", authtoken, partnerchallenge, "", NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 2 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 21 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 51 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: warning: ‘gpiConnect’ reading 25 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:371:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c: In function ‘gpConnectLoginTicketA’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-  431 |         return gpiConnect(connection, "", "", "", "", "", "", loginticket, NULL, firewall, GPIFalse, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 2 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 21 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 3 of type ‘const char[21]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 51 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 4 of type ‘const char[51]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 31 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 5 of type ‘const char[31]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 6 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: warning: ‘gpiConnect’ reading 256 bytes from a region of size 1 [-Wstringop-overread]
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 7 of type ‘const char[256]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 8 of type ‘const char[25]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:431:16: note: referencing argument 9 of type ‘const char[65]’
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.h:28:1: note: in a call to function ‘gpiConnect’
-   28 | gpiConnect(
-      | ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c: In function ‘gpSuggestUniqueNickA’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:704:16: warning: ‘gpiSuggestUniqueNick’ reading 31 bytes from a region of size 21 [-Wstringop-overread]
-  704 |         return gpiSuggestUniqueNick(connection, desirednick, blocking, callback, param);
-      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gp.c:704:16: note: referencing argument 2 of type ‘const char[31]’
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.h:70:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiSearch.h:163:10: note: in a call to function ‘gpiSuggestUniqueNick’
-  163 | GPResult gpiSuggestUniqueNick(
-      |          ^~~~~~~~~~~~~~~~~~~~
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpi.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpi.c.o -MF CMakeFiles/usgp.dir/gpi.c.o.d -o CMakeFiles/usgp.dir/gpi.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.c
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiBuddy.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiBuddy.c.o -MF CMakeFiles/usgp.dir/gpiBuddy.c.o.d -o CMakeFiles/usgp.dir/gpiBuddy.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiBuddy.c
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiBuffer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiBuffer.c.o -MF CMakeFiles/usgp.dir/gpiBuffer.c.o.d -o CMakeFiles/usgp.dir/gpiBuffer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiBuffer.c
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiCallback.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiCallback.c.o -MF CMakeFiles/usgp.dir/gpiCallback.c.o.d -o CMakeFiles/usgp.dir/gpiCallback.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiCallback.c
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiConnect.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiConnect.c.o -MF CMakeFiles/usgp.dir/gpiConnect.c.o.d -o CMakeFiles/usgp.dir/gpiConnect.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c: In function ‘gpiSendLogin’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:401:34: warning: comparison between ‘GPIBool’ {aka ‘enum _GPIBool’} and ‘enum _GPEnum’ [-Wenum-compare]
-  401 |         if(iconnection->firewall == GP_FIREWALL)
-      |                                  ^~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c: In function ‘gpiDisconnectCleanupProfile’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:798:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
-  798 |     if (profile->blocked)
-      |     ^~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.h:62,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:14:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.h:23:29: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
-   23 | #define freeclear(mem)      { gsifree(mem); (mem) = NULL; }
-      |                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:801:9: note: in expansion of macro ‘freeclear’
-  801 |         freeclear(profile->authSig);
-      |         ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c: In function ‘gpiSendLogin’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:340:36: warning: ‘%s’ directive writing up to 32 bytes into a region of size between 18 and 464 [-Wformat-overflow=]
-  340 |         sprintf(buffer, "%s%s%s%s%s%s",
-      |                                    ^~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:12:
-In function ‘sprintf’,
-    inlined from ‘gpiSendLogin’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:340:2:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 49 and 527 bytes into a destination of size 512
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c: In function ‘gpiProcessConnect’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:637:44: warning: ‘%s’ directive writing up to 32 bytes into a region of size between 18 and 464 [-Wformat-overflow=]
-  637 |                 sprintf(buffer, "%s%s%s%s%s%s",
-      |                                            ^~
-In function ‘sprintf’,
-    inlined from ‘gpiProcessConnect’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiConnect.c:637:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 49 and 527 bytes into a destination of size 512
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiInfo.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiInfo.c.o -MF CMakeFiles/usgp.dir/gpiInfo.c.o.d -o CMakeFiles/usgp.dir/gpiInfo.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiInfo.c
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiKeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiKeys.c.o -MF CMakeFiles/usgp.dir/gpiKeys.c.o.d -o CMakeFiles/usgp.dir/gpiKeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiKeys.c
-[ 58%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiOperation.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiOperation.c.o -MF CMakeFiles/usgp.dir/gpiOperation.c.o.d -o CMakeFiles/usgp.dir/gpiOperation.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiOperation.c
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiPeer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiPeer.c.o -MF CMakeFiles/usgp.dir/gpiPeer.c.o.d -o CMakeFiles/usgp.dir/gpiPeer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiPeer.c
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiProfile.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiProfile.c.o -MF CMakeFiles/usgp.dir/gpiProfile.c.o.d -o CMakeFiles/usgp.dir/gpiProfile.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.h:62,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c:11:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c: In function ‘gpiReadDiskProfile’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c:264:30: warning: ‘gpiReadDiskKeyValue’ accessing 512 bytes in a region of size 256 [-Wstringop-overflow=]
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c:264:30: note: referencing argument 3 of type ‘char[512]’
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c:264:30: warning: ‘gpiReadDiskKeyValue’ accessing 512 bytes in a region of size 256 [-Wstringop-overflow=]
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c:264:30: note: referencing argument 4 of type ‘char[512]’
-  264 |                 CHECK_RESULT(gpiReadDiskKeyValue(connection, &failed, key, value));
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.h:39:80: note: in definition of macro ‘CHECK_RESULT’
-   39 | #define CHECK_RESULT(result)                          { GPResult __result__ = (result);\
-      |                                                                                ^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiProfile.c:124:17: note: in a call to function ‘gpiReadDiskKeyValue’
-  124 | static GPResult gpiReadDiskKeyValue(GPConnection * connection,
-      |                 ^~~~~~~~~~~~~~~~~~~
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiSearch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiSearch.c.o -MF CMakeFiles/usgp.dir/gpiSearch.c.o.d -o CMakeFiles/usgp.dir/gpiSearch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiSearch.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiSearch.c: In function ‘gpiProcessSearch’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiSearch.c:928:50: warning: comparison between ‘GPIBool’ {aka ‘enum _GPIBool’} and ‘enum _GPEnum’ [-Wenum-compare]
-  928 |                                         if((more == GP_MORE) && (arg.more == GP_MORE))
-      |                                                  ^~
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiTransfer.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiTransfer.c.o -MF CMakeFiles/usgp.dir/gpiTransfer.c.o.d -o CMakeFiles/usgp.dir/gpiTransfer.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c: In function ‘gpiHandleSendRequest.isra’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:492:41: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
-  492 |                 sprintf(key, "\\name%d\\", i);
-      |                                         ^
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/../common/gsPlatform.h:86,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpi.h:15,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:17:
-In function ‘sprintf’,
-    inlined from ‘gpiHandleSendRequest.isra’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:492:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 8 and 17 bytes into a destination of size 16
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c: In function ‘gpiHandleSendRequest.isra’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:506:41: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
-  506 |                 sprintf(key, "\\size%d\\", i);
-      |                                         ^
-In function ‘sprintf’,
-    inlined from ‘gpiHandleSendRequest.isra’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:506:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 8 and 17 bytes into a destination of size 16
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c: In function ‘gpiHandleSendRequest.isra’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:520:40: warning: ‘\’ directive writing 1 byte into a region of size between 0 and 9 [-Wformat-overflow=]
-  520 |                 sprintf(key, "\\mtime%d\\", i);
-      |                                        ^~
-In function ‘sprintf’,
-    inlined from ‘gpiHandleSendRequest.isra’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiTransfer.c:520:3:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:30:10: note: ‘__builtin___sprintf_chk’ output between 9 and 18 bytes into a destination of size 16
-   30 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   31 |                                   __glibc_objsize (__s), __fmt,
-      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   32 |                                   __va_arg_pack ());
-      |                                   ~~~~~~~~~~~~~~~~~
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiUnique.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiUnique.c.o -MF CMakeFiles/usgp.dir/gpiUnique.c.o.d -o CMakeFiles/usgp.dir/gpiUnique.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUnique.c
-[ 59%] Building C object lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiUtility.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/gpiUtility.c.o -MF CMakeFiles/usgp.dir/gpiUtility.c.o.d -o CMakeFiles/usgp.dir/gpiUtility.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.c: In function ‘gpiSetError’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.c:34:9: warning: ‘__builtin_strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
-   34 |         strncpy(dest, src, len);
-      |         ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.c: In function ‘gpiSetErrorString’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP/gpiUtility.c:34:9: warning: ‘__builtin_strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
-[ 59%] Linking C static library libusgp.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cmake -P CMakeFiles/usgp.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP && /usr/bin/cmake -E cmake_link_script CMakeFiles/usgp.dir/link.txt --verbose=1
-/usr/bin/ar qc libusgp.a CMakeFiles/usgp.dir/gp.c.o CMakeFiles/usgp.dir/gpi.c.o CMakeFiles/usgp.dir/gpiBuddy.c.o CMakeFiles/usgp.dir/gpiBuffer.c.o CMakeFiles/usgp.dir/gpiCallback.c.o CMakeFiles/usgp.dir/gpiConnect.c.o CMakeFiles/usgp.dir/gpiInfo.c.o CMakeFiles/usgp.dir/gpiKeys.c.o CMakeFiles/usgp.dir/gpiOperation.c.o CMakeFiles/usgp.dir/gpiPeer.c.o CMakeFiles/usgp.dir/gpiProfile.c.o CMakeFiles/usgp.dir/gpiSearch.c.o CMakeFiles/usgp.dir/gpiTransfer.c.o CMakeFiles/usgp.dir/gpiUnique.c.o CMakeFiles/usgp.dir/gpiUtility.c.o
-/usr/bin/ranlib libusgp.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 59%] Built target usgp
 /usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
@@ -2225,47 +131,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Building C object lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/gbucket.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/gbucket.c.o -MF CMakeFiles/usstats.dir/gbucket.c.o.d -o CMakeFiles/usstats.dir/gbucket.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gbucket.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gbucket.c: In function ‘BucketAvg’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gbucket.c:213:58: warning: operation on ‘pbucket->nvals’ may be undefined [-Wsequence-point]
-  213 | #define AVG(cur, new, num) ((((cur) * (num)) + (new)) / (++num))
-      |                                                         ~^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gbucket.c:221:45: note: in expansion of macro ‘AVG’
-  221 |                 return DoSet(pbucket, bint( AVG((*(int *)DoGet(pbucket)), (*(int *)value), pbucket->nvals)));
-      |                                             ^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gbucket.c:213:58: warning: operation on ‘pbucket->nvals’ may be undefined [-Wsequence-point]
-  213 | #define AVG(cur, new, num) ((((cur) * (num)) + (new)) / (++num))
-      |                                                         ~^~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gbucket.c:223:47: note: in expansion of macro ‘AVG’
-  223 |                 return DoSet(pbucket, bfloat( AVG((*(double *)DoGet(pbucket)), (*(double *)value), pbucket->nvals)));
-      |                                               ^~~
-[ 59%] Building C object lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/gstats.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/gstats.c.o -MF CMakeFiles/usstats.dir/gstats.c.o.d -o CMakeFiles/usstats.dir/gstats.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c: In function ‘InitStatsThink’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c:302:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  302 |                 {
-      |                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c:332:9: note: here
-  332 |         case init_awaitchallenge:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c:384:25: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  384 |                         memset(rcvbuffer, 0, (unsigned int)rcvmax);
-      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c:388:9: note: here
-  388 |         case init_awaitsessionkey:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c:424:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  424 |                         stats_initstate = init_complete;
-      |                         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats/gstats.c:428:9: note: here
-  428 |         case init_complete:
-      |         ^~~~
-[ 59%] Linking C static library libusstats.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats && /usr/bin/cmake -P CMakeFiles/usstats.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats && /usr/bin/cmake -E cmake_link_script CMakeFiles/usstats.dir/link.txt --verbose=1
-/usr/bin/ar qc libusstats.a CMakeFiles/usstats.dir/gbucket.c.o CMakeFiles/usstats.dir/gstats.c.o
-/usr/bin/ranlib libusstats.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 59%] Built target usstats
 /usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
@@ -2274,13 +140,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Building C object lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/pingerMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/pingerMain.c.o -MF CMakeFiles/uspinger.dir/pingerMain.c.o.d -o CMakeFiles/uspinger.dir/pingerMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger/pingerMain.c
-[ 59%] Linking C static library libuspinger.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger && /usr/bin/cmake -P CMakeFiles/uspinger.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspinger.dir/link.txt --verbose=1
-/usr/bin/ar qc libuspinger.a CMakeFiles/uspinger.dir/pingerMain.c.o
-/usr/bin/ranlib libuspinger.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 59%] Built target uspinger
 /usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
@@ -2289,73 +149,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 59%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_crypt.c
-[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_queryengine.c
-[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_server.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_server.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_server.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_server.c
-[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverbrowsing.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverbrowsing.c: In function ‘WaitForTriggerUpdate’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverbrowsing.c:271:49: warning: comparison between ‘SBServerListState’ and ‘enum <anonymous>’ [-Wenum-compare]
-  271 |                 if (viaMaster && sb->list.state == sb_disconnected) //we were supposed to get from master, and it's disconnected
-      |                                                 ^~
-[ 60%] Building C object lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o -MF CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o.d -o CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c: In function ‘ProcessMainListData’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1201:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1201 |                 GOADecrypt(&(slist->cryptkey), (unsigned char *)inbuf, inlen);
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1203:9: note: here
- 1203 |         case pi_fixedheader:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1228:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1228 |                 slist->expectedelements = -1;
-      |                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1231:9: note: here
- 1231 |         case pi_keylist:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1263:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1263 |                 slist->expectedelements = -1;
-      |                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1264:9: note: here
- 1264 |         case pi_uniquevaluelist:
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1286:31: warning: this statement may fall through [-Wimplicit-fallthrough=]
- 1286 |                 slist->pstate = pi_servers;
-      |                 ~~~~~~~~~~~~~~^~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1287:9: note: here
- 1287 |         case pi_servers :
-      |         ^~~~
-In function ‘IncomingListParseServer’,
-    inlined from ‘ProcessMainListData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1292:17,
-    inlined from ‘ProcessIncomingData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1610:9,
-    inlined from ‘SBListThink’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1801:10:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1080:18: warning: ‘port’ may be used uninitialized [-Wmaybe-uninitialized]
- 1080 |         server = SBAllocServer(slist, ip, port);
-      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c: In function ‘SBListThink’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1055:24: note: ‘port’ was declared here
- 1055 |         unsigned short port;
-      |                        ^~~~
-In function ‘SBServerListFindServerByIP’,
-    inlined from ‘ProcessPushServer’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1508:18,
-    inlined from ‘ProcessAdHocData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1552:11,
-    inlined from ‘ProcessIncomingData’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1615:10,
-    inlined from ‘SBListThink’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1801:10:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:213:64: warning: ‘port’ may be used uninitialized [-Wmaybe-uninitialized]
-  213 |                 if (SBServerGetPublicInetAddress(server) == ip && SBServerGetPublicQueryPortNBO(server) == port)
-      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c: In function ‘SBListThink’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing/sb_serverlist.c:1499:24: note: ‘port’ was declared here
- 1499 |         unsigned short port;
-      |                        ^~~~
-[ 60%] Linking C static library libusserverbrowsing.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cmake -P CMakeFiles/usserverbrowsing.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing && /usr/bin/cmake -E cmake_link_script CMakeFiles/usserverbrowsing.dir/link.txt --verbose=1
-/usr/bin/ar qc libusserverbrowsing.a CMakeFiles/usserverbrowsing.dir/sb_crypt.c.o CMakeFiles/usserverbrowsing.dir/sb_queryengine.c.o CMakeFiles/usserverbrowsing.dir/sb_server.c.o CMakeFiles/usserverbrowsing.dir/sb_serverbrowsing.c.o CMakeFiles/usserverbrowsing.dir/sb_serverlist.c.o
-/usr/bin/ranlib libusserverbrowsing.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 60%] Built target usserverbrowsing
 /usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
@@ -2364,46 +158,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 60%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerAutoMatch.c.o -MF CMakeFiles/uspeer.dir/peerAutoMatch.c.o.d -o CMakeFiles/uspeer.dir/peerAutoMatch.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerAutoMatch.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerCallbacks.c.o -MF CMakeFiles/uspeer.dir/peerCallbacks.c.o.d -o CMakeFiles/uspeer.dir/peerCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerCallbacks.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o -MF CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o.d -o CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerGlobalCallbacks.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerHost.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerHost.c.o -MF CMakeFiles/uspeer.dir/peerHost.c.o.d -o CMakeFiles/uspeer.dir/peerHost.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerHost.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerKeys.c.o -MF CMakeFiles/uspeer.dir/peerKeys.c.o.d -o CMakeFiles/uspeer.dir/peerKeys.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerKeys.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMain.c.o -MF CMakeFiles/uspeer.dir/peerMain.c.o.d -o CMakeFiles/uspeer.dir/peerMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerMain.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerMangle.c.o -MF CMakeFiles/uspeer.dir/peerMangle.c.o.d -o CMakeFiles/uspeer.dir/peerMangle.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerMangle.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerOperations.c.o -MF CMakeFiles/uspeer.dir/peerOperations.c.o.d -o CMakeFiles/uspeer.dir/peerOperations.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerOperations.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPing.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPing.c.o -MF CMakeFiles/uspeer.dir/peerPing.c.o.d -o CMakeFiles/uspeer.dir/peerPing.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPlayers.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c:15:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c: In function ‘piGetXping’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerMain.h:67:37: warning: ‘__builtin_strncpy’ specified bound 64 equals destination size [-Wstringop-truncation]
-   67 | #define strzcpy(dest, src, len)   { strncpy(dest, src, (len)); (dest)[(len) - 1] = '\0'; }
-      |                                     ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPing.c:982:9: note: in expansion of macro ‘strzcpy’
-  982 |         strzcpy(xpingMatch.nicks[1], nick2, PI_NICK_MAX_LEN);
-      |         ^~~~~~~
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerPlayers.c.o -MF CMakeFiles/uspeer.dir/peerPlayers.c.o.d -o CMakeFiles/uspeer.dir/peerPlayers.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerPlayers.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerQR.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerQR.c.o -MF CMakeFiles/uspeer.dir/peerQR.c.o.d -o CMakeFiles/uspeer.dir/peerQR.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerQR.c
-[ 61%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerRooms.c.o -MF CMakeFiles/uspeer.dir/peerRooms.c.o.d -o CMakeFiles/uspeer.dir/peerRooms.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerRooms.c
-[ 62%] Building C object lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerSB.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/peerSB.c.o -MF CMakeFiles/uspeer.dir/peerSB.c.o.d -o CMakeFiles/uspeer.dir/peerSB.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer/peerSB.c
-[ 62%] Linking C static library libuspeer.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cmake -P CMakeFiles/uspeer.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspeer.dir/link.txt --verbose=1
-/usr/bin/ar qc libuspeer.a CMakeFiles/uspeer.dir/peerAutoMatch.c.o CMakeFiles/uspeer.dir/peerCallbacks.c.o CMakeFiles/uspeer.dir/peerGlobalCallbacks.c.o CMakeFiles/uspeer.dir/peerHost.c.o CMakeFiles/uspeer.dir/peerKeys.c.o CMakeFiles/uspeer.dir/peerMain.c.o CMakeFiles/uspeer.dir/peerMangle.c.o CMakeFiles/uspeer.dir/peerOperations.c.o CMakeFiles/uspeer.dir/peerPing.c.o CMakeFiles/uspeer.dir/peerPlayers.c.o CMakeFiles/uspeer.dir/peerQR.c.o CMakeFiles/uspeer.dir/peerRooms.c.o CMakeFiles/uspeer.dir/peerSB.c.o
-/usr/bin/ranlib libuspeer.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 62%] Built target uspeer
 /usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
@@ -2412,28 +167,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 62%] Building C object lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/ptMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/ptMain.c.o -MF CMakeFiles/uspt.dir/ptMain.c.o.d -o CMakeFiles/uspt.dir/ptMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c: In function ‘ptLookupFilePlanetInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c:692:20: warning: ‘?file=’ directive output may be truncated writing 6 bytes into a region of size between 1 and 2048 [-Wformat-truncation=]
-  692 |                 "%s?file=%d&gamename=%s", gPTAFilePlanetURL, fileID, __GSIACGamename);
-      |                    ^~~~~~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c:10:
-In function ‘snprintf’,
-    inlined from ‘ptLookupFilePlanetInfo’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt/ptMain.c:691:2:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 18 and 2138 bytes into a destination of size 2048
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-[ 62%] Linking C static library libuspt.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt && /usr/bin/cmake -P CMakeFiles/uspt.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt && /usr/bin/cmake -E cmake_link_script CMakeFiles/uspt.dir/link.txt --verbose=1
-/usr/bin/ar qc libuspt.a CMakeFiles/uspt.dir/ptMain.c.o
-/usr/bin/ranlib libuspt.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 62%] Built target uspt
 /usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
@@ -2442,21 +176,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 62%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeMain.c.o -MF CMakeFiles/ussake.dir/sakeMain.c.o.d -o CMakeFiles/ussake.dir/sakeMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeMain.c
-[ 62%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequest.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequest.c.o -MF CMakeFiles/ussake.dir/sakeRequest.c.o.d -o CMakeFiles/ussake.dir/sakeRequest.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequest.c
-[ 63%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestMisc.c.o -MF CMakeFiles/ussake.dir/sakeRequestMisc.c.o.d -o CMakeFiles/ussake.dir/sakeRequestMisc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequestMisc.c
-[ 63%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestModify.c.o -MF CMakeFiles/ussake.dir/sakeRequestModify.c.o.d -o CMakeFiles/ussake.dir/sakeRequestModify.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequestModify.c
-[ 63%] Building C object lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/sakeRequestRead.c.o -MF CMakeFiles/ussake.dir/sakeRequestRead.c.o.d -o CMakeFiles/ussake.dir/sakeRequestRead.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake/sakeRequestRead.c
-[ 63%] Linking C static library libussake.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cmake -P CMakeFiles/ussake.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake && /usr/bin/cmake -E cmake_link_script CMakeFiles/ussake.dir/link.txt --verbose=1
-/usr/bin/ar qc libussake.a CMakeFiles/ussake.dir/sakeMain.c.o CMakeFiles/ussake.dir/sakeRequest.c.o CMakeFiles/ussake.dir/sakeRequestMisc.c.o CMakeFiles/ussake.dir/sakeRequestModify.c.o CMakeFiles/ussake.dir/sakeRequestRead.c.o
-/usr/bin/ranlib libussake.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 63%] Built target ussake
 /usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
@@ -2465,83 +185,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciInterface.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciInterface.c.o -MF CMakeFiles/ussc.dir/sciInterface.c.o.d -o CMakeFiles/ussc.dir/sciInterface.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sc.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sci.h:18,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c: In function ‘sciInterfaceCreate’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/../common/gsPlatform.h:341:39: warning: ‘.comp.pubsvs.gamespy.com/Com...’ directive output may be truncated writing 67 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:24:66: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   24 | #define SC_SERVICE_URL_FORMAT                                    GSI_HTTP_PROTOCOL_URL "%s.comp.pubsvs." GSI_DOMAIN_NAME "/CompetitionService/CompetitionService.asmx"
-      |                                                                  ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:73:72: note: in expansion of macro ‘SC_SERVICE_URL_FORMAT’
-   73 |                         snprintf(scServiceURL, SC_SERVICE_MAX_URL_LEN, SC_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                        ^~~~~~~~~~~~~~~~~~~~~
-In file included from /usr/include/stdio.h:980,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/../common/gsPlatform.h:86:
-In function ‘snprintf’,
-    inlined from ‘sciInterfaceCreate’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:73:4:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 76 and 139 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c: In function ‘sciInterfaceCreate’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/../common/gsPlatform.h:341:39: warning: ‘.comp.pubsvs.gamespy.com/Atl...’ directive output may be truncated writing 58 bytes into a region of size between 57 and 120 [-Wformat-truncation=]
-  341 |         #define GSI_HTTP_PROTOCOL_URL "https://"
-      |                                       ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:25:50: note: in expansion of macro ‘GSI_HTTP_PROTOCOL_URL’
-   25 | #define SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.comp.pubsvs." GSI_DOMAIN_NAME "/AtlasDataServices/GameConfig.asmx"
-      |                                                  ^~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:82:86: note: in expansion of macro ‘SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT’
-   82 |                         snprintf(scGameConfigDataServiceURL, SC_SERVICE_MAX_URL_LEN, SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT, __GSIACGamename);
-      |                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:25:75: note: format string is defined here
-   25 | #define SC_GAME_CONFIG_DATA_SERVICE_URL_FORMAT   GSI_HTTP_PROTOCOL_URL "%s.comp.pubsvs." GSI_DOMAIN_NAME "/AtlasDataServices/GameConfig.asmx"
-      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In function ‘snprintf’,
-    inlined from ‘sciInterfaceCreate’ at /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciInterface.c:82:4:
-/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:10: note: ‘__builtin___snprintf_chk’ output between 67 and 130 bytes into a destination of size 128
-   54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   55 |                                    __glibc_objsize (__s), __fmt,
-      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   56 |                                    __va_arg_pack ());
-      |                                    ~~~~~~~~~~~~~~~~~
-[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciMain.c.o -MF CMakeFiles/ussc.dir/sciMain.c.o.d -o CMakeFiles/ussc.dir/sciMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciMain.c
-[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciReport.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciReport.c.o -MF CMakeFiles/ussc.dir/sciReport.c.o.d -o CMakeFiles/ussc.dir/sciReport.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c:17:41: warning: argument 1 of type ‘gsi_u8[40]’ {aka ‘unsigned char[40]’} with mismatched bound [-Warray-parameter=]
-   17 | SCResult SC_CALL sciCreateReport(gsi_u8 theSessionGuid[SC_SESSION_GUID_SIZE],
-      |                                  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.h:121:33: note: previously declared as ‘gsi_u8[16]’ {aka ‘unsigned char[16]’}
-  121 | SCResult sciCreateReport(gsi_u8 theSessionGuid[16],
-      |                          ~~~~~~~^~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c: In function ‘sciReportAddStringValue’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c:932:9: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
-  932 |         strncpy(&theReport->mBuffer.mData[theReport->mBuffer.mPos], theValue, strlen(theValue));
-      |         ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciReport.c:932:9: note: length computed here
-  932 |         strncpy(&theReport->mBuffer.mData[theReport->mBuffer.mPos], theValue, strlen(theValue));
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciSerialize.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciSerialize.c.o -MF CMakeFiles/ussc.dir/sciSerialize.c.o.d -o CMakeFiles/ussc.dir/sciSerialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciSerialize.c
-[ 63%] Building C object lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciWebServices.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/sciWebServices.c.o -MF CMakeFiles/ussc.dir/sciWebServices.c.o.d -o CMakeFiles/ussc.dir/sciWebServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc/sciWebServices.c
-[ 63%] Linking C static library libussc.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cmake -P CMakeFiles/ussc.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc && /usr/bin/cmake -E cmake_link_script CMakeFiles/ussc.dir/link.txt --verbose=1
-/usr/bin/ar qc libussc.a CMakeFiles/ussc.dir/sciInterface.c.o CMakeFiles/ussc.dir/sciMain.c.o CMakeFiles/ussc.dir/sciReport.c.o CMakeFiles/ussc.dir/sciSerialize.c.o CMakeFiles/ussc.dir/sciWebServices.c.o
-/usr/bin/ranlib libussc.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 63%] Built target ussc
 /usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
@@ -2550,557 +194,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDeserialize.c.o -MF CMakeFiles/usd2g.dir/d2gDeserialize.c.o.d -o CMakeFiles/usd2g.dir/d2gDeserialize.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c: In function ‘d2giParseOrderItemFromResponse’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c:568:25: warning: variable ‘pCatalogItem’ set but not used [-Wunused-but-set-variable]
-  568 |         D2GCatalogItem *pCatalogItem = NULL;
-      |                         ^~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c: In function ‘d2giParseLoadCatalogItemsFromResponse’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDeserialize.c:1206:58: warning: argument to ‘sizeof’ in ‘memset’ call is the same pointer type ‘D2GCatalogItemList *’ as the destination; expected ‘D2GCatalogItemList’ or an explicit length [-Wsizeof-pointer-memaccess]
- 1206 |         memset(getAllItemsResponse->mItemList, 0, sizeof(D2GCatalogItemList *));
-      |                                                          ^~~~~~~~~~~~~~~~~~
-[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gDownloads.c.o -MF CMakeFiles/usd2g.dir/d2gDownloads.c.o.d -o CMakeFiles/usd2g.dir/d2gDownloads.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gDownloads.c
-[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gMain.c.o -MF CMakeFiles/usd2g.dir/d2gMain.c.o.d -o CMakeFiles/usd2g.dir/d2gMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c: In function ‘d2gCreateCatalog’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:251:55: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  251 |                 d2gCatalog->mAccessToken = goawstrdup(accessToken);
-      |                                                       ^~~~~~~~~~~
-      |                                                       |
-      |                                                       short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsCommon.h:40,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/ghttp.h:16,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/ghttpMain.h:15,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/ghttpSoap.h:13,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/Direct2Game.h:11,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:12:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:251:42: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  251 |                 d2gCatalog->mAccessToken = goawstrdup(accessToken);
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:252:55: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
-  252 |                 d2gCatalog->mRegion      = goawstrdup(region);
-      |                                                       ^~~~~~
-      |                                                       |
-      |                                                       short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:252:42: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
-  252 |                 d2gCatalog->mRegion      = goawstrdup(region);
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c: In function ‘d2gCloneOrderTotal’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1421:84: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1421 |         tempOrderTotal->mOrder.mRootOrderGuid = goawstrdup(sourceOrderTotal->mOrder.mRootOrderGuid);
-      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
-      |                                                                                    |
-      |                                                                                    short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1421:47: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1421 |         tempOrderTotal->mOrder.mRootOrderGuid = goawstrdup(sourceOrderTotal->mOrder.mRootOrderGuid);
-      |                                               ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1422:79: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1422 |         tempOrderTotal->mOrder.mSubTotal = goawstrdup(sourceOrderTotal->mOrder.mSubTotal);
-      |                                                       ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
-      |                                                                               |
-      |                                                                               short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1422:42: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1422 |         tempOrderTotal->mOrder.mSubTotal = goawstrdup(sourceOrderTotal->mOrder.mSubTotal);
-      |                                          ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1423:76: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1423 |         tempOrderTotal->mOrder.mTax   = goawstrdup(sourceOrderTotal->mOrder.mTax);
-      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                            |
-      |                                                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1423:39: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1423 |         tempOrderTotal->mOrder.mTax   = goawstrdup(sourceOrderTotal->mOrder.mTax);
-      |                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1424:76: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1424 |         tempOrderTotal->mOrder.mTotal = goawstrdup(sourceOrderTotal->mOrder.mTotal);
-      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                            |
-      |                                                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1424:39: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1424 |         tempOrderTotal->mOrder.mTotal = goawstrdup(sourceOrderTotal->mOrder.mTotal);
-      |                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1426:102: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1426 |         tempOrderTotal->mOrder.mValidation.mMessage = goawstrdup(sourceOrderTotal->mOrder.mValidation.mMessage);
-      |                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
-      |                                                                                                      |
-      |                                                                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1426:53: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1426 |         tempOrderTotal->mOrder.mValidation.mMessage = goawstrdup(sourceOrderTotal->mOrder.mValidation.mMessage);
-      |                                                     ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1428:101: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1428 |         tempOrderTotal->mOrder.mGeoInfo.mCultureCode  = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCultureCode);
-      |                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-      |                                                                                                     |
-      |                                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1428:55: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1428 |         tempOrderTotal->mOrder.mGeoInfo.mCultureCode  = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCultureCode);
-      |                                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1429:101: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1429 |         tempOrderTotal->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
-      |                                                                                                     |
-      |                                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1429:55: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1429 |         tempOrderTotal->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderTotal->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c: In function ‘d2gCloneOrderPurchase’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1528:88: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1528 |         anOrderPurchase->mOrder.mRootOrderGuid = goawstrdup(sourceOrderPurchase->mOrder.mRootOrderGuid);
-      |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
-      |                                                                                        |
-      |                                                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1528:48: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1528 |         anOrderPurchase->mOrder.mRootOrderGuid = goawstrdup(sourceOrderPurchase->mOrder.mRootOrderGuid);
-      |                                                ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1529:83: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1529 |         anOrderPurchase->mOrder.mSubTotal = goawstrdup(sourceOrderPurchase->mOrder.mSubTotal);
-      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
-      |                                                                                   |
-      |                                                                                   short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1529:43: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1529 |         anOrderPurchase->mOrder.mSubTotal = goawstrdup(sourceOrderPurchase->mOrder.mSubTotal);
-      |                                           ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1530:81: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1530 |         anOrderPurchase->mOrder.mTax    = goawstrdup(sourceOrderPurchase->mOrder.mTax);
-      |                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                 |
-      |                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1530:41: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1530 |         anOrderPurchase->mOrder.mTax    = goawstrdup(sourceOrderPurchase->mOrder.mTax);
-      |                                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1531:81: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1531 |         anOrderPurchase->mOrder.mTotal  = goawstrdup(sourceOrderPurchase->mOrder.mTotal);
-      |                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                                 |
-      |                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1531:41: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1531 |         anOrderPurchase->mOrder.mTotal  = goawstrdup(sourceOrderPurchase->mOrder.mTotal);
-      |                                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1533:100: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1533 |     anOrderPurchase->mOrder.mGeoInfo.mCultureCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCultureCode);
-      |                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-      |                                                                                                    |
-      |                                                                                                    short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1533:51: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1533 |     anOrderPurchase->mOrder.mGeoInfo.mCultureCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCultureCode);
-      |                                                   ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1534:101: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1534 |     anOrderPurchase->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
-      |                                                                                                     |
-      |                                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1534:52: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1534 |     anOrderPurchase->mOrder.mGeoInfo.mCurrencyCode = goawstrdup(sourceOrderPurchase->mOrder.mGeoInfo.mCurrencyCode);
-      |                                                    ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1537:106: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1537 |         anOrderPurchase->mOrder.mValidation.mMessage = goawstrdup(sourceOrderPurchase->mOrder.mValidation.mMessage);
-      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
-      |                                                                                                          |
-      |                                                                                                          short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1537:54: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1537 |         anOrderPurchase->mOrder.mValidation.mMessage = goawstrdup(sourceOrderPurchase->mOrder.mValidation.mMessage);
-      |                                                      ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c: In function ‘d2gGetExtraItemInfoKeyValueByKeyName’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1969:28: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1969 |                 if (wcscmp(keyI, extraInfoKey) == 0 && valueI != NULL)
-      |                            ^~~~
-      |                            |
-      |                            const short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:87:
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1969:34: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1969 |                 if (wcscmp(keyI, extraInfoKey) == 0 && valueI != NULL)
-      |                                  ^~~~~~~~~~~~
-      |                                  |
-      |                                  const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1971:54: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1971 |                         *extraInfoValue = goawstrdup(valueI);
-      |                                                      ^~~~~~
-      |                                                      |
-      |                                                      const short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../ghttp/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:1971:41: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1971 |                         *extraInfoValue = goawstrdup(valueI);
-      |                                         ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c: In function ‘d2gFilterCatalogItemListByKeyName’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:2033:92: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2033 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0)
-      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                            |
-      |                                                                                            short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:2033:99: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2033 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0)
-      |                                                                                                   ^~~~~~~~~~~~
-      |                                                                                                   |
-      |                                                                                                   const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c: In function ‘d2gFilterCatalogItemListByKeyNameValue’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:2141:92: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2141 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0 &&
-      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                                            |
-      |                                                                                            short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:2141:99: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2141 |                                 if (wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mKey, extraInfoKey) == 0 &&
-      |                                                                                                   ^~~~~~~~~~~~
-      |                                                                                                   |
-      |                                                                                                   const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:2142:96: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2142 |                                         wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mValue, extraInfoValue) == 0)
-      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                                                |
-      |                                                                                                short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gMain.c:2142:105: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 2142 |                                         wcscmp(anItem->mExtraItemInfoList.mExtraInfoElements[j].mValue, extraInfoValue) == 0)
-      |                                                                                                         ^~~~~~~~~~~~~~
-      |                                                                                                         |
-      |                                                                                                         const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-[ 63%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gServices.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gServices.c.o -MF CMakeFiles/usd2g.dir/d2gServices.c.o.d -o CMakeFiles/usd2g.dir/d2gServices.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gServices.c
-[ 64%] Building C object lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cc -DGHTTP_EXTENDEDERROR -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS  -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/d2gUtil.c.o -MF CMakeFiles/usd2g.dir/d2gUtil.c.o.d -o CMakeFiles/usd2g.dir/d2gUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giCompareWFloat’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:740:44: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  740 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) <= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                            ^~~~~~~~~~~~~~~~~~~~
-      |                                            |
-      |                                            short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsCommon.h:43,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsResultCodes.h:9,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:11:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:740:88: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  740 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) <= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                                                                        ^~~~~~~~~~~~~~~~~~~
-      |                                                                                        |
-      |                                                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:744:44: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  744 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) >= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                            ^~~~~~~~~~~~~~~~~~~~
-      |                                            |
-      |                                            short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:744:88: warning: passing argument 1 of ‘gsiWStringToDouble’ from incompatible pointer type [-Wincompatible-pointer-types]
-  744 |                 return (gsiWStringToDouble(*(UCS2String *) ptrA) >= gsiWStringToDouble(*(UCS2String *)ptrB));
-      |                                                                                        ^~~~~~~~~~~~~~~~~~~
-      |                                                                                        |
-      |                                                                                        short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatformUtil.h:168:42: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  168 | double gsiWStringToDouble(const wchar_t *inputString);
-      |                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giCompareWStr’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:758:32: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  758 |                 return (wcscmp(*(UCS2String *)ptrA, *(UCS2String *) ptrB) <= 0);
-      |                                ^~~~~~~~~~~~~~~~~~~
-      |                                |
-      |                                short unsigned int *
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:87,
-                 from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsCommon.h:40:
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:758:53: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  758 |                 return (wcscmp(*(UCS2String *)ptrA, *(UCS2String *) ptrB) <= 0);
-      |                                                     ^~~~~~~~~~~~~~~~~~~~
-      |                                                     |
-      |                                                     short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:762:32: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  762 |                 return (wcscmp(*(UCS2String *)ptrA,*(UCS2String *) ptrB) >= 0);
-      |                                ^~~~~~~~~~~~~~~~~~~
-      |                                |
-      |                                short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:762:52: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
-  762 |                 return (wcscmp(*(UCS2String *)ptrA,*(UCS2String *) ptrB) >= 0);
-      |                                                    ^~~~~~~~~~~~~~~~~~~~
-      |                                                    |
-      |                                                    short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giFindOrAddCategory’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1305:32: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1305 |         int cmpResult = wcscmp(newCategory,currentCategory);
-      |                                ^~~~~~~~~~~
-      |                                |
-      |                                short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1305:44: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1305 |         int cmpResult = wcscmp(newCategory,currentCategory);
-      |                                            ^~~~~~~~~~~~~~~
-      |                                            |
-      |                                            short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giCloneOrderItem’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1472:75: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1472 |     dstOrderItem->mItem.mExternalItemCode = goawstrdup(srcOrderItem->mItem.mExternalItemCode);
-      |                                                        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
-      |                                                                           |
-      |                                                                           short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1472:43: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1472 |     dstOrderItem->mItem.mExternalItemCode = goawstrdup(srcOrderItem->mItem.mExternalItemCode);
-      |                                           ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1473:65: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1473 |     dstOrderItem->mItem.mName   = goawstrdup(srcOrderItem->mItem.mName);
-      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~~
-      |                                                                 |
-      |                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1473:33: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1473 |     dstOrderItem->mItem.mName   = goawstrdup(srcOrderItem->mItem.mName);
-      |                                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1474:65: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1474 |     dstOrderItem->mItem.mPrice  = goawstrdup(srcOrderItem->mItem.mPrice);
-      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                 |
-      |                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1474:33: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1474 |     dstOrderItem->mItem.mPrice  = goawstrdup(srcOrderItem->mItem.mPrice);
-      |                                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1475:65: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1475 |     dstOrderItem->mItem.mTax    = goawstrdup(srcOrderItem->mItem.mTax);
-      |                                              ~~~~~~~~~~~~~~~~~~~^~~~~
-      |                                                                 |
-      |                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1475:33: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1475 |     dstOrderItem->mItem.mTax    = goawstrdup(srcOrderItem->mItem.mTax);
-      |                                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1478:78: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1478 |     dstOrderItem->mValidation.mMessage = goawstrdup(srcOrderItem->mValidation.mMessage);
-      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
-      |                                                                              |
-      |                                                                              short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1478:40: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1478 |     dstOrderItem->mValidation.mMessage = goawstrdup(srcOrderItem->mValidation.mMessage);
-      |                                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1481:77: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1481 |     dstOrderItem->mItemTotal.mSubTotal = goawstrdup(srcOrderItem->mItemTotal.mSubTotal);
-      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
-      |                                                                             |
-      |                                                                             short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1481:40: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1481 |     dstOrderItem->mItemTotal.mSubTotal = goawstrdup(srcOrderItem->mItemTotal.mSubTotal);
-      |                                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1482:77: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1482 |     dstOrderItem->mItemTotal.mTotal    = goawstrdup(srcOrderItem->mItemTotal.mTotal);
-      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
-      |                                                                             |
-      |                                                                             short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1482:40: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1482 |     dstOrderItem->mItemTotal.mTotal    = goawstrdup(srcOrderItem->mItemTotal.mTotal);
-      |                                        ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giCloneDownloadList’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1541:102: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1541 |         dstDownloadItemList->mDownloads[i].mAssetType = goawstrdup(srcDownloadItemList->mDownloads[i].mAssetType);
-      |                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
-      |                                                                                                      |
-      |                                                                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1541:55: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1541 |         dstDownloadItemList->mDownloads[i].mAssetType = goawstrdup(srcDownloadItemList->mDownloads[i].mAssetType);
-      |                                                       ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1559:97: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1559 |         dstDownloadItemList->mDownloads[i].mName = goawstrdup(srcDownloadItemList->mDownloads[i].mName);
-      |                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
-      |                                                                                                 |
-      |                                                                                                 short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1559:50: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1559 |         dstDownloadItemList->mDownloads[i].mName = goawstrdup(srcDownloadItemList->mDownloads[i].mName);
-      |                                                  ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giCloneLicenseList’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1621:85: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1621 |         dstLicenses->mLicenses[i].mLicenseKey = goawstrdup(srcLicenses->mLicenses[i].mLicenseKey);
-      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
-      |                                                                                     |
-      |                                                                                     short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1621:47: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1621 |         dstLicenses->mLicenses[i].mLicenseKey = goawstrdup(srcLicenses->mLicenses[i].mLicenseKey);
-      |                                               ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1639:86: warning: passing argument 1 of ‘goawstrdup’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1639 |         dstLicenses->mLicenses[i].mLicenseName = goawstrdup(srcLicenses->mLicenses[i].mLicenseName);
-      |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
-      |                                                                                      |
-      |                                                                                      short unsigned int *
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/../common/gsPlatform.h:562:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  562 | wchar_t* goawstrdup(const wchar_t*src);
-      |                     ~~~~~~~~~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1639:48: warning: assignment to ‘short unsigned int *’ from incompatible pointer type ‘wchar_t *’ {aka ‘int *’} [-Wincompatible-pointer-types]
- 1639 |         dstLicenses->mLicenses[i].mLicenseName = goawstrdup(srcLicenses->mLicenses[i].mLicenseName);
-      |                                                ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giLookUpExtraInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1847:24: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1847 |         if (wcscmp(info->mKey, key) == 0)
-      |                    ~~~~^~~~~~
-      |                        |
-      |                        short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1847:32: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1847 |         if (wcscmp(info->mKey, key) == 0)
-      |                                ^~~
-      |                                |
-      |                                const short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘const short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giGetExtraInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1892:24: warning: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1892 |         if (wcscmp(info->mKey, key) == 0)
-      |                    ~~~~^~~~~~
-      |                        |
-      |                        short unsigned int *
-/usr/include/wchar.h:130:35: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                    ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1892:32: warning: passing argument 2 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
- 1892 |         if (wcscmp(info->mKey, key) == 0)
-      |                                ^~~
-      |                                |
-      |                                short unsigned int *
-/usr/include/wchar.h:130:56: note: expected ‘const wchar_t *’ {aka ‘const int *’} but argument is of type ‘short unsigned int *’
-  130 | extern int wcscmp (const wchar_t *__s1, const wchar_t *__s2)
-      |                                         ~~~~~~~~~~~~~~~^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giFreeExtraInfo’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:1931:54: warning: argument to ‘sizeof’ in ‘memcmp’ call is the same pointer type ‘short unsigned int *’ as the first source; expected ‘short unsigned int’ or an explicit length [-Wsizeof-pointer-memaccess]
- 1931 |         if (memcmp(elem->mKey,extraInfo->mKey, sizeof(extraInfo->mKey)) == 0)
-      |                                                      ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giDeleteManifestRecord’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:2256:17: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
- 2256 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:2256:17: note: length computed here
- 2256 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c: In function ‘d2giUpdateManifestRecord’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:2158:17: warning: ‘__builtin___strncpy_chk’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
- 2158 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game/d2gUtil.c:2158:17: note: length computed here
- 2158 |                 strncpy(manifestFileNameTmp, manifestFileName, strlen(manifestFileName));
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 64%] Linking C static library libusd2g.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cmake -P CMakeFiles/usd2g.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game && /usr/bin/cmake -E cmake_link_script CMakeFiles/usd2g.dir/link.txt --verbose=1
-/usr/bin/ar qc libusd2g.a CMakeFiles/usd2g.dir/d2gDeserialize.c.o CMakeFiles/usd2g.dir/d2gDownloads.c.o CMakeFiles/usd2g.dir/d2gMain.c.o CMakeFiles/usd2g.dir/d2gServices.c.o CMakeFiles/usd2g.dir/d2gUtil.c.o
-/usr/bin/ranlib libusd2g.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 64%] Built target usd2g
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
@@ -3109,198 +203,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/add.c.o -MF CMakeFiles/gsm.dir/src/add.c.o.d -o CMakeFiles/gsm.dir/src/add.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/add.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/code.c.o -MF CMakeFiles/gsm.dir/src/code.c.o.d -o CMakeFiles/gsm.dir/src/code.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/code.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/code.c:9:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
-   12 | /*efine SIGHANDLER_T    int             /* signal handlers are void     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:13:41: warning: "/*" within comment [-Wcomment]
-   13 | /*efine HAS_SYSV_SIGNAL 1               /* sigs not blocked/reset?      */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:25:41: warning: "/*" within comment [-Wcomment]
-   25 | /*efine HAS__FSETMODE   1               /* _fsetmode -- set file mode   */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:28:41: warning: "/*" within comment [-Wcomment]
-   28 | /*efine HAS_STRINGS_H   1               /* /usr/include/strings.h       */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:35:41: warning: "/*" within comment [-Wcomment]
-   35 | /*efine HAS_UTIMES      1               /* use utimes() syscall instead */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
-   38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
-      |                                          
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/debug.c.o -MF CMakeFiles/gsm.dir/src/debug.c.o.d -o CMakeFiles/gsm.dir/src/debug.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/debug.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/decode.c.o -MF CMakeFiles/gsm.dir/src/decode.c.o.d -o CMakeFiles/gsm.dir/src/decode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/decode.c
-[ 64%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/long_term.c.o -MF CMakeFiles/gsm.dir/src/long_term.c.o.d -o CMakeFiles/gsm.dir/src/long_term.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/long_term.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/lpc.c.o -MF CMakeFiles/gsm.dir/src/lpc.c.o.d -o CMakeFiles/gsm.dir/src/lpc.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/lpc.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/preprocess.c.o -MF CMakeFiles/gsm.dir/src/preprocess.c.o.d -o CMakeFiles/gsm.dir/src/preprocess.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:12:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c: In function ‘Gsm_Preprocess’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:106:23: warning: operand of ‘?:’ changes signedness from ‘longword’ {aka ‘long int’} to ‘ulongword’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
-  106 |         : ((b) <= 0 ? (a) + (b)   \
-      |                       ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:96:26: note: in expansion of macro ‘GSM_L_ADD’
-   96 |                 L_z2   = GSM_L_ADD( L_temp, L_s2 );
-      |                          ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:103:22: warning: operand of ‘?:’ changes signedness from ‘long int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
-  103 |         ( (a) <  0 ? ( (b) >= 0 ? (a) + (b)     \
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  104 |                  : (utmp = (ulongword)-((a) + 1) + (ulongword)-((b) + 1)) \
-      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  105 |                    >= MAX_LONGWORD ? MIN_LONGWORD : -(longword)utmp-2 )   \
-      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:96:26: note: in expansion of macro ‘GSM_L_ADD’
-   96 |                 L_z2   = GSM_L_ADD( L_temp, L_s2 );
-      |                          ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:106:23: warning: operand of ‘?:’ changes signedness from ‘longword’ {aka ‘long int’} to ‘ulongword’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
-  106 |         : ((b) <= 0 ? (a) + (b)   \
-      |                       ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:100:26: note: in expansion of macro ‘GSM_L_ADD’
-  100 |                 L_temp = GSM_L_ADD( L_z2, 16384 );
-      |                          ^~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:103:22: warning: operand of ‘?:’ changes signedness from ‘long int’ to ‘long unsigned int’ due to unsignedness of other operand [-Wsign-compare]
-  103 |         ( (a) <  0 ? ( (b) >= 0 ? (a) + (b)     \
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  104 |                  : (utmp = (ulongword)-((a) + 1) + (ulongword)-((b) + 1)) \
-      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  105 |                    >= MAX_LONGWORD ? MIN_LONGWORD : -(longword)utmp-2 )   \
-      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/preprocess.c:100:26: note: in expansion of macro ‘GSM_L_ADD’
-  100 |                 L_temp = GSM_L_ADD( L_z2, 16384 );
-      |                          ^~~~~~~~~
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/rpe.c.o -MF CMakeFiles/gsm.dir/src/rpe.c.o.d -o CMakeFiles/gsm.dir/src/rpe.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c: In function ‘RPE_grid_positioning’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:405:31: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  405 |                 case 3: *ep++ = 0;
-      |                         ~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:406:17: note: here
-  406 |                 case 2:  do {
-      |                 ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:407:39: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  407 |                                 *ep++ = 0;
-      |                                 ~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:408:17: note: here
-  408 |                 case 1:         *ep++ = 0;
-      |                 ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:408:39: warning: this statement may fall through [-Wimplicit-fallthrough=]
-  408 |                 case 1:         *ep++ = 0;
-      |                                 ~~~~~~^~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/rpe.c:409:17: note: here
-  409 |                 case 0:         *ep++ = *xMp++;
-      |                 ^~~~
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_destroy.c.o -MF CMakeFiles/gsm.dir/src/gsm_destroy.c.o.d -o CMakeFiles/gsm.dir/src/gsm_destroy.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_destroy.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_destroy.c:10:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
-   12 | /*efine SIGHANDLER_T    int             /* signal handlers are void     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:13:41: warning: "/*" within comment [-Wcomment]
-   13 | /*efine HAS_SYSV_SIGNAL 1               /* sigs not blocked/reset?      */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:25:41: warning: "/*" within comment [-Wcomment]
-   25 | /*efine HAS__FSETMODE   1               /* _fsetmode -- set file mode   */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:28:41: warning: "/*" within comment [-Wcomment]
-   28 | /*efine HAS_STRINGS_H   1               /* /usr/include/strings.h       */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:35:41: warning: "/*" within comment [-Wcomment]
-   35 | /*efine HAS_UTIMES      1               /* use utimes() syscall instead */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
-   38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
-      |                                          
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_decode.c.o -MF CMakeFiles/gsm.dir/src/gsm_decode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_decode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_decode.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_encode.c.o -MF CMakeFiles/gsm.dir/src/gsm_encode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_encode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_encode.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_explode.c.o -MF CMakeFiles/gsm.dir/src/gsm_explode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_explode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_explode.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_implode.c.o -MF CMakeFiles/gsm.dir/src/gsm_implode.c.o.d -o CMakeFiles/gsm.dir/src/gsm_implode.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_implode.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_create.c.o -MF CMakeFiles/gsm.dir/src/gsm_create.c.o.d -o CMakeFiles/gsm.dir/src/gsm_create.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_create.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_create.c:9:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:12:41: warning: "/*" within comment [-Wcomment]
-   12 | /*efine SIGHANDLER_T    int             /* signal handlers are void     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:13:41: warning: "/*" within comment [-Wcomment]
-   13 | /*efine HAS_SYSV_SIGNAL 1               /* sigs not blocked/reset?      */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:25:41: warning: "/*" within comment [-Wcomment]
-   25 | /*efine HAS__FSETMODE   1               /* _fsetmode -- set file mode   */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:28:41: warning: "/*" within comment [-Wcomment]
-   28 | /*efine HAS_STRINGS_H   1               /* /usr/include/strings.h       */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:35:41: warning: "/*" within comment [-Wcomment]
-   35 | /*efine HAS_UTIMES      1               /* use utimes() syscall instead */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/config.h:38:41: warning: "/*" within comment [-Wcomment]
-   38 | /*efine HAS_UTIMEUSEC   1               /* microseconds in utimbuf?     */
-      |                                          
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_create.c:7:25: warning: ‘ident’ defined but not used [-Wunused-const-variable=]
-    7 | static char const       ident[] = "$Header: /tmp_amd/presto/export/kbs/jutta/src/gsm/RCS/gsm_create.c,v 1.4 1996/07/02 09:59:05 jutta Exp $";
-      |                         ^~~~~
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_print.c.o -MF CMakeFiles/gsm.dir/src/gsm_print.c.o.d -o CMakeFiles/gsm.dir/src/gsm_print.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_print.c
-[ 65%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/gsm_option.c.o -MF CMakeFiles/gsm.dir/src/gsm_option.c.o.d -o CMakeFiles/gsm.dir/src/gsm_option.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/gsm_option.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/short_term.c.o -MF CMakeFiles/gsm.dir/src/short_term.c.o.d -o CMakeFiles/gsm.dir/src/short_term.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:12:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c: In function ‘Decoding_of_the_coded_Log_Area_Ratios’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:63:9: note: in expansion of macro ‘STEP’
-   63 |         STEP(  -2560,  -16,  13107 );
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:66:9: note: in expansion of macro ‘STEP’
-   66 |         STEP(  -1792,   -8,  17476 );
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:67:9: note: in expansion of macro ‘STEP’
-   67 |         STEP(   -341,   -4,  31454 );
-      |         ^~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:56:46: warning: left shift of negative value [-Wshift-negative-value]
-   56 |                 temp1    = GSM_SUB( temp1, B << 1 );            \
-      |                                              ^~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc/private.h:122:45: note: in definition of macro ‘GSM_SUB’
-  122 |         ((ltmp = (longword)(a) - (longword)(b)) >= MAX_WORD \
-      |                                             ^
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/short_term.c:68:9: note: in expansion of macro ‘STEP’
-   68 |         STEP(  -1144,   -4,  29708 );
-      |         ^~~~
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DNeedFunctionPrototypes=1 -DRS_FORCE_IP=\"\" -DSASR -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/src/table.c.o -MF CMakeFiles/gsm.dir/src/table.c.o.d -o CMakeFiles/gsm.dir/src/table.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/src/table.c
-[ 66%] Linking C static library libgsm.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cmake -P CMakeFiles/gsm.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm && /usr/bin/cmake -E cmake_link_script CMakeFiles/gsm.dir/link.txt --verbose=1
-/usr/bin/ar qc libgsm.a CMakeFiles/gsm.dir/src/add.c.o CMakeFiles/gsm.dir/src/code.c.o CMakeFiles/gsm.dir/src/debug.c.o CMakeFiles/gsm.dir/src/decode.c.o CMakeFiles/gsm.dir/src/long_term.c.o CMakeFiles/gsm.dir/src/lpc.c.o CMakeFiles/gsm.dir/src/preprocess.c.o CMakeFiles/gsm.dir/src/rpe.c.o CMakeFiles/gsm.dir/src/gsm_destroy.c.o CMakeFiles/gsm.dir/src/gsm_decode.c.o CMakeFiles/gsm.dir/src/gsm_encode.c.o CMakeFiles/gsm.dir/src/gsm_explode.c.o CMakeFiles/gsm.dir/src/gsm_implode.c.o CMakeFiles/gsm.dir/src/gsm_create.c.o CMakeFiles/gsm.dir/src/gsm_print.c.o CMakeFiles/gsm.dir/src/gsm_option.c.o CMakeFiles/gsm.dir/src/short_term.c.o CMakeFiles/gsm.dir/src/table.c.o
-/usr/bin/ranlib libgsm.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 66%] Built target gsm
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
@@ -3309,39 +212,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvCodec.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvCodec.c.o -MF CMakeFiles/usvoice2.dir/gvCodec.c.o.d -o CMakeFiles/usvoice2.dir/gvCodec.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvCodec.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvCustomDevice.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvCustomDevice.c.o -MF CMakeFiles/usvoice2.dir/gvCustomDevice.c.o.d -o CMakeFiles/usvoice2.dir/gvCustomDevice.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvCustomDevice.c
-[ 66%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvDevice.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvDevice.c.o -MF CMakeFiles/usvoice2.dir/gvDevice.c.o.d -o CMakeFiles/usvoice2.dir/gvDevice.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvDevice.c
-[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvFrame.c.o -MF CMakeFiles/usvoice2.dir/gvFrame.c.o.d -o CMakeFiles/usvoice2.dir/gvFrame.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvFrame.c
-[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvMain.c.o -MF CMakeFiles/usvoice2.dir/gvMain.c.o.d -o CMakeFiles/usvoice2.dir/gvMain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvMain.c
-[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSource.c.o -MF CMakeFiles/usvoice2.dir/gvSource.c.o.d -o CMakeFiles/usvoice2.dir/gvSource.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSource.c
-[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvSpeex.c.o -MF CMakeFiles/usvoice2.dir/gvSpeex.c.o.d -o CMakeFiles/usvoice2.dir/gvSpeex.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c: In function ‘gviSpeexEncode’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c:144:13: warning: variable ‘bytesWritten’ set but not used [-Wunused-but-set-variable]
-  144 |         int bytesWritten;
-      |             ^~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c: In function ‘gviSpeexDecodeAdd’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c:164:13: warning: variable ‘rcode’ set but not used [-Wunused-but-set-variable]
-  164 |         int rcode;
-      |             ^~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c: In function ‘gviSpeexDecodeSet’:
-/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvSpeex.c:182:13: warning: variable ‘rcode’ set but not used [-Wunused-but-set-variable]
-  182 |         int rcode;
-      |             ^~~~~
-[ 67%] Building C object lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cc -DGSI_MEM_MANAGED -DGS_PEER -DGV_NO_DEFAULT_HARDWARE -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/gvUtil.c.o -MF CMakeFiles/usvoice2.dir/gvUtil.c.o.d -o CMakeFiles/usvoice2.dir/gvUtil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/gvUtil.c
-[ 67%] Linking C static library libusvoice2.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cmake -P CMakeFiles/usvoice2.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 && /usr/bin/cmake -E cmake_link_script CMakeFiles/usvoice2.dir/link.txt --verbose=1
-/usr/bin/ar qc libusvoice2.a CMakeFiles/usvoice2.dir/gvCodec.c.o CMakeFiles/usvoice2.dir/gvCustomDevice.c.o CMakeFiles/usvoice2.dir/gvDevice.c.o CMakeFiles/usvoice2.dir/gvFrame.c.o CMakeFiles/usvoice2.dir/gvMain.c.o CMakeFiles/usvoice2.dir/gvSource.c.o CMakeFiles/usvoice2.dir/gvSpeex.c.o CMakeFiles/usvoice2.dir/gvUtil.c.o
-/usr/bin/ranlib libusvoice2.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 67%] Built target usvoice2
 /usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
@@ -3350,13 +221,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 67%] Building C object lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll && /usr/bin/cc -DGHTTP_EXTENDEDERROR=1 -DGSI_MEM_MANAGED -DGS_PEER -DRS_FORCE_IP=\"\" -DUNISPY_USE_HTTPS -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk -I/workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm/inc -O3 -DNDEBUG -Wall -Wno-unused-parameter -Wextra -MD -MT lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/dllmain.c.o -MF CMakeFiles/UniSpySDK.dir/dllmain.c.o.d -o CMakeFiles/UniSpySDK.dir/dllmain.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll/dllmain.c
-[ 67%] Linking C static library libUniSpySDK.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll && /usr/bin/cmake -P CMakeFiles/UniSpySDK.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll && /usr/bin/cmake -E cmake_link_script CMakeFiles/UniSpySDK.dir/link.txt --verbose=1
-/usr/bin/ar qc libUniSpySDK.a CMakeFiles/UniSpySDK.dir/dllmain.c.o
-/usr/bin/ranlib libUniSpySDK.a
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 67%] Built target UniSpySDK
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
@@ -3365,332 +230,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 67%] Building C object lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/cleanup.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cc   -g -MD -MT lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/cleanup.c.o -MF CMakeFiles/milescleanup.dir/cleanup.c.o.d -o CMakeFiles/milescleanup.dir/cleanup.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/cleanup.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/cleanup.c:1:
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:138:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  138 | typedef unsigned long(__stdcall *AIL_file_open_callback)(const char *, unsigned long*);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:139:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  139 | typedef void(__stdcall *AIL_file_close_callback)(unsigned long);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:140:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  140 | typedef long(__stdcall *AIL_file_seek_callback)(unsigned long, long, unsigned long);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:141:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  141 | typedef unsigned long(__stdcall *AIL_file_read_callback)(unsigned long, void *, unsigned long);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:142:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  142 | typedef void(__stdcall *AIL_stream_callback)(HSTREAM);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:143:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  143 | typedef void(__stdcall *AIL_3dsample_callback)(H3DPOBJECT);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:144:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  144 | typedef void(__stdcall *AIL_sample_callback)(HSAMPLE);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:182:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  182 | IMPORTS long __stdcall AIL_3D_sample_volume(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:183:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  183 | IMPORTS void __stdcall AIL_set_3D_sample_volume(H3DSAMPLE sample, float volume);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:184:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  184 | IMPORTS void __stdcall AIL_end_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:185:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  185 | IMPORTS void __stdcall AIL_resume_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:186:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  186 | IMPORTS void __stdcall AIL_stop_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:187:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  187 | IMPORTS void __stdcall AIL_start_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:188:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  188 | IMPORTS unsigned int __stdcall AIL_3D_sample_loop_count(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:189:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  189 | IMPORTS void __stdcall AIL_set_3D_sample_offset(H3DSAMPLE sample, unsigned int offset);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:190:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  190 | IMPORTS int __stdcall AIL_3D_sample_length(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:191:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  191 | IMPORTS unsigned int __stdcall AIL_3D_sample_offset(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:192:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  192 | IMPORTS int __stdcall AIL_3D_sample_playback_rate(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:193:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  193 | IMPORTS void __stdcall AIL_set_3D_sample_playback_rate(H3DSAMPLE sample, int playback_rate);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:194:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  194 | IMPORTS int __stdcall AIL_set_3D_sample_file(H3DSAMPLE sample, const void* file_image);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:195:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  195 | IMPORTS HPROVIDER __stdcall AIL_set_sample_processor(HSAMPLE sample, SAMPLESTAGE pipeline_stage, HPROVIDER provider);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:196:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  196 | IMPORTS void __stdcall AIL_set_filter_sample_preference(HSAMPLE sample, const char* name, const void* val);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:197:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  197 | IMPORTS void __stdcall AIL_release_sample_handle(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:198:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  198 | IMPORTS void __stdcall AIL_close_3D_provider(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:199:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  199 | IMPORTS int __stdcall AIL_set_preference(unsigned int number, int value);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:200:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  200 | IMPORTS int __stdcall AIL_waveOutOpen(HDIGDRIVER* driver, LPHWAVEOUT* waveout, int id, LPWAVEFORMAT format);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:201:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  201 | IMPORTS void __stdcall AIL_waveOutClose(HDIGDRIVER driver);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:202:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  202 | IMPORTS void __stdcall AIL_set_3D_sample_loop_count(H3DSAMPLE sample, unsigned int count);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:203:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  203 | IMPORTS void __stdcall AIL_set_stream_playback_rate(HSTREAM stream, int rate);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:204:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  204 | IMPORTS int __stdcall AIL_stream_playback_rate(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:205:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  205 | IMPORTS void __stdcall AIL_stream_ms_position(HSTREAM sample, S32* total_milliseconds, S32* current_milliseconds);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:206:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  206 | IMPORTS void __stdcall AIL_set_stream_ms_position(HSTREAM stream, int pos);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:207:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  207 | IMPORTS int __stdcall AIL_stream_loop_count(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:208:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  208 | IMPORTS void __stdcall AIL_set_stream_loop_block(HSTREAM stream, int loop_start, int loop_end);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:209:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  209 | IMPORTS void __stdcall AIL_set_stream_loop_count(HSTREAM stream, int count);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:210:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  210 | IMPORTS int __stdcall AIL_stream_volume(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:211:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  211 | IMPORTS void __stdcall AIL_set_stream_volume(HSTREAM stream, int volume);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:212:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  212 | IMPORTS int __stdcall AIL_stream_pan(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:213:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  213 | IMPORTS void __stdcall AIL_set_stream_pan(HSTREAM stream, int pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:214:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  214 | IMPORTS void __stdcall AIL_close_stream(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:215:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  215 | IMPORTS void __stdcall AIL_pause_stream(HSTREAM stream, int onoff);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:216:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  216 | IMPORTS AIL_stream_callback __stdcall AIL_register_stream_callback(HSTREAM stream, AIL_stream_callback callback);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:217:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  217 | IMPORTS AIL_3dsample_callback __stdcall AIL_register_3D_EOS_callback(H3DSAMPLE sample, AIL_3dsample_callback EOS);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:218:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  218 | IMPORTS AIL_sample_callback __stdcall AIL_register_EOS_callback(HSAMPLE sample, AIL_sample_callback EOS);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:219:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  219 | IMPORTS void __stdcall AIL_start_stream(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:220:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  220 | IMPORTS HSTREAM __stdcall AIL_open_stream_by_sample(HDIGDRIVER driver, HSAMPLE sample, const char* file_name, int mem);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:221:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  221 | IMPORTS void __stdcall AIL_set_sample_playback_rate(HSAMPLE sample, int playback_rate);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:222:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  222 | IMPORTS int __stdcall AIL_sample_playback_rate(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:223:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  223 | IMPORTS void __stdcall AIL_sample_ms_position(HSAMPLE sample, long* total_ms, long* current_ms);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:224:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  224 | IMPORTS void __stdcall AIL_set_sample_ms_position(HSAMPLE sample, int pos);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:225:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  225 | IMPORTS int __stdcall AIL_sample_loop_count(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:226:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  226 | IMPORTS void __stdcall AIL_set_sample_loop_count(HSAMPLE sample, int count);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:227:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  227 | IMPORTS int __stdcall AIL_sample_volume(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:228:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  228 | IMPORTS void __stdcall AIL_set_sample_volume(HSAMPLE sample, int volume);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:229:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  229 | IMPORTS int __stdcall AIL_sample_pan(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:230:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  230 | IMPORTS void __stdcall AIL_set_sample_pan(HSAMPLE sample, int pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:231:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  231 | IMPORTS void __stdcall AIL_end_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:232:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  232 | IMPORTS void __stdcall AIL_resume_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:233:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  233 | IMPORTS void __stdcall AIL_stop_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:234:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  234 | IMPORTS void __stdcall AIL_start_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:235:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  235 | IMPORTS void __stdcall AIL_init_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:237:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  237 |     HSAMPLE sample, const char* file_name, const void* file_image, int file_size, int block);
-      |     ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:238:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  238 | IMPORTS void __stdcall AIL_set_3D_sample_effects_level(H3DSAMPLE sample, float effect_level);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:239:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  239 | IMPORTS void __stdcall AIL_set_3D_sample_distances(H3DSAMPLE sample, float max_dist, float min_dist);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:240:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  240 | IMPORTS void __stdcall AIL_set_3D_velocity_vector(H3DSAMPLE sample, float x, float y, float z);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:241:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  241 | IMPORTS void __stdcall AIL_set_3D_position(H3DPOBJECT obj, float X, float Y, float Z);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:243:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  243 |     H3DPOBJECT obj, float X_face, float Y_face, float Z_face, float X_up, float Y_up, float Z_up);
-      |     ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:244:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  244 | IMPORTS int __stdcall AIL_WAV_info(const void* data, AILSOUNDINFO* info);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:245:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  245 | IMPORTS void __stdcall AIL_stop_timer(HTIMER timer);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:246:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  246 | IMPORTS void __stdcall AIL_release_timer_handle(HTIMER timer);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:247:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  247 | IMPORTS void __stdcall AIL_shutdown(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:248:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  248 | IMPORTS int __stdcall AIL_enumerate_filters(HPROENUM* next, HPROVIDER* dest, char** name);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:250:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  250 |     AIL_file_seek_callback seekcb, AIL_file_read_callback readcb);
-      |     ^~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:251:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  251 | IMPORTS void __stdcall AIL_release_3D_sample_handle(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:252:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  252 | IMPORTS H3DSAMPLE __stdcall AIL_allocate_3D_sample_handle(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:253:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  253 | IMPORTS void __stdcall AIL_set_3D_user_data(H3DPOBJECT obj, unsigned int index, int value);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:254:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  254 | IMPORTS void __stdcall AIL_unlock(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:255:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  255 | IMPORTS void __stdcall AIL_lock(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:256:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  256 | IMPORTS void __stdcall AIL_set_3D_speaker_type(HPROVIDER lib, int speaker_type);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:257:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  257 | IMPORTS void __stdcall AIL_close_3D_listener(H3DPOBJECT listener);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:258:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  258 | IMPORTS int __stdcall AIL_enumerate_3D_providers(HPROENUM* next, HPROVIDER* dest, char** name);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:259:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  259 | IMPORTS M3DRESULT __stdcall AIL_open_3D_provider(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:260:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  260 | IMPORTS char* __stdcall AIL_last_error(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:261:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  261 | IMPORTS H3DPOBJECT __stdcall AIL_open_3D_listener(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:262:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  262 | IMPORTS int __stdcall AIL_3D_user_data(H3DSAMPLE sample, unsigned int index);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:263:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  263 | IMPORTS int __stdcall AIL_sample_user_data(HSAMPLE sample, unsigned int index);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:264:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  264 | IMPORTS HSAMPLE __stdcall AIL_allocate_sample_handle(HDIGDRIVER dig);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:265:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  265 | IMPORTS void __stdcall AIL_set_sample_user_data(HSAMPLE sample, unsigned int index, int value);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:266:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  266 | IMPORTS int __stdcall AIL_decompress_ADPCM(const AILSOUNDINFO *info, void **outdata, unsigned long *outsize);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:267:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  267 | IMPORTS void __stdcall AIL_get_DirectSound_info(HSAMPLE sample, AILLPDIRECTSOUND *lplpDS, AILLPDIRECTSOUNDBUFFER *lplpDSB);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:268:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  268 | IMPORTS void __stdcall AIL_mem_free_lock(void *ptr);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:269:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  269 | IMPORTS HSTREAM __stdcall AIL_open_stream(HDIGDRIVER dig, const char *filename, int stream_mem);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:270:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  270 | IMPORTS int __stdcall AIL_startup(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:271:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  271 | IMPORTS void __stdcall AIL_quick_unload(HAUDIO audio);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:272:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  272 | IMPORTS HAUDIO __stdcall AIL_quick_load_and_play(const char *filename, unsigned int loop_count, int wait_request);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:273:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  273 | IMPORTS void __stdcall AIL_quick_set_volume(HAUDIO audio, float volume, float extravol);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:275:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  275 |     int use_digital, int use_MIDI, unsigned int output_rate, int output_bits, int output_channels);
-      |     ^~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:276:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  276 | IMPORTS void __stdcall AIL_quick_handles(HDIGDRIVER *pdig, HMDIDRIVER *pmdi, HDLSDEVICE *pdls);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:277:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  277 | IMPORTS void __stdcall AIL_sample_volume_pan(HSAMPLE sample, float *volume, float *pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:278:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  278 | IMPORTS void __stdcall AIL_set_3D_sample_occlusion(H3DSAMPLE sample, float occlusion);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:279:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  279 | IMPORTS char *__stdcall AIL_set_redist_directory(const char *dir);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:280:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  280 | IMPORTS int __stdcall AIL_set_sample_file(HSAMPLE sample, const void *file_image, int block);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:281:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  281 | IMPORTS void __stdcall AIL_set_sample_volume_pan(HSAMPLE sample, float volume, float pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:282:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  282 | IMPORTS void __stdcall AIL_set_stream_volume_pan(HSTREAM stream, float volume, float pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:283:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  283 | IMPORTS void __stdcall AIL_stream_volume_pan(HSTREAM stream, float *volume, float *pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:284:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  284 | IMPORTS unsigned long __stdcall AIL_get_timer_highest_delay(void);
-      | ^~~~~~~
-[ 67%] Linking C static library libmilescleanup.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cmake -P CMakeFiles/milescleanup.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cmake -E cmake_link_script CMakeFiles/milescleanup.dir/link.txt --verbose=1
-/usr/bin/ar qc libmilescleanup.a CMakeFiles/milescleanup.dir/cleanup.c.o
-/usr/bin/ranlib libmilescleanup.a
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 67%] Built target milescleanup
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
@@ -3699,628 +239,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 67%] Building C object lib/miles_sdk_stub/CMakeFiles/milesstub.dir/miles.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cc -DBUILD_STUBS -Dmilesstub_EXPORTS -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -g -fPIC -MD -MT lib/miles_sdk_stub/CMakeFiles/milesstub.dir/miles.c.o -MF CMakeFiles/milesstub.dir/miles.c.o.d -o CMakeFiles/milesstub.dir/miles.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c
-In file included from /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:16:
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:138:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  138 | typedef unsigned long(__stdcall *AIL_file_open_callback)(const char *, unsigned long*);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:139:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  139 | typedef void(__stdcall *AIL_file_close_callback)(unsigned long);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:140:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  140 | typedef long(__stdcall *AIL_file_seek_callback)(unsigned long, long, unsigned long);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:141:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  141 | typedef unsigned long(__stdcall *AIL_file_read_callback)(unsigned long, void *, unsigned long);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:142:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  142 | typedef void(__stdcall *AIL_stream_callback)(HSTREAM);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:143:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  143 | typedef void(__stdcall *AIL_3dsample_callback)(H3DPOBJECT);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:144:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  144 | typedef void(__stdcall *AIL_sample_callback)(HSAMPLE);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:182:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  182 | IMPORTS long __stdcall AIL_3D_sample_volume(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:183:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  183 | IMPORTS void __stdcall AIL_set_3D_sample_volume(H3DSAMPLE sample, float volume);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:184:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  184 | IMPORTS void __stdcall AIL_end_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:185:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  185 | IMPORTS void __stdcall AIL_resume_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:186:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  186 | IMPORTS void __stdcall AIL_stop_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:187:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  187 | IMPORTS void __stdcall AIL_start_3D_sample(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:188:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  188 | IMPORTS unsigned int __stdcall AIL_3D_sample_loop_count(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:189:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  189 | IMPORTS void __stdcall AIL_set_3D_sample_offset(H3DSAMPLE sample, unsigned int offset);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:190:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  190 | IMPORTS int __stdcall AIL_3D_sample_length(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:191:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  191 | IMPORTS unsigned int __stdcall AIL_3D_sample_offset(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:192:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  192 | IMPORTS int __stdcall AIL_3D_sample_playback_rate(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:193:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  193 | IMPORTS void __stdcall AIL_set_3D_sample_playback_rate(H3DSAMPLE sample, int playback_rate);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:194:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  194 | IMPORTS int __stdcall AIL_set_3D_sample_file(H3DSAMPLE sample, const void* file_image);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:195:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  195 | IMPORTS HPROVIDER __stdcall AIL_set_sample_processor(HSAMPLE sample, SAMPLESTAGE pipeline_stage, HPROVIDER provider);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:196:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  196 | IMPORTS void __stdcall AIL_set_filter_sample_preference(HSAMPLE sample, const char* name, const void* val);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:197:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  197 | IMPORTS void __stdcall AIL_release_sample_handle(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:198:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  198 | IMPORTS void __stdcall AIL_close_3D_provider(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:199:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  199 | IMPORTS int __stdcall AIL_set_preference(unsigned int number, int value);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:200:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  200 | IMPORTS int __stdcall AIL_waveOutOpen(HDIGDRIVER* driver, LPHWAVEOUT* waveout, int id, LPWAVEFORMAT format);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:201:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  201 | IMPORTS void __stdcall AIL_waveOutClose(HDIGDRIVER driver);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:202:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  202 | IMPORTS void __stdcall AIL_set_3D_sample_loop_count(H3DSAMPLE sample, unsigned int count);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:203:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  203 | IMPORTS void __stdcall AIL_set_stream_playback_rate(HSTREAM stream, int rate);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:204:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  204 | IMPORTS int __stdcall AIL_stream_playback_rate(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:205:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  205 | IMPORTS void __stdcall AIL_stream_ms_position(HSTREAM sample, S32* total_milliseconds, S32* current_milliseconds);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:206:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  206 | IMPORTS void __stdcall AIL_set_stream_ms_position(HSTREAM stream, int pos);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:207:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  207 | IMPORTS int __stdcall AIL_stream_loop_count(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:208:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  208 | IMPORTS void __stdcall AIL_set_stream_loop_block(HSTREAM stream, int loop_start, int loop_end);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:209:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  209 | IMPORTS void __stdcall AIL_set_stream_loop_count(HSTREAM stream, int count);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:210:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  210 | IMPORTS int __stdcall AIL_stream_volume(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:211:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  211 | IMPORTS void __stdcall AIL_set_stream_volume(HSTREAM stream, int volume);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:212:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  212 | IMPORTS int __stdcall AIL_stream_pan(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:213:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  213 | IMPORTS void __stdcall AIL_set_stream_pan(HSTREAM stream, int pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:214:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  214 | IMPORTS void __stdcall AIL_close_stream(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:215:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  215 | IMPORTS void __stdcall AIL_pause_stream(HSTREAM stream, int onoff);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:216:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  216 | IMPORTS AIL_stream_callback __stdcall AIL_register_stream_callback(HSTREAM stream, AIL_stream_callback callback);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:217:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  217 | IMPORTS AIL_3dsample_callback __stdcall AIL_register_3D_EOS_callback(H3DSAMPLE sample, AIL_3dsample_callback EOS);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:218:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  218 | IMPORTS AIL_sample_callback __stdcall AIL_register_EOS_callback(HSAMPLE sample, AIL_sample_callback EOS);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:219:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  219 | IMPORTS void __stdcall AIL_start_stream(HSTREAM stream);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:220:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  220 | IMPORTS HSTREAM __stdcall AIL_open_stream_by_sample(HDIGDRIVER driver, HSAMPLE sample, const char* file_name, int mem);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:221:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  221 | IMPORTS void __stdcall AIL_set_sample_playback_rate(HSAMPLE sample, int playback_rate);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:222:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  222 | IMPORTS int __stdcall AIL_sample_playback_rate(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:223:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  223 | IMPORTS void __stdcall AIL_sample_ms_position(HSAMPLE sample, long* total_ms, long* current_ms);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:224:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  224 | IMPORTS void __stdcall AIL_set_sample_ms_position(HSAMPLE sample, int pos);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:225:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  225 | IMPORTS int __stdcall AIL_sample_loop_count(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:226:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  226 | IMPORTS void __stdcall AIL_set_sample_loop_count(HSAMPLE sample, int count);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:227:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  227 | IMPORTS int __stdcall AIL_sample_volume(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:228:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  228 | IMPORTS void __stdcall AIL_set_sample_volume(HSAMPLE sample, int volume);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:229:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  229 | IMPORTS int __stdcall AIL_sample_pan(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:230:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  230 | IMPORTS void __stdcall AIL_set_sample_pan(HSAMPLE sample, int pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:231:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  231 | IMPORTS void __stdcall AIL_end_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:232:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  232 | IMPORTS void __stdcall AIL_resume_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:233:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  233 | IMPORTS void __stdcall AIL_stop_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:234:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  234 | IMPORTS void __stdcall AIL_start_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:235:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  235 | IMPORTS void __stdcall AIL_init_sample(HSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:237:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  237 |     HSAMPLE sample, const char* file_name, const void* file_image, int file_size, int block);
-      |     ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:238:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  238 | IMPORTS void __stdcall AIL_set_3D_sample_effects_level(H3DSAMPLE sample, float effect_level);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:239:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  239 | IMPORTS void __stdcall AIL_set_3D_sample_distances(H3DSAMPLE sample, float max_dist, float min_dist);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:240:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  240 | IMPORTS void __stdcall AIL_set_3D_velocity_vector(H3DSAMPLE sample, float x, float y, float z);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:241:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  241 | IMPORTS void __stdcall AIL_set_3D_position(H3DPOBJECT obj, float X, float Y, float Z);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:243:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  243 |     H3DPOBJECT obj, float X_face, float Y_face, float Z_face, float X_up, float Y_up, float Z_up);
-      |     ^~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:244:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  244 | IMPORTS int __stdcall AIL_WAV_info(const void* data, AILSOUNDINFO* info);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:245:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  245 | IMPORTS void __stdcall AIL_stop_timer(HTIMER timer);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:246:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  246 | IMPORTS void __stdcall AIL_release_timer_handle(HTIMER timer);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:247:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  247 | IMPORTS void __stdcall AIL_shutdown(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:248:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  248 | IMPORTS int __stdcall AIL_enumerate_filters(HPROENUM* next, HPROVIDER* dest, char** name);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:250:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  250 |     AIL_file_seek_callback seekcb, AIL_file_read_callback readcb);
-      |     ^~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:251:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  251 | IMPORTS void __stdcall AIL_release_3D_sample_handle(H3DSAMPLE sample);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:252:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  252 | IMPORTS H3DSAMPLE __stdcall AIL_allocate_3D_sample_handle(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:253:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  253 | IMPORTS void __stdcall AIL_set_3D_user_data(H3DPOBJECT obj, unsigned int index, int value);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:254:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  254 | IMPORTS void __stdcall AIL_unlock(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:255:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  255 | IMPORTS void __stdcall AIL_lock(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:256:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  256 | IMPORTS void __stdcall AIL_set_3D_speaker_type(HPROVIDER lib, int speaker_type);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:257:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  257 | IMPORTS void __stdcall AIL_close_3D_listener(H3DPOBJECT listener);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:258:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  258 | IMPORTS int __stdcall AIL_enumerate_3D_providers(HPROENUM* next, HPROVIDER* dest, char** name);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:259:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  259 | IMPORTS M3DRESULT __stdcall AIL_open_3D_provider(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:260:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  260 | IMPORTS char* __stdcall AIL_last_error(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:261:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  261 | IMPORTS H3DPOBJECT __stdcall AIL_open_3D_listener(HPROVIDER lib);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:262:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  262 | IMPORTS int __stdcall AIL_3D_user_data(H3DSAMPLE sample, unsigned int index);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:263:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  263 | IMPORTS int __stdcall AIL_sample_user_data(HSAMPLE sample, unsigned int index);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:264:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  264 | IMPORTS HSAMPLE __stdcall AIL_allocate_sample_handle(HDIGDRIVER dig);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:265:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  265 | IMPORTS void __stdcall AIL_set_sample_user_data(HSAMPLE sample, unsigned int index, int value);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:266:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  266 | IMPORTS int __stdcall AIL_decompress_ADPCM(const AILSOUNDINFO *info, void **outdata, unsigned long *outsize);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:267:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  267 | IMPORTS void __stdcall AIL_get_DirectSound_info(HSAMPLE sample, AILLPDIRECTSOUND *lplpDS, AILLPDIRECTSOUNDBUFFER *lplpDSB);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:268:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  268 | IMPORTS void __stdcall AIL_mem_free_lock(void *ptr);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:269:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  269 | IMPORTS HSTREAM __stdcall AIL_open_stream(HDIGDRIVER dig, const char *filename, int stream_mem);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:270:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  270 | IMPORTS int __stdcall AIL_startup(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:271:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  271 | IMPORTS void __stdcall AIL_quick_unload(HAUDIO audio);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:272:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  272 | IMPORTS HAUDIO __stdcall AIL_quick_load_and_play(const char *filename, unsigned int loop_count, int wait_request);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:273:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  273 | IMPORTS void __stdcall AIL_quick_set_volume(HAUDIO audio, float volume, float extravol);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:275:5: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  275 |     int use_digital, int use_MIDI, unsigned int output_rate, int output_bits, int output_channels);
-      |     ^~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:276:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  276 | IMPORTS void __stdcall AIL_quick_handles(HDIGDRIVER *pdig, HMDIDRIVER *pmdi, HDLSDEVICE *pdls);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:277:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  277 | IMPORTS void __stdcall AIL_sample_volume_pan(HSAMPLE sample, float *volume, float *pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:278:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  278 | IMPORTS void __stdcall AIL_set_3D_sample_occlusion(H3DSAMPLE sample, float occlusion);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:279:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  279 | IMPORTS char *__stdcall AIL_set_redist_directory(const char *dir);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:280:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  280 | IMPORTS int __stdcall AIL_set_sample_file(HSAMPLE sample, const void *file_image, int block);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:281:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  281 | IMPORTS void __stdcall AIL_set_sample_volume_pan(HSAMPLE sample, float volume, float pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:282:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  282 | IMPORTS void __stdcall AIL_set_stream_volume_pan(HSTREAM stream, float volume, float pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:283:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  283 | IMPORTS void __stdcall AIL_stream_volume_pan(HSTREAM stream, float *volume, float *pan);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss/mss.h:284:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  284 | IMPORTS unsigned long __stdcall AIL_get_timer_highest_delay(void);
-      | ^~~~~~~
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:55:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   55 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:62:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   62 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:70:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   70 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:75:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   75 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:80:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   80 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:85:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   85 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:90:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   90 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:95:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-   95 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:100:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  100 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:107:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  107 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:114:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  114 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:119:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  119 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:124:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  124 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:129:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  129 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:134:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  134 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:138:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  138 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:146:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  146 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:151:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  151 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:160:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  160 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:167:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  167 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:172:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  172 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:177:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  177 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:185:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  185 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:193:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  193 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:205:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  205 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:213:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  213 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:220:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  220 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:224:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  224 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:232:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  232 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:239:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  239 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:247:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  247 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:254:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  254 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:262:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  262 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:270:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  270 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:278:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  278 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:283:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  283 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:288:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  288 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:293:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  293 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:300:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  300 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:305:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  305 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:313:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  313 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:321:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  321 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:333:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  333 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:341:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  341 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:348:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  348 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:356:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  356 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:363:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  363 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:371:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  371 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:378:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  378 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:386:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  386 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:393:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  393 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:400:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  400 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:407:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  407 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:414:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  414 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:420:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  420 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:432:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  432 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:439:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  439 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:447:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  447 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:454:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  454 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:462:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  462 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:470:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  470 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:505:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  505 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:509:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  509 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:513:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  513 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:519:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  519 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:525:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  525 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:529:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  529 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:534:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  534 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:540:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  540 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:545:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  545 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:550:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  550 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:555:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  555 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:560:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  560 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:565:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  565 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:577:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  577 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:583:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  583 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:588:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  588 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:594:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  594 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:599:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  599 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:606:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  606 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:617:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  617 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:624:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  624 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:644:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  644 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:648:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  648 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:653:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  653 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:668:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  668 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:676:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  676 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:691:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  691 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:700:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  700 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:706:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  706 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:713:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  713 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:721:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  721 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:725:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  725 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:730:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  730 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:735:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  735 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:745:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  745 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:755:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  755 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:763:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  763 | {
-      | ^
-/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/miles.c:771:1: warning: ‘stdcall’ attribute ignored [-Wattributes]
-  771 | {
-      | ^
-[ 67%] Linking C shared library libmss32.so
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cmake -E cmake_link_script CMakeFiles/milesstub.dir/link.txt --verbose=1
-/usr/bin/cc -fPIC -g -shared -Wl,-soname,libmss32.so.1.0 -o libmss32.so.1.0.0 CMakeFiles/milesstub.dir/miles.c.o  libmilescleanup.a ../libminiaudio.a 
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub && /usr/bin/cmake -E cmake_symlink_library libmss32.so.1.0.0 libmss32.so.1.0 libmss32.so
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 67%] Built target milesstub
 /usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
@@ -4329,41 +248,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 67%] Building C object lib/zlib/CMakeFiles/zlib.dir/adler32.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/adler32.c.o -MF CMakeFiles/zlib.dir/adler32.c.o.d -o CMakeFiles/zlib.dir/adler32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/adler32.c
-[ 67%] Building C object lib/zlib/CMakeFiles/zlib.dir/compress.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/compress.c.o -MF CMakeFiles/zlib.dir/compress.c.o.d -o CMakeFiles/zlib.dir/compress.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/compress.c
-[ 67%] Building C object lib/zlib/CMakeFiles/zlib.dir/crc32.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/crc32.c.o -MF CMakeFiles/zlib.dir/crc32.c.o.d -o CMakeFiles/zlib.dir/crc32.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/crc32.c
-[ 67%] Building C object lib/zlib/CMakeFiles/zlib.dir/gzio.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/gzio.c.o -MF CMakeFiles/zlib.dir/gzio.c.o.d -o CMakeFiles/zlib.dir/gzio.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/gzio.c
-[ 67%] Building C object lib/zlib/CMakeFiles/zlib.dir/uncompr.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/uncompr.c.o -MF CMakeFiles/zlib.dir/uncompr.c.o.d -o CMakeFiles/zlib.dir/uncompr.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/uncompr.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/deflate.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/deflate.c.o -MF CMakeFiles/zlib.dir/deflate.c.o.d -o CMakeFiles/zlib.dir/deflate.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/deflate.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/trees.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/trees.c.o -MF CMakeFiles/zlib.dir/trees.c.o.d -o CMakeFiles/zlib.dir/trees.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/trees.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/zutil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/zutil.c.o -MF CMakeFiles/zlib.dir/zutil.c.o.d -o CMakeFiles/zlib.dir/zutil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/zutil.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/infblock.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/infblock.c.o -MF CMakeFiles/zlib.dir/infblock.c.o.d -o CMakeFiles/zlib.dir/infblock.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/infblock.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/infcodes.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/infcodes.c.o -MF CMakeFiles/zlib.dir/infcodes.c.o.d -o CMakeFiles/zlib.dir/infcodes.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/infcodes.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/inftrees.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/inftrees.c.o -MF CMakeFiles/zlib.dir/inftrees.c.o.d -o CMakeFiles/zlib.dir/inftrees.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/inftrees.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/infutil.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/infutil.c.o -MF CMakeFiles/zlib.dir/infutil.c.o.d -o CMakeFiles/zlib.dir/infutil.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/infutil.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/inflate.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/inflate.c.o -MF CMakeFiles/zlib.dir/inflate.c.o.d -o CMakeFiles/zlib.dir/inflate.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/inflate.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/inffast.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/inffast.c.o -MF CMakeFiles/zlib.dir/inffast.c.o.d -o CMakeFiles/zlib.dir/inffast.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/inffast.c
-[ 68%] Building C object lib/zlib/CMakeFiles/zlib.dir/maketree.c.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cc -DZ_PREFIX -I/workspace/CnC_Generals_Zero_Hour/lib/zlib -O3 -DNDEBUG -fPIC -MD -MT lib/zlib/CMakeFiles/zlib.dir/maketree.c.o -MF CMakeFiles/zlib.dir/maketree.c.o.d -o CMakeFiles/zlib.dir/maketree.c.o -c /workspace/CnC_Generals_Zero_Hour/lib/zlib/maketree.c
-[ 69%] Linking C static library libzlib.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cmake -P CMakeFiles/zlib.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/zlib && /usr/bin/cmake -E cmake_link_script CMakeFiles/zlib.dir/link.txt --verbose=1
-/usr/bin/ar qc libzlib.a CMakeFiles/zlib.dir/adler32.c.o CMakeFiles/zlib.dir/compress.c.o CMakeFiles/zlib.dir/crc32.c.o CMakeFiles/zlib.dir/gzio.c.o CMakeFiles/zlib.dir/uncompr.c.o CMakeFiles/zlib.dir/deflate.c.o CMakeFiles/zlib.dir/trees.c.o CMakeFiles/zlib.dir/zutil.c.o CMakeFiles/zlib.dir/infblock.c.o CMakeFiles/zlib.dir/infcodes.c.o CMakeFiles/zlib.dir/inftrees.c.o CMakeFiles/zlib.dir/infutil.c.o CMakeFiles/zlib.dir/inflate.c.o CMakeFiles/zlib.dir/inffast.c.o CMakeFiles/zlib.dir/maketree.c.o
-/usr/bin/ranlib libzlib.a
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 69%] Built target zlib
 /usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
@@ -4372,17 +257,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Building CXX object lib/liblzhl/CMakeFiles/lzhl.dir/src/huff.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/c++  -I/workspace/CnC_Generals_Zero_Hour/lib/liblzhl/include -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT lib/liblzhl/CMakeFiles/lzhl.dir/src/huff.cpp.o -MF CMakeFiles/lzhl.dir/src/huff.cpp.o.d -o CMakeFiles/lzhl.dir/src/huff.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/liblzhl/src/huff.cpp
-[ 69%] Building CXX object lib/liblzhl/CMakeFiles/lzhl.dir/src/lz.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/c++  -I/workspace/CnC_Generals_Zero_Hour/lib/liblzhl/include -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT lib/liblzhl/CMakeFiles/lzhl.dir/src/lz.cpp.o -MF CMakeFiles/lzhl.dir/src/lz.cpp.o.d -o CMakeFiles/lzhl.dir/src/lz.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/liblzhl/src/lz.cpp
-[ 69%] Building CXX object lib/liblzhl/CMakeFiles/lzhl.dir/src/lzhl.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/c++  -I/workspace/CnC_Generals_Zero_Hour/lib/liblzhl/include -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT lib/liblzhl/CMakeFiles/lzhl.dir/src/lzhl.cpp.o -MF CMakeFiles/lzhl.dir/src/lzhl.cpp.o.d -o CMakeFiles/lzhl.dir/src/lzhl.cpp.o -c /workspace/CnC_Generals_Zero_Hour/lib/liblzhl/src/lzhl.cpp
-[ 69%] Linking CXX static library liblzhl.a
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/cmake -P CMakeFiles/lzhl.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl && /usr/bin/cmake -E cmake_link_script CMakeFiles/lzhl.dir/link.txt --verbose=1
-/usr/bin/ar qc liblzhl.a CMakeFiles/lzhl.dir/src/huff.cpp.o CMakeFiles/lzhl.dir/src/lz.cpp.o CMakeFiles/lzhl.dir/src/lzhl.cpp.o
-/usr/bin/ranlib liblzhl.a
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 69%] Built target lzhl
 /usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
@@ -4391,13 +266,7 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 69%] Building CXX object src/CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o -MF CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o.d -o CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/lvgl_platform/lvgl_platform.cpp
-[ 70%] Linking CXX static library liblvgl_platform.a
-cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/cmake -P CMakeFiles/lvgl_platform.dir/cmake_clean_target.cmake
-cd /workspace/CnC_Generals_Zero_Hour/build/src && /usr/bin/cmake -E cmake_link_script CMakeFiles/lvgl_platform.dir/link.txt --verbose=1
-/usr/bin/ar qc liblvgl_platform.a CMakeFiles/lvgl_platform.dir/lvgl_platform/lvgl_platform.cpp.o
-/usr/bin/ranlib liblvgl_platform.a
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 [ 70%] Built target lvgl_platform
 /usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
@@ -4406,8 +275,8 @@ cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "U
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 /usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
 gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
-[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_local_file_system.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_local_file_system.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_local_file_system.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_local_file_system.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_local_file_system.cpp
 In file included from /usr/include/c++/13/backward/hash_map:60,
                  from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
                  from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
@@ -4415,32 +284,17 @@ In file included from /usr/include/c++/13/backward/hash_map:60,
                  from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
                  from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
                  from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/localfilesystem.h:34,
-                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp:2:
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/lvgl_device/common/lvgllocalfilesystem.h:3,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_local_file_system.cpp:1:
 /usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
    32 | #warning \
       |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h:57,
-                 from /workspace/CnC_Generals_Zero_Hour/include/common/file.h:3,
-                 from /workspace/CnC_Generals_Zero_Hour/include/common/local_file.h:3,
-                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file.cpp:1:
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:37:
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:748:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
   748 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
       |                                                                                                  ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h: In static member function ‘static void* File::operator new(size_t, FileMagicEnum)’:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:693:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  693 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h: In static member function ‘static void* File::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:706:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  706 |                 return 0; \
-      |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
-   84 |         MEMORY_POOL_GLUE_ABC(File)
-      |         ^~~~~~~~~~~~~~~~~~~~
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
   651 |                 return 0; \
@@ -4471,46 +325,1896 @@ In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/comm
 /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
    54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ramfile.h: In static member function ‘static void* RAMFile::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  651 |                 return 0; \
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h: In static member function ‘static void* File::operator new(size_t, FileMagicEnum)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:693:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  693 |                 return 0; \
       |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ramfile.h:77:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   77 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RAMFile, "RAMFile")
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/streamingarchivefile.h: In static member function ‘static void* StreamingArchiveFile::operator new(size_t)’:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
-  651 |                 return 0; \
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+   84 |         MEMORY_POOL_GLUE_ABC(File)
+      |         ^~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h: In static member function ‘static void* File::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:706:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  706 |                 return 0; \
       |                        ^
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
-  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/streamingarchivefile.h:77:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
-   77 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(StreamingArchiveFile, "StreamingArchiveFile")
-      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o
-cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file_system.cpp
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/file.h:84:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_ABC’
+   84 |         MEMORY_POOL_GLUE_ABC(File)
+      |         ^~~~~~~~~~~~~~~~~~~~
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_os_display.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_os_display.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_os_display.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_os_display.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_os_display.cpp
 In file included from /usr/include/c++/13/backward/hash_map:60,
                  from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
                  from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
                  from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
                  from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
                  from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefilesystem.h:55,
-                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/archivefile.h:36,
-                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file_system.cpp:2:
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_client/gametext.h:52,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_os_display.cpp:4:
 /usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
    32 | #warning \
       |  ^~~~~~~
-In file included from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/common/lvgl_big_file_system.cpp:5:
-/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gameaudio.h:51:10: fatal error: game_engine/common/audioEventInfo.h: No such file or directory
-   51 | #include "game_engine/common/audioEventInfo.h"
-      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:37:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:748:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  748 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
+      |                                                                                                  ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_keyboard.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_keyboard.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_keyboard.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_keyboard.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/game_client/lvgl_keyboard.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_client/keyboard.h:55,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/lvgl_device/game_client/lvglkeyboard.h:3,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/game_client/lvgl_keyboard.cpp:1:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:37:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:748:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  748 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
+      |                                                                                                  ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_mouse.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_mouse.cpp.o -MF CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_mouse.cpp.o.d -o CMakeFiles/gameenginedevice.dir/lvgl_device/game_client/lvgl_mouse.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/game_client/lvgl_mouse.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_client/mouse.h:56,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/lvgl_device/game_client/lvglmouse.h:6,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/lvgl_device/game_client/lvgl_mouse.cpp:1:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:37:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h: In static member function ‘static void* MemoryPoolObject::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:748:98: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  748 |         inline void *operator new(size_t s) { DEBUG_CRASH(("This should be impossible")); return 0; }
+      |                                                                                                  ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h: In static member function ‘static void* Bucket::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/namekeygenerator.h:62:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   62 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Bucket, "NameKeyBucketPool" );
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h: In static member function ‘static void* Overridable::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/overridable.h:44:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   44 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( Overridable, "Overridable"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h: In static member function ‘static void* ScienceInfo::operator new(size_t)’:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:651:24: warning: ‘operator new’ must not return NULL unless it is declared ‘throw()’ (or ‘-fcheck-new’ is in effect)
+  651 |                 return 0; \
+      |                        ^
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/gamememory.h:677:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITHOUT_GCMP’
+  677 |         MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/science.h:54:9: note: in expansion of macro ‘MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE’
+   54 |         MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( ScienceInfo, "ScienceInfo"  )
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+/workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:10: fatal error: w3d_device/common/W3DModuleFactory.h: No such file or directory
+   31 | #include "w3d_device/common/W3DModuleFactory.h"
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 compilation terminated.
-gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:93: src/game_engine_device/CMakeFiles/gameenginedevice.dir/lvgl_device/common/lvgl_big_file_system.cpp.o] Error 1
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake: *** [Makefile:94: all] Error 2
+/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
+/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
+/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
+/usr/bin/gmake  -f CMakeFiles/Makefile2 all
+gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 52%] Built target lvgl
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 53%] Built target miniaudio
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 54%] Built target usgt2
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 56%] Built target uscommon
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target ushttp
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target uswebservice
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target usbrigades
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uschat
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usnatneg
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usqr2
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uscdkey
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usgp
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usstats
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target uspinger
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 60%] Built target usserverbrowsing
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspeer
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspt
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussake
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussc
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 64%] Built target usd2g
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 66%] Built target gsm
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target usvoice2
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target UniSpySDK
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milescleanup
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milesstub
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target zlib
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target lzhl
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Built target lvgl_platform
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/W3DModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/w3dmodulefactory.h:39:10: fatal error: common/ModuleFactory.h: No such file or directory
+   39 | #include "common/ModuleFactory.h"
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake: *** [Makefile:94: all] Error 2
+/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
+/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
+/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
+/usr/bin/gmake  -f CMakeFiles/Makefile2 all
+gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 52%] Built target lvgl
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 53%] Built target miniaudio
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 54%] Built target usgt2
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 56%] Built target uscommon
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target ushttp
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target uswebservice
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target usbrigades
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uschat
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usnatneg
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usqr2
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uscdkey
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usgp
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usstats
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target uspinger
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 60%] Built target usserverbrowsing
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspeer
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspt
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussake
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussc
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 64%] Built target usd2g
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 66%] Built target gsm
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target usvoice2
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target UniSpySDK
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milescleanup
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milesstub
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target zlib
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target lzhl
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Built target lvgl_platform
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:46,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/w3dmodulefactory.h:39,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/W3DModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:48:10: fatal error: common/NameKeyGenerator.h: No such file or directory
+   48 | #include "common/NameKeyGenerator.h"
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake: *** [Makefile:94: all] Error 2
+/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
+/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
+/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
+/usr/bin/gmake  -f CMakeFiles/Makefile2 all
+gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 52%] Built target lvgl
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 53%] Built target miniaudio
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 54%] Built target usgt2
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 56%] Built target uscommon
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target ushttp
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target uswebservice
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target usbrigades
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uschat
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usnatneg
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usqr2
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uscdkey
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usgp
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usstats
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target uspinger
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 60%] Built target usserverbrowsing
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspeer
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspt
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussake
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussc
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 64%] Built target usd2g
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 66%] Built target gsm
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target usvoice2
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target UniSpySDK
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milescleanup
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milesstub
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target zlib
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target lzhl
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Built target lvgl_platform
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:46,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/w3dmodulefactory.h:39,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/W3DModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:49:10: fatal error: common/Module.h: No such file or directory
+   49 | #include "common/Module.h"
+      |          ^~~~~~~~~~~~~~~~~
+compilation terminated.
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake: *** [Makefile:94: all] Error 2
+/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
+/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
+/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
+/usr/bin/gmake  -f CMakeFiles/Makefile2 all
+gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 52%] Built target lvgl
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 53%] Built target miniaudio
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 54%] Built target usgt2
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 56%] Built target uscommon
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target ushttp
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target uswebservice
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target usbrigades
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uschat
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usnatneg
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usqr2
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uscdkey
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usgp
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usstats
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target uspinger
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 60%] Built target usserverbrowsing
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspeer
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspt
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussake
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussc
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 64%] Built target usd2g
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 66%] Built target gsm
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target usvoice2
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target UniSpySDK
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milescleanup
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milesstub
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target zlib
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target lzhl
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Built target lvgl_platform
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:46,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/w3dmodulefactory.h:39,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/W3DModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/Module.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:49:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/module.h:38:10: fatal error: common/INI.h: No such file or directory
+   38 | #include "common/INI.h"
+      |          ^~~~~~~~~~~~~~
+compilation terminated.
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake: *** [Makefile:94: all] Error 2
+/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
+/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
+/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
+/usr/bin/gmake  -f CMakeFiles/Makefile2 all
+gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 52%] Built target lvgl
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 53%] Built target miniaudio
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 54%] Built target usgt2
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 56%] Built target uscommon
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target ushttp
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target uswebservice
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target usbrigades
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uschat
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usnatneg
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usqr2
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uscdkey
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usgp
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usstats
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target uspinger
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 60%] Built target usserverbrowsing
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspeer
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspt
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussake
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussc
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 64%] Built target usd2g
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 66%] Built target gsm
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target usvoice2
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target UniSpySDK
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milescleanup
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milesstub
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target zlib
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target lzhl
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Built target lvgl_platform
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:46,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/w3dmodulefactory.h:39,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/W3DModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+In file included from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/Module.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:49:
+/workspace/CnC_Generals_Zero_Hour/include/game_engine/common/module.h:41:10: fatal error: common/Snapshot.h: No such file or directory
+   41 | #include "common/Snapshot.h"
+      |          ^~~~~~~~~~~~~~~~~~~
+compilation terminated.
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
+gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake: *** [Makefile:94: all] Error 2
+/usr/bin/cmake -P /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles/VerifyGlobs.cmake
+/usr/bin/cmake -S/workspace/CnC_Generals_Zero_Hour -B/workspace/CnC_Generals_Zero_Hour/build --check-build-system CMakeFiles/Makefile.cmake 0
+/usr/bin/cmake -E cmake_progress_start /workspace/CnC_Generals_Zero_Hour/build/CMakeFiles /workspace/CnC_Generals_Zero_Hour/build//CMakeFiles/progress.marks
+/usr/bin/gmake  -f CMakeFiles/Makefile2 all
+gmake[1]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/lvgl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/lvgl.dir/build.make lib/CMakeFiles/lvgl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/lvgl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 52%] Built target lvgl
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib /workspace/CnC_Generals_Zero_Hour/build/lib/CMakeFiles/miniaudio.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/CMakeFiles/miniaudio.dir/build.make lib/CMakeFiles/miniaudio.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/CMakeFiles/miniaudio.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 53%] Built target miniaudio
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build.make lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gt2/CMakeFiles/usgt2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 54%] Built target usgt2
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build.make lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/common/CMakeFiles/uscommon.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 56%] Built target uscommon
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build.make lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/ghttp/CMakeFiles/ushttp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target ushttp
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build.make lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/webservices/CMakeFiles/uswebservice.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target uswebservice
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build.make lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/brigades/CMakeFiles/usbrigades.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 57%] Built target usbrigades
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build.make lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Chat/CMakeFiles/uschat.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uschat
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build.make lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/natneg/CMakeFiles/usnatneg.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usnatneg
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build.make lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/qr2/CMakeFiles/usqr2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target usqr2
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build.make lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gcdkey/CMakeFiles/uscdkey.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 58%] Built target uscdkey
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build.make lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/GP/CMakeFiles/usgp.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usgp
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build.make lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/gstats/CMakeFiles/usstats.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target usstats
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build.make lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pinger/CMakeFiles/uspinger.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 59%] Built target uspinger
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build.make lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/serverbrowsing/CMakeFiles/usserverbrowsing.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 60%] Built target usserverbrowsing
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build.make lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Peer/CMakeFiles/uspeer.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspeer
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build.make lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/pt/CMakeFiles/uspt.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 62%] Built target uspt
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build.make lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sake/CMakeFiles/ussake.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussake
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build.make lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sc/CMakeFiles/ussc.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 63%] Built target ussc
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build.make lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Direct2Game/CMakeFiles/usd2g.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 64%] Built target usd2g
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build.make lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/libgsm/CMakeFiles/gsm.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 66%] Built target gsm
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2 /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build.make lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/Voice2/CMakeFiles/usvoice2.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target usvoice2
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll /workspace/CnC_Generals_Zero_Hour/build/lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build.make lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/uni_spy_sdk/sharedDll/CMakeFiles/UniSpySDK.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target UniSpySDK
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build.make lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milescleanup.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milescleanup
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub /workspace/CnC_Generals_Zero_Hour/build/lib/miles_sdk_stub/CMakeFiles/milesstub.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build.make lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/miles_sdk_stub/CMakeFiles/milesstub.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 67%] Built target milesstub
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/zlib /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/zlib /workspace/CnC_Generals_Zero_Hour/build/lib/zlib/CMakeFiles/zlib.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/zlib/CMakeFiles/zlib.dir/build.make lib/zlib/CMakeFiles/zlib.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/zlib/CMakeFiles/zlib.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target zlib
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl /workspace/CnC_Generals_Zero_Hour/build/lib/liblzhl/CMakeFiles/lzhl.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f lib/liblzhl/CMakeFiles/lzhl.dir/build.make lib/liblzhl/CMakeFiles/lzhl.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'lib/liblzhl/CMakeFiles/lzhl.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 69%] Built target lzhl
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src /workspace/CnC_Generals_Zero_Hour/build/src/CMakeFiles/lvgl_platform.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/CMakeFiles/lvgl_platform.dir/build.make src/CMakeFiles/lvgl_platform.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+gmake[2]: Nothing to be done for 'src/CMakeFiles/lvgl_platform.dir/build'.
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Built target lvgl_platform
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/depend
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+cd /workspace/CnC_Generals_Zero_Hour/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /workspace/CnC_Generals_Zero_Hour /workspace/CnC_Generals_Zero_Hour/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device/CMakeFiles/gameenginedevice.dir/DependInfo.cmake "--color="
+gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
+/usr/bin/gmake  -f src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make src/game_engine_device/CMakeFiles/gameenginedevice.dir/build
+gmake[2]: Entering directory '/workspace/CnC_Generals_Zero_Hour/build'
+[ 70%] Building CXX object src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o
+cd /workspace/CnC_Generals_Zero_Hour/build/src/game_engine_device && /usr/bin/c++ -DLV_USE_X11=1 -I/workspace/CnC_Generals_Zero_Hour/include -I/workspace/CnC_Generals_Zero_Hour/include/game_engine -I/workspace/CnC_Generals_Zero_Hour/include/game_engine_device -I/workspace/CnC_Generals_Zero_Hour/include/pre_compiled -I/workspace/CnC_Generals_Zero_Hour/src -I/workspace/CnC_Generals_Zero_Hour/lib/miniaudio -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub -I/workspace/CnC_Generals_Zero_Hour/lib/miles_sdk_stub/mss -I/workspace/CnC_Generals_Zero_Hour/include/precompiled -I/workspace/CnC_Generals_Zero_Hour/lib -I/workspace/CnC_Generals_Zero_Hour/lib/lvgl -O3 -DNDEBUG -std=gnu++17 -MD -MT src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -MF CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o.d -o CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o -c /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp
+In file included from /usr/include/c++/13/backward/hash_map:60,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/../game_engine/common/stltypedefs.h:74,
+                 from /workspace/CnC_Generals_Zero_Hour/include/common/stl_type_defs.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ini.h:38,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/../../generals_md/code/game_engine/include/common/subsysteminterface.h:35,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/subsystem_interface.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/modulefactory.h:46,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine/common/ModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/w3dmodulefactory.h:39,
+                 from /workspace/CnC_Generals_Zero_Hour/include/game_engine_device/w3d_device/common/W3DModuleFactory.h:2,
+                 from /workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:31:
+/usr/include/c++/13/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
+   32 | #warning \
+      |  ^~~~~~~
+/workspace/CnC_Generals_Zero_Hour/src/game_engine_device/w3d_device/common/Thing/W3DModuleFactory.cpp:32:10: fatal error: w3d_device/game_client/Module/W3DDebrisDraw.h: No such file or directory
+   32 | #include "w3d_device/game_client/Module/W3DDebrisDraw.h"
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+gmake[2]: *** [src/game_engine_device/CMakeFiles/gameenginedevice.dir/build.make:177: src/game_engine_device/CMakeFiles/gameenginedevice.dir/w3d_device/common/Thing/W3DModuleFactory.cpp.o] Error 1
 gmake[2]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'
 gmake[1]: *** [CMakeFiles/Makefile2:1988: src/game_engine_device/CMakeFiles/gameenginedevice.dir/all] Error 2
 gmake[1]: Leaving directory '/workspace/CnC_Generals_Zero_Hour/build'

--- a/migration.md
+++ b/migration.md
@@ -278,3 +278,4 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - Building with `cmake --build build -- -j1` avoids the 'No child processes' error seen on some hosts when using parallel Makefiles.
 - Unified `src/game_engine/common` with snake_case source files and removed legacy `Common` duplicate.
 - Renamed radar implementation to snake_case under w3d_device/common/system.
+- Introduced a portable `tchar.h` wrapper and added case-correct alias headers for cross-platform builds.


### PR DESCRIPTION
## Summary
- add portable `tchar.h` wrapper
- include new header in wwstring
- fix include path in `gameaudio.h`
- add case-sensitive alias headers for several modules
- document progress in `migration.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j1` *(fails: w3dmodulefactory missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ad598adb48325b4002809dbd9e86b