### PR TITLE
Fix wwmath build errors

### DIFF
--- a/include/D3dx8math.h
+++ b/include/D3dx8math.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "d3dx8_math.h"

--- a/include/libraries/ww_vegas/ww_debug/wwprofile.h
+++ b/include/libraries/ww_vegas/ww_debug/wwprofile.h
@@ -41,10 +41,7 @@
 #ifndef WWPROFILE_H
 #define WWPROFILE_H
 
-#ifdef _UNIX
-typedef signed long long __int64;
-typedef signed long long _int64;
-#endif
+#include <cstdint>
 	
 			
 /*
@@ -75,7 +72,7 @@ protected:
 	const char *					Name;
 	int								TotalCalls;
 	float								TotalTime;
-	__int64							StartTime;
+	int64_t							StartTime;
 	int								RecursionCounter;
 
 	WWProfileHierachyNodeClass *	Parent;
@@ -162,7 +159,7 @@ private:
 	static	WWProfileHierachyNodeClass		Root;
 	static	WWProfileHierachyNodeClass *	CurrentNode;
 	static	int									FrameCounter;
-	static	__int64								ResetTime;
+	static	int64_t								ResetTime;
 
 	friend	class		WWProfileInOrderIterator;
 };
@@ -201,7 +198,7 @@ public:
 	~WWTimeItClass( void );
 private:
 	const char * Name;
-	__int64	Time;
+	int64_t	Time;
 };
 
 #ifdef WWDEBUG
@@ -223,7 +220,7 @@ public:
 	~WWMeasureItClass( void );
 
 private:
-	__int64	Time;
+	int64_t	Time;
 	float *  PResult;
 };
 

--- a/include/libraries/ww_vegas/ww_lib/chunkio.h
+++ b/include/libraries/ww_vegas/ww_lib/chunkio.h
@@ -377,4 +377,4 @@ private:
 
 
 
-#endif CHUNKIO_H
+#endif // CHUNKIO_H

--- a/include/libraries/ww_vegas/ww_lib/mempool.h
+++ b/include/libraries/ww_vegas/ww_lib/mempool.h
@@ -155,7 +155,7 @@ private:
 ** the class.
 */
 #define DEFINE_AUTO_POOL(T,BLOCKSIZE) \
-ObjectPoolClass<T,BLOCKSIZE> AutoPoolClass<T,BLOCKSIZE>::Allocator
+template<> ObjectPoolClass<T,BLOCKSIZE> AutoPoolClass<T,BLOCKSIZE>::Allocator
 
 
 

--- a/include/libraries/ww_vegas/ww_lib/multilist.h
+++ b/include/libraries/ww_vegas/ww_lib/multilist.h
@@ -487,7 +487,7 @@ class PriorityMultiListIterator : public MultiListIterator<ObjectType>
 public:
 	PriorityMultiListIterator(MultiListClass<ObjectType> *list)
 		:	OriginalHead (NULL),
-			MultiListIterator<ObjectType>(list)			{ First (); }
+			MultiListIterator<ObjectType>(list)			{ this->First(); }
 
 	bool
 	Process_Head (ObjectType **object)
@@ -496,14 +496,14 @@ public:
 
 		//	Check to ensure we don't wrap around the list (stop after iterating
 		// the list once).
