### PR TITLE
Add cross platform critical section wrappers

### DIFF
--- a/include/libraries/ww_vegas/ww_lib/always.h
+++ b/include/libraries/ww_vegas/ww_lib/always.h
@@ -42,6 +42,7 @@
 
 #include <assert.h>
 #include <cstddef>
+#include "common/win32_compat.h"
 
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #pragma warning(disable : 4530)


### PR DESCRIPTION
## Summary
- provide `CRITICAL_SECTION` and condition variable shims using the C++ std library
- include `win32_compat.h` from `always.h` so `__cdecl` is available on non‑Windows builds

## Testing
- `cmake --build build --target wwlib -j1`

------
https://chatgpt.com/codex/tasks/task_e_685b27ed2e4c8325a340920fba53e556