### PR TITLE
Improve cross-platform headers

### DIFF
--- a/include/common/win32_compat.h
+++ b/include/common/win32_compat.h
@@ -5,6 +5,9 @@
 #ifndef __cdecl
 #define __cdecl
 #endif
+#ifndef _cdecl
+#define _cdecl
+#endif
 
 using DWORD = std::uint32_t;
 using WORD  = std::uint16_t;

--- a/include/libraries/ww_vegas/ww_lib/cpudetect.h
+++ b/include/libraries/ww_vegas/ww_lib/cpudetect.h
@@ -45,11 +45,12 @@
 
 #include "always.h"
 #include "wwstring.h"
+#include <cstdint>
 
-#ifdef WIN32
+#ifdef _WIN32
 typedef signed __int64 sint64;
-#elif defined (_UNIX)
-typedef signed long long sint64;
+#else
+using sint64 = std::int64_t;
 #endif
 
 class CPUDetectInitClass;

--- a/include/libraries/ww_vegas/ww_lib/mmsys.h
+++ b/include/libraries/ww_vegas/ww_lib/mmsys.h
@@ -44,8 +44,10 @@
 ** This header just includes mmsystem.h with warning 4201 disabled
 */
 
+#ifdef _WIN32
 #pragma warning(disable:4201)
 #include <mmsystem.h>
 #pragma warning(default:4201)
+#endif
 
 #endif // MMSYS_H

--- a/include/libraries/ww_vegas/ww_lib/systimer.h
+++ b/include/libraries/ww_vegas/ww_lib/systimer.h
@@ -38,7 +38,7 @@
 #ifndef _SYSTIMER_H
 
 #include "always.h"
-#include <windows.h>
+#include "common/windows.h"
 #include "mmsys.h"
 
 #define TIMEGETTIME SystemTime.Get

--- a/include/libraries/ww_vegas/ww_lib/wwstring.h
+++ b/include/libraries/ww_vegas/ww_lib/wwstring.h
@@ -117,8 +117,8 @@ public:
 	bool			Is_Empty (void) const;
 
 	void			Erase (int start_index, int char_count);
-	int _cdecl  Format (const TCHAR *format, ...);
-	int _cdecl  Format_Args (const TCHAR *format, const va_list & arg_list );
+        int __cdecl  Format (const TCHAR *format, ...);
+        int __cdecl  Format_Args (const TCHAR *format, const va_list & arg_list );
 
 	TCHAR *		Get_Buffer (int new_length);
 	TCHAR *		Peek_Buffer (void);

--- a/migration.md
+++ b/migration.md
@@ -281,3 +281,4 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - Introduced a portable `tchar.h` wrapper and added case-correct alias headers for cross-platform builds.
 - Added lvgl_hello example under src/examples. The program opens an 800x600 LVGL window and demonstrates widgets with a 'Hello world' label and a centred button that reacts to clicks. Building with -DBUILD_ENGINE=OFF skips the main Generals engine.
 - lvgl_hello now selects the SDL backend by default, improving rendering on macOS.
+- Updated CPU detection code for non-Windows builds and replaced Windows headers with portable stubs.

--- a/src/libraries/ww_vegas/ww_lib/cpudetect.cpp
+++ b/src/libraries/ww_vegas/ww_lib/cpudetect.cpp
@@ -20,7 +20,9 @@
 #include "wwstring.h"
 #include "wwdebug.h"
 #include "thread.h"
+#ifdef _WIN32
 #include "mpu.h"
+#endif
 #pragma warning (disable : 4201)	// Nonstandard extension - nameless struct
 #include "common/windows.h"
 #include "systimer.h"
@@ -28,6 +30,99 @@
 #ifdef _UNIX
 # include <time.h>  // for time(), localtime() and timezone variable.
 #endif