-		if (CurNode != NULL && CurNode->Object != NULL && OriginalHead != CurNode) {
-			OriginalHead		= (OriginalHead == NULL) ? CurNode : OriginalHead;
-			(*object)			= (ObjectType *)CurNode->Object;
+		if (this->CurNode != NULL && this->CurNode->Object != NULL && OriginalHead != this->CurNode) {
+			OriginalHead		= (OriginalHead == NULL) ? this->CurNode : OriginalHead;
+			(*object)			= (ObjectType *)this->CurNode->Object;
 
 
 			// Remove the node from the head of the list and
 			// add it to the tail of the list
-			Remove_Current_Object();
+			this->Remove_Current_Object();
 			((MultiListClass<ObjectType> *)PriorityMultiListIterator::List)->Add_Tail ((*object));
 
 			retval = true;

--- a/include/libraries/ww_vegas/ww_lib/random.h
+++ b/include/libraries/ww_vegas/ww_lib/random.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "RANDOM.H"

--- a/include/libraries/ww_vegas/ww_lib/simplevec.h
+++ b/include/libraries/ww_vegas/ww_lib/simplevec.h
@@ -261,8 +261,8 @@ public:
 
 	// Array-like access (does not grow)
 	int				Count(void) const						{ return(ActiveCount); }
-	T &				operator[](int index)				{ assert(index < ActiveCount); return(Vector[index]); } 
-	T const &		operator[](int index) const		{ assert(index < ActiveCount); return(Vector[index]); }
+	T &				operator[](int index)				{ assert(index < ActiveCount); return(this->Vector[index]); } 
+	T const &		operator[](int index) const		{ assert(index < ActiveCount); return(this->Vector[index]); }
 
 	// Change maximum size of vector
 	virtual bool	Resize(int newsize);
@@ -325,10 +325,10 @@ inline SimpleDynVecClass<T>::SimpleDynVecClass(int size) :
 template<class T>
 inline SimpleDynVecClass<T>::~SimpleDynVecClass(void)
 {
-	if (Vector != NULL) {
-		delete[] Vector;
-		Vector = NULL;
-	}
+        if (this->Vector != NULL) {
+                delete[] this->Vector;
+                this->Vector = NULL;
+        }
 }
 
 /***********************************************************************************************
@@ -347,11 +347,11 @@ inline SimpleDynVecClass<T>::~SimpleDynVecClass(void)
 template<class T>
 inline bool SimpleDynVecClass<T>::Resize(int newsize)
 {
-	if (SimpleVecClass<T>::Resize(newsize)) {
-		if (Length() < ActiveCount) ActiveCount = Length();
-		return(true);
-	}
-	return(false);
+        if (SimpleVecClass<T>::Resize(newsize)) {
+                if (this->Length() < ActiveCount) ActiveCount = this->Length();
+                return(true);
+        }
+        return(false);
 }
 
 /***********************************************************************************************
@@ -370,7 +370,7 @@ inline bool SimpleDynVecClass<T>::Resize(int newsize)
 template<class T>
 inline bool SimpleDynVecClass<T>::Add(T const & object,int new_size_hint)
 {
-	if (ActiveCount >= VectorMax) {
+        if (ActiveCount >= this->VectorMax) {
 		
 		/*
 		** We are out of space so tell the vector to grow
@@ -384,8 +384,8 @@ inline bool SimpleDynVecClass<T>::Add(T const & object,int new_size_hint)
 	/*
 	**	There is room for the new object now. Add it to the end of the object vector.
 	*/
-	(*this)[ActiveCount++] = object;
-	return true;
+        (*this)[ActiveCount++] = object;
+        return true;
 }
 
 /***********************************************************************************************
@@ -403,10 +403,10 @@ inline bool SimpleDynVecClass<T>::Add(T const & object,int new_size_hint)
 template<class T>
 inline T *  SimpleDynVecClass<T>::Add_Multiple( int number_to_add )
 {
-	int index = ActiveCount;
-	ActiveCount += number_to_add;
+        int index = ActiveCount;
+        ActiveCount += number_to_add;
 
-	if (ActiveCount >= VectorMax) {
+        if (ActiveCount >= this->VectorMax) {
 		
 		/*
 		** We are out of space so tell the vector to grow
@@ -414,7 +414,7 @@ inline T *  SimpleDynVecClass<T>::Add_Multiple( int number_to_add )
 		Grow( ActiveCount );
 	}
 
-	return &Vector[index];
+        return &this->Vector[index];
 }
 
 
@@ -444,9 +444,9 @@ inline bool SimpleDynVecClass<T>::Delete(int index,bool allow_shrink)
 	** those objects to collapse the array.  NOTE: again, this template
 	** cannot be used for classes that cannot be memcopied!!
 	*/
-	if (index < ActiveCount-1) {
-		memmove(&(Vector[index]),&(Vector[index+1]),(ActiveCount - index - 1) * sizeof(T));
-	}
+        if (index < ActiveCount-1) {
+                memmove(&(this->Vector[index]),&(this->Vector[index+1]),(ActiveCount - index - 1) * sizeof(T));
+        }
 	ActiveCount--;
 
 	/*
@@ -513,9 +513,9 @@ inline bool SimpleDynVecClass<T>::Delete_Range(int start,int count,bool allow_sh
 	** those objects to collapse the array.  NOTE: again, this template
 	** cannot be used for classes that cannot be memcopied!!
 	*/
-	if (start < ActiveCount - count) {
-		memmove(&(Vector[start]),&(Vector[start + count]),(ActiveCount - start - count) * sizeof(T));
-	}
+        if (start < ActiveCount - count) {
+                memmove(&(this->Vector[start]),&(this->Vector[start + count]),(ActiveCount - start - count) * sizeof(T));
+        }
 
 	ActiveCount -= count;
 
@@ -577,8 +577,8 @@ inline bool SimpleDynVecClass<T>::Grow(int new_size_hint)
 	** Vector should grow to 25% bigger, grow at least 4 elements,
 	** and grow at least up to the user's new_size_hint
 	*/
-	int new_size = MAX(Length() + Length()/4,Length() + 4);
-	new_size = MAX(new_size,new_size_hint);
+        int new_size = MAX(this->Length() + this->Length()/4,this->Length() + 4);
+        new_size = MAX(new_size,new_size_hint);
 	
 	return Resize(new_size);
 }
