### PR TITLE
Resolve cross-platform GetFileAttributes conflict

### DIFF
--- a/include/common/win32_compat.h
+++ b/include/common/win32_compat.h
@@ -26,6 +26,10 @@ using LONG  = std::int32_t;
 #define _MAX_PATH MAX_PATH
 #endif
 
+#ifndef FILE_ATTRIBUTE_READONLY
+#define FILE_ATTRIBUTE_READONLY 0x00000001u
+#endif
+
 using HANDLE = void*;
 using HWND   = HANDLE;
 
@@ -48,7 +52,14 @@ static inline DWORD GetCurrentDirectory(DWORD n, char *b) {
 }
 #ifndef GetFileAttributes
 static inline DWORD GetFileAttributes(const char *p) {
-    struct stat st; return stat(p, &st) == 0 ? 0 : 0xFFFFFFFFu;
+    struct stat st;
+    if (stat(p, &st) == 0) {
+        DWORD attr = 0;
+        if (!(st.st_mode & S_IWUSR))
+            attr |= FILE_ATTRIBUTE_READONLY;
+        return attr;
+    }
+    return 0xFFFFFFFFu;
 }
 #endif
 static inline char *_strdup(const char *s) { return strdup(s); }

--- a/src/libraries/ww_vegas/ww_util/miscutil.cpp
+++ b/src/libraries/ww_vegas/ww_util/miscutil.cpp
@@ -40,21 +40,11 @@
 #include <unistd.h>
 
 #define stricmp strcasecmp
-#define FILE_ATTRIBUTE_READONLY 0x01
 static inline char *strupr(char *s)
 {
     for (char *p = s; *p; ++p)
         *p = static_cast<char>(toupper(static_cast<unsigned char>(*p)));
     return s;
-}
-
-static inline unsigned long GetFileAttributes(const char *filename)
-{
-    struct stat st;
-    if (stat(filename, &st) == 0) {
-        return (st.st_mode & S_IWUSR) ? 0 : FILE_ATTRIBUTE_READONLY;
-    }
-    return 0xFFFFFFFF;
 }
 static inline void DeleteFile(const char *filename) { unlink(filename); }
 


### PR DESCRIPTION
## Summary
- remove duplicate `GetFileAttributes` from `miscutil.cpp`
- implement portable version in `win32_compat.h`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: `Atan2` not defined in matrix3.h)*

------
https://chatgpt.com/codex/tasks/task_e_685beb6a299c832586c460f1f59c4c92