### PR TITLE
Display microGLES framebuffer in LVGL

### DIFF
--- a/include/game_engine_device/lvgl_device/common/lvglgameengine.h
+++ b/include/game_engine_device/lvgl_device/common/lvglgameengine.h
@@ -3,6 +3,10 @@
 #include "common/GameEngine.h"
 #include "game_network/NetworkInterface.h"
 #include "GameLogic/GameLogic.h"
+#include <lvgl.h>
+#include "lvgl_present.h"
+
+struct Framebuffer;
 
 class LvglGameEngine : public GameEngine
 {
@@ -14,4 +18,10 @@ public:
     virtual void reset();
     virtual void update();
     virtual void serviceWindowsOS();
+
+    void present_framebuffer(const Framebuffer *fb);
+
+private:
+    lv_obj_t *m_canvas = nullptr;
+    lv_draw_buf_t *m_draw_buf = nullptr;
 };

--- a/include/lvgl_present.h
+++ b/include/lvgl_present.h
@@ -1,0 +1,18 @@
+#ifndef LVGL_PRESENT_H
+#define LVGL_PRESENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct Framebuffer;
+
+void lvgl_present_framebuffer(const struct Framebuffer *fb);
+
+#ifdef __cplusplus
+}
+class LvglGameEngine;
+void lvgl_set_game_engine(LvglGameEngine *engine);
+#endif
+
+#endif // LVGL_PRESENT_H

--- a/lib/d3d8_gles/src/d3d8_to_gles.c
+++ b/lib/d3d8_gles/src/d3d8_to_gles.c
@@ -5,6 +5,11 @@
 #include <math.h>
 #include <stdalign.h>
 #include <EGL/eglext.h>
+#include "lvgl_present.h"
+
+#ifndef HAVE_LVGL_PRESENT
+__attribute__((weak)) void lvgl_present_framebuffer(const struct Framebuffer *fb) { (void)fb; }
+#endif
 
 #ifdef D3D8_GLES_LOGGING
 #include <stdio.h>
@@ -1229,6 +1234,7 @@ static HRESULT D3DAPI d3d8_create_additional_swap_chain(IDirect3DDevice8 *This, 
 static HRESULT D3DAPI d3d8_reset(IDirect3DDevice8 *This, D3DPRESENT_PARAMETERS *pPresentationParameters) { return D3DERR_NOTAVAILABLE; }
 static HRESULT D3DAPI d3d8_present(IDirect3DDevice8 *This, CONST RECT *pSourceRect, CONST RECT *pDestRect, HWND hDestWindowOverride, CONST RGNDATA *pDirtyRegion) {
     eglSwapBuffers(This->gles->display, This->gles->surface);
+    lvgl_present_framebuffer(NULL);
     return D3D_OK;
 }
 static HRESULT D3DAPI d3d8_get_back_buffer(IDirect3DDevice8 *This, UINT BackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer) { return D3DERR_NOTAVAILABLE; }

--- a/src/game_engine_device/lvgl_device/common/lvgl_game_engine.cpp
+++ b/src/game_engine_device/lvgl_device/common/lvgl_game_engine.cpp
@@ -1,10 +1,27 @@
 #include "lvgl_game_engine/lvgl_game_engine.h"
 #include "lvgl_platform/lvgl_platform.h"
+#include "lvgl_present.h"
 #include "common/logger.h"
+#include "pipeline/gl_framebuffer.h"
+#include <atomic>
 
 void LvglGameEngine::init()
 {
     LOG_INFO("LvglGameEngine::init");
+
+    lv_display_t *disp = lv_display_get_default();
+    uint32_t width = lv_display_get_horizontal_resolution(disp);
+    uint32_t height = lv_display_get_vertical_resolution(disp);
+
+    m_canvas = lv_canvas_create(lv_screen_active());
+    lv_obj_set_pos(m_canvas, 0, 0);
+    lv_obj_set_size(m_canvas, width, height);
+
+    m_draw_buf = lv_draw_buf_create(width, height, LV_COLOR_FORMAT_NATIVE, LV_STRIDE_AUTO);
+    lv_canvas_set_draw_buf(m_canvas, m_draw_buf);
+    lv_canvas_fill_bg(m_canvas, lv_color_black(), LV_OPA_COVER);
+
+    lvgl_set_game_engine(this);
 }
 
 void LvglGameEngine::reset()
@@ -22,4 +39,28 @@ void LvglGameEngine::serviceWindowsOS()
 {
     LOG_INFO("LvglGameEngine::serviceWindowsOS");
     LvglPlatform::poll_events();
+}
+
+void LvglGameEngine::present_framebuffer(const Framebuffer *fb)
+{
+    if(!fb || !m_draw_buf)
+        return;
+
+    uint32_t width = fb->width;
+    uint32_t height = fb->height;
+    uint16_t *dst = reinterpret_cast<uint16_t*>(m_draw_buf->data);
+
+    for(uint32_t y = 0; y < height; ++y) {
+        for(uint32_t x = 0; x < width; ++x) {
+            uint32_t pixel = std::atomic_load(&fb->color_buffer[(size_t)y * width + x]);
+            lv_color_t c;
+            c.red = (pixel >> 16) & 0xFF;
+            c.green = (pixel >> 8) & 0xFF;
+            c.blue = pixel & 0xFF;
+            dst[y * width + x] = lv_color_to_u16(c);
+        }
+    }
+
+    lv_canvas_set_buffer(m_canvas, dst, width, height, LV_COLOR_FORMAT_NATIVE);
+    lv_obj_invalidate(m_canvas);
 }

--- a/src/game_engine_device/lvgl_device/common/lvgl_present.cpp
+++ b/src/game_engine_device/lvgl_device/common/lvgl_present.cpp
@@ -1,0 +1,20 @@
+#include "lvgl_present.h"
+#include "game_engine_device/lvgl_device/common/lvglgameengine.h"
+#include "pipeline/gl_framebuffer.h"
+
+extern "C" Framebuffer *GL_get_default_framebuffer(void);
+
+static LvglGameEngine *g_engine = nullptr;
+
+extern "C" void lvgl_present_framebuffer(const Framebuffer *fb)
+{
+    if(!fb)
+        fb = GL_get_default_framebuffer();
+    if(g_engine && fb)
+        g_engine->present_framebuffer(fb);
+}
+
+void lvgl_set_game_engine(LvglGameEngine *engine)
+{
+    g_engine = engine;
+}


### PR DESCRIPTION
## Summary
- allocate LVGL canvas in `LvglGameEngine` and add a draw buffer
- add `present_framebuffer` method to copy pixels to the canvas
- expose a small `lvgl_present_framebuffer` API and call it from d3d8 shim

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GetFileAttributes redefinition)*

------
https://chatgpt.com/codex/tasks/task_e_685bed5e4b9c832596b48e3b69022002