### PR TITLE
Use GLES shim for Direct3D interface

### DIFF
--- a/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
@@ -8,4 +8,5 @@ target_include_directories(ww3d2 PUBLIC
 target_link_libraries(ww3d2 PUBLIC
     wwlib
     wwmath
+    d3d8_to_gles
 )

--- a/src/libraries/ww_vegas/ww_3d2/dx8wrapper.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/dx8wrapper.cpp
@@ -65,6 +65,7 @@
 #include "thread.h"
 #include <stdio.h>
 #include <D3dx8core.h>
+#include <d3d8_to_gles.h>
 #include "pot.h"
 #include "wwprofile.h"
 #include "ffactory.h"
@@ -248,7 +249,9 @@ bool DX8Wrapper::Init(void * hwnd)
 	/*
 	** Create the D3D interface object
 	*/
-	D3DInterface = Direct3DCreate8(D3D_SDK_VERSION);		// TODO: handle failure cases...
+	/* Use the d3d8_gles shim instead of the system Direct3D runtime */
+        D3DInterface = Direct3DCreate8(D3D_SDK_VERSION);
+        /* TODO: handle failure cases */
 	if (!D3DInterface)
 		return false;
 	IsInitted = true;	


### PR DESCRIPTION
## Summary
- include `d3d8_to_gles` header in `dx8wrapper.cpp`
- create the Direct3D8 interface via the GLES shim
- link `ww3d2` against the `d3d8_to_gles` library

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ambiguating new declaration in miscutil.cpp)*
- `ctest -V build`

------
https://chatgpt.com/codex/tasks/task_e_685bd416c70c83258b1e6dfb54587399