@@ -603,9 +603,9 @@ inline bool SimpleDynVecClass<T>::Shrink(void)
 	/*
 	** Shrink the array if it is wasting more than 25%
 	*/
-	if (ActiveCount < VectorMax/4) {
-		return Resize(ActiveCount);
-	}
+        if (ActiveCount < this->VectorMax/4) {
+                return Resize(ActiveCount);
+        }
 	return true;
 }
 

--- a/include/libraries/ww_vegas/ww_lib/slist.h
+++ b/include/libraries/ww_vegas/ww_lib/slist.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "SLIST.H"

--- a/include/libraries/ww_vegas/ww_lib/slnode.h
+++ b/include/libraries/ww_vegas/ww_lib/slnode.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "SLNODE.H"

--- a/include/libraries/ww_vegas/ww_lib/win.h
+++ b/include/libraries/ww_vegas/ww_lib/win.h
@@ -59,11 +59,12 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include	<windows.h>
-//#include <mmsystem.h>
-//#include	<windowsx.h>
-//#include	<winnt.h>
-//#include	<winuser.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
+typedef void* HINSTANCE;
+typedef void* HWND;
+#endif
 
 #if (_MSC_VER >= 1200)
 #pragma warning(pop)

--- a/include/libraries/ww_vegas/ww_lib/wwfile.h
+++ b/include/libraries/ww_vegas/ww_lib/wwfile.h
@@ -37,12 +37,12 @@
 #pragma once
 #endif // _MSC_VER >= 1000
 
-#ifndef WWFILE_Hx
-#define WWFILE_Hx
+#ifndef WWFILE_H
+#define WWFILE_H
 
 #ifdef _UNIX
 #include "osdep.h"
-#endif
+#endif // WWFILE_H
 
 #define YEAR(dt)	(((dt & 0xFE000000) >> (9 + 16)) + 1980)
 #define MONTH(dt)	 ((dt & 0x01E00000) >> (5 + 16))

--- a/src/libraries/ww_vegas/ww_lib/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_lib/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(wwlib PUBLIC
     ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_lib
     ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_debug
     ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_lib
+    ${PROJECT_SOURCE_DIR}/src/tools/WW3D/pluglib
 )
 
 # wwlib does not directly depend on wwdebug

--- a/src/libraries/ww_vegas/ww_math/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_math/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(wwmath STATIC ${WWMATH_SRCS})
 target_include_directories(wwmath PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_math
+    ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_save_load
 )
 