+
+#ifndef _WIN32
+
+#include <cstring>
+
+StringClass CPUDetectClass::ProcessorLog;
+StringClass CPUDetectClass::CompactLog;
+
+int CPUDetectClass::ProcessorType = 0;
+int CPUDetectClass::ProcessorFamily = 0;
+int CPUDetectClass::ProcessorModel = 0;
+int CPUDetectClass::ProcessorRevision = 0;
+int CPUDetectClass::ProcessorSpeed = 0;
+sint64 CPUDetectClass::ProcessorTicksPerSecond = 0;
+double CPUDetectClass::InvProcessorTicksPerSecond = 0.0;
+
+CPUDetectClass::ProcessorManufacturerType CPUDetectClass::ProcessorManufacturer = CPUDetectClass::MANUFACTURER_UNKNOWN;
+CPUDetectClass::IntelProcessorType CPUDetectClass::IntelProcessor = CPUDetectClass::INTEL_PROCESSOR_UNKNOWN;
+CPUDetectClass::AMDProcessorType CPUDetectClass::AMDProcessor = CPUDetectClass::AMD_PROCESSOR_UNKNOWN;
+CPUDetectClass::VIAProcessorType CPUDetectClass::VIAProcessor = CPUDetectClass::VIA_PROCESSOR_UNKNOWN;
+CPUDetectClass::RiseProcessorType CPUDetectClass::RiseProcessor = CPUDetectClass::RISE_PROCESSOR_UNKNOWN;
+
+unsigned CPUDetectClass::FeatureBits = 0;
+unsigned CPUDetectClass::ExtendedFeatureBits = 0;
+
+unsigned CPUDetectClass::L2CacheSize = 0;
+unsigned CPUDetectClass::L2CacheLineSize = 0;
+unsigned CPUDetectClass::L2CacheSetAssociative = 0;
+unsigned CPUDetectClass::L1DataCacheSize = 0;
+unsigned CPUDetectClass::L1DataCacheLineSize = 0;
+unsigned CPUDetectClass::L1DataCacheSetAssociative = 0;
+unsigned CPUDetectClass::L1InstructionCacheSize = 0;
+unsigned CPUDetectClass::L1InstructionCacheLineSize = 0;
+unsigned CPUDetectClass::L1InstructionCacheSetAssociative = 0;
+unsigned CPUDetectClass::L1InstructionTraceCacheSize = 0;
+unsigned CPUDetectClass::L1InstructionTraceCacheSetAssociative = 0;
+
+unsigned CPUDetectClass::TotalPhysicalMemory = 0;
+unsigned CPUDetectClass::AvailablePhysicalMemory = 0;
+unsigned CPUDetectClass::TotalPageMemory = 0;
+unsigned CPUDetectClass::AvailablePageMemory = 0;
+unsigned CPUDetectClass::TotalVirtualMemory = 0;
+unsigned CPUDetectClass::AvailableVirtualMemory = 0;
+
+unsigned CPUDetectClass::OSVersionNumberMajor = 0;
+unsigned CPUDetectClass::OSVersionNumberMinor = 0;
+unsigned CPUDetectClass::OSVersionBuildNumber = 0;
+unsigned CPUDetectClass::OSVersionPlatformId = 0;
+StringClass CPUDetectClass::OSVersionExtraInfo;
+
+bool CPUDetectClass::HasCPUIDInstruction = false;
+bool CPUDetectClass::HasRDTSCInstruction = false;
+bool CPUDetectClass::HasSSESupport = false;
+bool CPUDetectClass::HasSSE2Support = false;
+bool CPUDetectClass::HasCMOVSupport = false;
+bool CPUDetectClass::HasMMXSupport = false;
+bool CPUDetectClass::Has3DNowSupport = false;
+bool CPUDetectClass::HasExtended3DNowSupport = false;
+
+char CPUDetectClass::VendorID[20] = "";
+char CPUDetectClass::ProcessorString[48] = "";
+
+const char* CPUDetectClass::Get_Processor_Manufacturer_Name()
+{
+    return "<Unknown>";
+}
+
+bool CPUDetectClass::CPUID(unsigned&, unsigned&, unsigned&, unsigned&, unsigned)
+{
+    return false;
+}
+
+void CPUDetectClass::Init_CPUID_Instruction() {}
+void CPUDetectClass::Init_Processor_Speed() {}
+void CPUDetectClass::Init_Processor_String() { ProcessorString[0] = '\0'; }
+void CPUDetectClass::Init_Processor_Manufacturer() {}
+void CPUDetectClass::Init_Processor_Family() {}
+void CPUDetectClass::Init_Processor_Features() {}
+void CPUDetectClass::Init_Memory() {}
+void CPUDetectClass::Init_OS() {}
+void CPUDetectClass::Init_Intel_Processor_Type() {}
+void CPUDetectClass::Init_AMD_Processor_Type() {}
+void CPUDetectClass::Init_VIA_Processor_Type() {}
+void CPUDetectClass::Init_Rise_Processor_Type() {}
+void CPUDetectClass::Init_Cache() {}
+void CPUDetectClass::Init_Processor_Log() {}
+void CPUDetectClass::Init_Compact_Log() {}
+
+struct OSInfoStruct { const char* Code; const char* SubCode; const char* VersionString; unsigned char VersionMajor; unsigned char VersionMinor; unsigned short VersionSub; unsigned char BuildMajor; unsigned char BuildMinor; unsigned short BuildSub; };
+
+static void Get_OS_Info(OSInfoStruct&, unsigned, unsigned, unsigned, unsigned) {}
+
+#else // _WIN32
 
 struct OSInfoStruct {
 	const char* Code;
@@ -1330,3 +1425,4 @@ void Get_OS_Info(
 		}
 	}
 }
+#endif // _WIN32


### PR DESCRIPTION
## Summary
- guard `_cdecl` in win32_compat
- define `sint64` cross-platform
- avoid missing Windows headers
- stub CPU detection on non-Windows
- document CPU detection changes in migration notes

## Testing
- `cmake -S . -B build`
- `cmake --build build -j1` *(fails: build interrupted due to long compile time)*

------
https://chatgpt.com/codex/tasks/task_e_685b257926ec83259218a7a2c6e9d3f7