### PR TITLE
Link gameenginedevice with d3d8 shim

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -291,3 +291,5 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - LVGL's X11 backend is now optional. The cmake option `LVGL_USE_X11` defaults to OFF
   and `lv_conf.h` honours compile definitions so backends can be toggled without
   warnings.
+- WW3D2 links against the `d3d8_gles` shim and `gameenginedevice` now links this
+  library so DirectX 8 calls route through the OpenGL ES translation layer.

--- a/src/game_engine_device/CMakeLists.txt
+++ b/src/game_engine_device/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(gameenginedevice PUBLIC
     lvgl_platform
     wwmath
     ww3d2
+    d3d8_to_gles
     wwutil
     wwsaveload
     wwaudio


### PR DESCRIPTION
## Summary
- link `gameenginedevice` target to `d3d8_to_gles`
- document WW3D2 shim linkage in migration notes

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GetFileAttributes redefinition)*

------
https://chatgpt.com/codex/tasks/task_e_685bd7260b248325b07b502018c47106