-target_link_libraries(wwmath PUBLIC wwlib)
+target_link_libraries(wwmath PUBLIC wwlib wwsaveload)

--- a/src/libraries/ww_vegas/ww_math/lookuptable.cpp
+++ b/src/libraries/ww_vegas/ww_math/lookuptable.cpp
@@ -43,6 +43,7 @@
 #include "chunkio.h"
 #include "persistfactory.h"
 #include "vector2.h"
+#include <strings.h>
 
 
 /*
@@ -145,7 +146,7 @@ LookupTableClass * LookupTableMgrClass::Get_Table(const char * name,bool try_to_
 	// check if we already have this table loaded...
 	RefMultiListIterator<LookupTableClass> it(&Tables);
 	for (it.First(); !it.Is_Done(); it.Next()) {
-		if (stricmp(it.Peek_Obj()->Get_Name(),name) == 0) {
+		if (strcasecmp(it.Peek_Obj()->Get_Name(),name) == 0) {
 			return it.Get_Obj(); // add a reference for the user...
 		}
 	}

--- a/src/libraries/ww_vegas/ww_math/matrix3d.cpp
+++ b/src/libraries/ww_vegas/ww_math/matrix3d.cpp
@@ -516,11 +516,8 @@ void Matrix3D::Get_Inverse(Matrix3D & inv) const
 	// TODO: Implement the general purpose inverse function here (once we need it :-)
 	//Get_Orthogonal_Inverse(inv);
 
-	Matrix4x4	mat4(*this);
-	Matrix4x4	mat4Inv;
-
-	float det;
-	D3DXMatrixInverse((D3DXMATRIX *)&mat4Inv, &det, (D3DXMATRIX*)&mat4);
+        Matrix4x4       mat4(*this);
+        Matrix4x4       mat4Inv = mat4.Inverse();
 
 	inv.Row[0][0]=mat4Inv[0][0];
 	inv.Row[0][1]=mat4Inv[0][1];

--- a/src/libraries/ww_vegas/ww_math/v3_rnd.h
+++ b/src/libraries/ww_vegas/ww_math/v3_rnd.h
@@ -129,7 +129,7 @@ class Vector3SolidBoxRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidBoxRandomizer & Vector3SolidBoxRandomizer::operator = (const Vector3SolidBoxRandomizer &that) { that; return *this; }
+                Vector3SolidBoxRandomizer & operator=(const Vector3SolidBoxRandomizer &that) { (void)that; return *this; }
 
 		Vector3	Extents;
 };
@@ -160,7 +160,7 @@ class Vector3SolidSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidSphereRandomizer & Vector3SolidSphereRandomizer::operator = (const Vector3SolidSphereRandomizer &that) { that; return *this; }
+                Vector3SolidSphereRandomizer & operator=(const Vector3SolidSphereRandomizer &that) { (void)that; return *this; }
 
 		float	Radius;
 };
@@ -191,7 +191,7 @@ class Vector3HollowSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3HollowSphereRandomizer & Vector3HollowSphereRandomizer::operator = (const Vector3HollowSphereRandomizer &that) { that; return *this; }
+                Vector3HollowSphereRandomizer & operator=(const Vector3HollowSphereRandomizer &that) { (void)that; return *this; }
 
 		float	Radius;
 };
@@ -223,7 +223,7 @@ class Vector3SolidCylinderRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidCylinderRandomizer & Vector3SolidCylinderRandomizer::operator = (const Vector3SolidCylinderRandomizer &that) { that; return *this; }
+                Vector3SolidCylinderRandomizer & operator=(const Vector3SolidCylinderRandomizer &that) { (void)that; return *this; }
 
 		float	Extent;
 		float	Radius;

--- a/src/libraries/ww_vegas/ww_math/wwmath.cpp
+++ b/src/libraries/ww_vegas/ww_math/wwmath.cpp
@@ -57,16 +57,15 @@ void		WWMath::Init(void)
 		_FastAcosTable[a]=acos(cv);
 		_FastAsinTable[a]=asin(cv);
 	}
+        for (int a=0;a<SIN_TABLE_SIZE;++a) {
+                float cv= (float)a * 2.0f * WWMATH_PI / SIN_TABLE_SIZE;
+                _FastSinTable[a]=sin(cv);
 
-	for (a=0;a<SIN_TABLE_SIZE;++a) {
-		float cv= (float)a * 2.0f * WWMATH_PI / SIN_TABLE_SIZE; //float(a-SIN_TABLE_SIZE/2)*(1.0f/(SIN_TABLE_SIZE/2));
-		_FastSinTable[a]=sin(cv);
-		
-		if (a>0) {
-			_FastInvSinTable[a]=1.0f/_FastSinTable[a];
-		} else {
-			_FastInvSinTable[a]=WWMATH_FLOAT_MAX;
-		}
+                if (a>0) {
+                        _FastInvSinTable[a]=1.0f/_FastSinTable[a];
+                } else {
+                        _FastInvSinTable[a]=WWMATH_FLOAT_MAX;
+                }
 	}
 }
 

--- a/src/libraries/ww_vegas/ww_save_load/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_save_load/CMakeLists.txt
@@ -6,4 +6,8 @@ add_library(wwsaveload STATIC ${WWSAVELOAD_SRCS})
 
 target_include_directories(wwsaveload PUBLIC
     ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_lib
+    ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_debug
+    ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_math
 )
+

--- a/src/libraries/ww_vegas/ww_save_load/definitionfactorymgr.cpp
+++ b/src/libraries/ww_vegas/ww_save_load/definitionfactorymgr.cpp
@@ -35,6 +35,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "definitionfactorymgr.h"
+#include <strings.h>
 #include "definitionfactory.h"
 #include "wwdebug.h"
 #include <string.h>
@@ -99,7 +100,7 @@ DefinitionFactoryMgrClass::Find_Factory (const char *name)
 		//
 		//	Is this the factory we were looking for?
 		//
-		if (::stricmp (curr_factory->Get_Name (), name) == 0) {
+		if (strcasecmp (curr_factory->Get_Name (), name) == 0) {
 			factory = curr_factory;
 		}
 	}

--- a/src/libraries/ww_vegas/ww_save_load/definitionmgr.cpp
+++ b/src/libraries/ww_vegas/ww_save_load/definitionmgr.cpp
@@ -193,7 +193,7 @@ DefinitionMgrClass::Find_Named_Definition (const char *name, bool twiddle)
 		//
 		//	Is this the definition we were looking for?
 		//
-		if (curr_def != NULL && ::stricmp (curr_def->Get_Name (), name) == 0) {
+		if (curr_def != NULL && strcasecmp (curr_def->Get_Name (), name) == 0) {
 			definition = curr_def;
 			break;
 		}
@@ -278,7 +278,7 @@ DefinitionMgrClass::Find_Typed_Definition (const char *name, uint32 class_id, bo
 					//
 					//	Is this the definition we were looking for?
 					//
-					if (::stricmp (curr_def->Get_Name (), name) == 0) {
+					if (strcasecmp (curr_def->Get_Name (), name) == 0) {
 						definition = curr_def;
 						// Add the definition to the hash table, so that it can be quickly accessed the next time it is needed.
 						if (!defs) {

--- a/src/libraries/ww_vegas/ww_save_load/parameter.cpp
+++ b/src/libraries/ww_vegas/ww_save_load/parameter.cpp
@@ -40,6 +40,7 @@
 #include "simpleparameter.h"
 #include "wwstring.h"
 #include "definitionclassids.h"
+#include <strings.h>
 
 
 /////////////////////////////////////////////////////////////////////
@@ -1928,7 +1929,7 @@ FilenameListParameterClass::operator== (const FilenameListParameterClass &src)
 		for (int index = 0; (index < count1) && retval; index ++) {
 			StringClass &filename1 = (*m_FilenameList)[index];
 			StringClass &filename2 = (*src.m_FilenameList)[index];
-			retval &= (::stricmp (filename1, filename2) == 0);
+			retval &= (strcasecmp (filename1, filename2) == 0);
 		}
 	}
 
@@ -2072,7 +2073,7 @@ ScriptListParameterClass::Are_Lists_Identical
 	for (int index = 0; (index < count1) && retval; index ++) {
 		StringClass &string1 = list1[index];
 		StringClass &string2 = list2[index];
-		retval &= (::stricmp (string1, string2) == 0);
+		retval &= (strcasecmp (string1, string2) == 0);
 	}
 
 	return retval;

--- a/src/libraries/ww_vegas/ww_save_load/persistfactory.h
+++ b/src/libraries/ww_vegas/ww_save_load/persistfactory.h
@@ -50,6 +50,7 @@
 #include "chunkio.h"
 #include "wwdebug.h"
 #include "saveload.h"
+#include <cstdint>
 
 class PersistClass;
 
@@ -130,9 +131,9 @@ SimplePersistFactoryClass<T,CHUNKID>::Load(ChunkLoadClass & cload) const
 template<class T, int CHUNKID> void
 SimplePersistFactoryClass<T,CHUNKID>::Save(ChunkSaveClass & csave,PersistClass * obj) const 
 {
-	uint32 objptr = (uint32)obj;
-	csave.Begin_Chunk(SIMPLEFACTORY_CHUNKID_OBJPOINTER);
-	csave.Write(&objptr,sizeof(uint32));
+    uintptr_t objptr = reinterpret_cast<uintptr_t>(obj);
+    csave.Begin_Chunk(SIMPLEFACTORY_CHUNKID_OBJPOINTER);
+    csave.Write(&objptr,sizeof(objptr));
 	csave.End_Chunk();
 
 	csave.Begin_Chunk(SIMPLEFACTORY_CHUNKID_OBJDATA);

--- a/src/libraries/ww_vegas/ww_save_load/twiddler.cpp
+++ b/src/libraries/ww_vegas/ww_save_load/twiddler.cpp
@@ -41,6 +41,7 @@
 #include "simpledefinitionfactory.h"
 #include "persistfactory.h"
 #include "win.h"
+#include <ctime>
 #include "wwhack.h"
 
 
@@ -111,7 +112,7 @@ TwiddlerClass::Twiddle (void) const
 		//
 		//	Get a random index into our definition list
 		//
-		RandomClass randomizer (::GetTickCount ());
+		RandomClass randomizer (static_cast<unsigned>(time(NULL)));
 		int index = randomizer (0, m_DefinitionList.Count () - 1);
 
 		//

--- a/src/tools/WW3D/pluglib/chunkio.h
+++ b/src/tools/WW3D/pluglib/chunkio.h
@@ -377,4 +377,4 @@ private:
 
 
 
-#endif CHUNKIO_H
+#endif // CHUNKIO_H

--- a/src/tools/WW3D/pluglib/wwfile.h
+++ b/src/tools/WW3D/pluglib/wwfile.h
@@ -37,12 +37,12 @@
 #pragma once
 #endif // _MSC_VER >= 1000
 
-#ifndef WWFILE_Hx
-#define WWFILE_Hx
+#ifndef WWFILE_H
+#define WWFILE_H
 
 #ifdef _UNIX
 #include "osdep.h"
-#endif
+#endif // WWFILE_H
 
 #define YEAR(dt)	(((dt & 0xFE000000) >> (9 + 16)) + 1980)
 #define MONTH(dt)	 ((dt & 0x01E00000) >> (5 + 16))


### PR DESCRIPTION
## Summary
- fix templated vector references
- fix memory pool macro
- add lowercase include stubs for case-sensitive files
- add missing include directories and build fixes
- stub Windows-specific calls and adapt random seeding
- replace DirectX inverse with existing math code
- remove Windows-specific types

## Testing
- `cmake -S . -B build`
- `cmake --build build --target wwmath`

------
https://chatgpt.com/codex/tasks/task_e_685b69f243f4832580b260a147c656fb