### PR TITLE
Implement basic surface and LVGL support

### DIFF
--- a/lib/d3d8_gles/CMakeLists.txt
+++ b/lib/d3d8_gles/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(d3d8_to_gles STATIC ${SOURCES})
     target_link_libraries(d3d8_to_gles PUBLIC
         ${GLESv1_CM_LIBRARY}
         ${EGL_LIBRARY}
+        lvgl
         m)
 endif()
 

--- a/lib/d3d8_gles/include/d3d8_to_gles.h
+++ b/lib/d3d8_gles/include/d3d8_to_gles.h
@@ -5,6 +5,7 @@
 #include "GLES/gl.h"
 #include "GLES/glext.h"
 #include "EGL/egl.h"
+#include <lvgl.h>
 
 #include <limits.h>
 #include <float.h>
@@ -168,6 +169,10 @@ typedef struct {
     DWORD texcoord_index0;
     D3DPRESENT_PARAMETERS present_params;
     D3DDISPLAYMODE display_mode;
+    lv_obj_t *canvas;
+    uint8_t *canvas_buf;
+    size_t canvas_buf_size;
+    struct IDirect3DSurface8 *backbuffer;
 } GLES_Device;
 
 // Vertex/index buffer structure
@@ -412,6 +417,28 @@ struct IDirect3DTexture8 {
     const IDirect3DTexture8Vtbl *lpVtbl;
     GLES_Texture *texture;
     IDirect3DDevice8 *device;
+};
+
+// IDirect3DSurface8 interface
+typedef struct IDirect3DSurface8 IDirect3DSurface8;
+typedef struct {
+    HRESULT (D3DAPI *QueryInterface)(IDirect3DSurface8 *This, REFIID riid, void **ppvObj);
+    ULONG (D3DAPI *AddRef)(IDirect3DSurface8 *This);
+    ULONG (D3DAPI *Release)(IDirect3DSurface8 *This);
+    HRESULT (D3DAPI *GetDevice)(IDirect3DSurface8 *This, IDirect3DDevice8 **ppDevice);
+    HRESULT (D3DAPI *SetPrivateData)(IDirect3DSurface8 *This, REFGUID refguid, CONST void *pData, DWORD SizeOfData, DWORD Flags);
+    HRESULT (D3DAPI *GetPrivateData)(IDirect3DSurface8 *This, REFGUID refguid, void *pData, DWORD *pSizeOfData);
+    HRESULT (D3DAPI *FreePrivateData)(IDirect3DSurface8 *This, REFGUID refguid);
+    HRESULT (D3DAPI *GetContainer)(IDirect3DSurface8 *This, REFIID riid, void **ppContainer);
+    HRESULT (D3DAPI *GetDesc)(IDirect3DSurface8 *This, D3DSURFACE_DESC *pDesc);
+    HRESULT (D3DAPI *LockRect)(IDirect3DSurface8 *This, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags);
+    HRESULT (D3DAPI *UnlockRect)(IDirect3DSurface8 *This);
+} IDirect3DSurface8Vtbl;
+
+struct IDirect3DSurface8 {
+    const IDirect3DSurface8Vtbl *lpVtbl;
+    IDirect3DDevice8 *device;
+    D3DSURFACE_DESC desc;
 };
 
 // D3DX function prototypes


### PR DESCRIPTION
## Summary
- extend internal GLES_Device with LVGL canvas members
- add IDirect3DSurface8 definition
- implement reset/present/back buffer handling
- link d3d8_to_gles against lvgl

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: miscutil.cpp redefinition of GetFileAttributes)*

------
https://chatgpt.com/codex/tasks/task_e_685becd8da188325a1425c7db270dca4