### PR TITLE
Integrate microGLES library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -109,8 +109,8 @@ if(APPLE)
     endif()
 endif()
 
-add_library(uGLES INTERFACE)
-target_include_directories(uGLES INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/u_GLES)
+add_subdirectory(u_gles)
+add_library(uGLES ALIAS renderer_lib)
 
 # DirectX 8 to OpenGL ES 1.1 translation layer
 add_subdirectory(d3d8_gles)

--- a/lib/u_gles/CMakeLists.txt
+++ b/lib/u_gles/CMakeLists.txt
@@ -103,6 +103,8 @@ add_executable(renderer ${RENDERER_MAIN})
 target_include_directories(renderer_lib PUBLIC
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 # Locate GLES and EGL libraries if available. The headers are provided in

--- a/migration.md
+++ b/migration.md
@@ -296,3 +296,5 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
   warnings.
 - WW3D2 links against the `d3d8_gles` shim and `gameenginedevice` now links this
   library so DirectX 8 calls route through the OpenGL ES translation layer.
+- The microGLES renderer under `lib/u_gles` is built by default. Its `renderer_lib`
+  target is aliased as `uGLES` and the Generals executable links this library.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ if(BUILD_ENGINE)
     target_link_libraries(Generals PRIVATE gameenginedevice)
     target_link_libraries(Generals PRIVATE gameengine)
     target_link_libraries(Generals PRIVATE milesstub)
+    target_link_libraries(Generals PRIVATE uGLES)
 endif()
 
 add_subdirectory(examples)


### PR DESCRIPTION
## Summary
- build microGLES sources from `lib/u_gles`
- alias the renderer library as `uGLES`
- link the new library from the Generals executable
- document uGLES in the migration notes

## Testing
- `cmake -S lib/u_gles -B lib/u_gles/build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build lib/u_gles/build`
- `cmake -S lib/u_gles -B lib/u_gles/build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build lib/u_gles/build_debug`
- `cmake --build lib/u_gles/build --target format`
- `timeout 2 ./lib/u_gles/build/bin/renderer_conformance > /tmp/conformance_short.txt`
- `cmake -S . -B build`
- `cmake --build build -- -j4` *(fails: `lv_sdl_window.c` undefined reference to SDL)*

------
https://chatgpt.com/codex/tasks/task_e_685bdbddd0c88325aa71c747be7591c0