### PR TITLE
Clean path comment in gadgettabcontrol.h

### DIFF
--- a/include/game_client/gadgettabcontrol.h
+++ b/include/game_client/gadgettabcontrol.h
@@ -33,7 +33,7 @@
 //
 // Project:    RTS3
 //
-// File name:  C:\projects\RTS\code\gameengine\Include\GameClient\GadgetTabControl.h
+// File name:  game_engine/include/game_client/gadget_tab_control.h
 //
 // Created:    Graham Smallwood, November 2001
 //


### PR DESCRIPTION
## Summary
- switch Windows path comment in `gadgettabcontrol.h` to the new snake_case location

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: ambiguating new declaration of `GetFileAttributes`)*

------
https://chatgpt.com/codex/tasks/task_e_685be519f0a08325ab376928c63df3d4