### PR TITLE
Fix path separators in headers

### DIFF
--- a/include/game_engine/game_network/nat.h
+++ b/include/game_engine/game_network/nat.h
@@ -32,7 +32,7 @@
 #ifndef __NAT_H
 #define __NAT_H
 
-#include "Lib\BaseType.h"
+#include "lib/base_type.h"
 #include "game_network/NetworkInterface.h"
 #include "game_network/FirewallHelper.h"
 

--- a/include/libraries/ww_vegas/ww_3d2/textdraw.h
+++ b/include/libraries/ww_vegas/ww_3d2/textdraw.h
@@ -44,7 +44,7 @@
 #include "dynamesh.h"
 
 // sgc : wwlib and wwmath contain different rect.h files...
-#include "..\wwmath\rect.h"
+#include "../ww_math/rect.h"
 
 class	Font3DInstanceClass;
 


### PR DESCRIPTION
## Summary
- clean Windows separators from includes
- use updated snake_case include paths

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: GetFileAttributes redeclaration)*

------
https://chatgpt.com/codex/tasks/task_e_685bde965ad08325ba86ccee729bbc65