### PR TITLE
Implement minimal X mesh loader

### DIFF
--- a/lib/d3d8_gles/CMakeLists.txt
+++ b/lib/d3d8_gles/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Source files
-set(SOURCES src/d3d8_to_gles.c)
+set(SOURCES src/d3d8_to_gles.c src/x_mesh_parser.c)
 
 if(HEADER_ONLY)
     add_library(d3d8_to_gles INTERFACE)

--- a/lib/d3d8_gles/include/d3d8_to_gles.h
+++ b/lib/d3d8_gles/include/d3d8_to_gles.h
@@ -37,6 +37,9 @@
 #ifndef D3DXERR_SKINNINGNOTSUPPORTED
 #define D3DXERR_SKINNINGNOTSUPPORTED MAKE_DDHRESULT(2903)
 #endif
+#ifndef D3DXERR_INVALIDDATA
+#define D3DXERR_INVALIDDATA MAKE_DDHRESULT(2905)
+#endif
 
 #ifndef D3DADAPTER_DEFAULT
 #define D3DADAPTER_DEFAULT 0
@@ -75,6 +78,11 @@ typedef struct _D3DXATTRIBUTERANGE {
     DWORD VertexStart;
     DWORD VertexCount;
 } D3DXATTRIBUTERANGE;
+
+typedef struct {
+    float x, y, z;
+    float nx, ny, nz;
+} VertexPN;
 
 typedef D3DXATTRIBUTERANGE *LPD3DXATTRIBUTERANGE;
 
@@ -427,6 +435,9 @@ HRESULT WINAPI D3DXCreateTexture(LPDIRECT3DDEVICE8 pDevice, UINT Width, UINT Hei
 HRESULT WINAPI D3DXCreateTextureFromFileExA(LPDIRECT3DDEVICE8 pDevice, LPCSTR pSrcFile, UINT Width, UINT Height, UINT MipLevels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, DWORD Filter, DWORD MipFilter, D3DCOLOR ColorKey, D3DXIMAGE_INFO *pSrcInfo, PALETTEENTRY *pPalette, LPDIRECT3DTEXTURE8 *ppTexture);
 HRESULT WINAPI D3DXLoadSurfaceFromSurface(LPDIRECT3DSURFACE8 pDestSurface, CONST PALETTEENTRY *pDestPalette, CONST RECT *pDestRect, LPDIRECT3DSURFACE8 pSrcSurface, CONST PALETTEENTRY *pSrcPalette, CONST RECT *pSrcRect, DWORD Filter, D3DCOLOR ColorKey);
 HRESULT WINAPI D3DXFilterTexture(LPDIRECT3DBASETEXTURE8 pBaseTexture, CONST PALETTEENTRY *pPalette, UINT SrcLevel, DWORD Filter);
+HRESULT WINAPI D3DXLoadMeshFromX(LPSTR pFilename, DWORD Options, LPDIRECT3DDEVICE8 pD3D,
+                                 LPD3DXBUFFER *ppAdjacency, LPD3DXBUFFER *ppMaterials,
+                                 DWORD *pNumMaterials, LPD3DXMESH *ppMesh);
 
 // Math functions
 D3DXMATRIX* WINAPI D3DXMatrixIdentity(D3DXMATRIX *pOut);

--- a/lib/d3d8_gles/src/d3d8_to_gles.c
+++ b/lib/d3d8_gles/src/d3d8_to_gles.c
@@ -1,5 +1,6 @@
 // src/d3d8_to_gles.c
 #include "d3d8_to_gles.h"
+#include "x_mesh_parser.h"
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -1784,10 +1785,123 @@ HRESULT WINAPI D3DXDeclaratorFromFVF(DWORD FVF,
     return D3D_OK;
 }
 
-typedef struct {
-    float x, y, z; // Position
-    float nx, ny, nz; // Normal
-} VertexPN;
+static HRESULT create_mesh_from_data(LPDIRECT3DDEVICE8 device,
+                                     VertexPN *verts, DWORD vcount,
+                                     WORD *indices, DWORD fcount,
+                                     LPD3DXMESH *pp_mesh) {
+    DWORD fvf = D3DFVF_XYZ | D3DFVF_NORMAL;
+    UINT vb_size = vcount * sizeof(VertexPN);
+    UINT ib_size = fcount * 3 * sizeof(WORD);
+    DWORD options = D3DXMESH_MANAGED;
+
+    IDirect3DVertexBuffer8 *vb;
+    HRESULT hr = device->lpVtbl->CreateVertexBuffer(device, vb_size,
+                                                    D3DUSAGE_WRITEONLY, fvf,
+                                                    D3DPOOL_MANAGED, &vb);
+    if (FAILED(hr)) return hr;
+
+    BYTE *vb_data;
+    hr = vb->lpVtbl->Lock(vb, 0, vb_size, &vb_data, 0);
+    if (SUCCEEDED(hr)) {
+        memcpy(vb_data, verts, vb_size);
+        vb->lpVtbl->Unlock(vb);
+    } else {
+        vb->lpVtbl->Release(vb);
+        return hr;
+    }
+
+    IDirect3DIndexBuffer8 *ib;
+    hr = device->lpVtbl->CreateIndexBuffer(device, ib_size, D3DUSAGE_WRITEONLY,
+                                           D3DFMT_INDEX16, D3DPOOL_MANAGED, &ib);
+    if (FAILED(hr)) {
+        vb->lpVtbl->Release(vb);
+        return hr;
+    }
+
+    BYTE *ib_data;
+    hr = ib->lpVtbl->Lock(ib, 0, ib_size, &ib_data, 0);
+    if (SUCCEEDED(hr)) {
+        memcpy(ib_data, indices, ib_size);
+        ib->lpVtbl->Unlock(ib);
+    } else {
+        vb->lpVtbl->Release(vb);
+        ib->lpVtbl->Release(ib);
+        return hr;
+    }
+
+    ID3DXMesh *mesh = calloc(1, sizeof(ID3DXMesh) + sizeof(ID3DXMeshVtbl));
+    if (!mesh) {
+        vb->lpVtbl->Release(vb);
+        ib->lpVtbl->Release(ib);
+        return D3DERR_OUTOFVIDEOMEMORY;
+    }
+
+    mesh->attrib_table = calloc(1, sizeof(D3DXATTRIBUTERANGE));
+    if (!mesh->attrib_table) {
+        vb->lpVtbl->Release(vb);
+        ib->lpVtbl->Release(ib);
+        free(mesh);
+        return D3DERR_OUTOFVIDEOMEMORY;
+    }
+    mesh->attrib_table[0].AttribId = 0;
+    mesh->attrib_table[0].FaceStart = 0;
+    mesh->attrib_table[0].FaceCount = fcount;
+    mesh->attrib_table[0].VertexStart = 0;
+    mesh->attrib_table[0].VertexCount = vcount;
+    mesh->attrib_table_size = 1;
+
+    mesh->attrib_buffer = calloc(fcount, sizeof(DWORD));
+    if (!mesh->attrib_buffer) {
+        vb->lpVtbl->Release(vb);
+        ib->lpVtbl->Release(ib);
+        free(mesh->attrib_table);
+        free(mesh);
+        return D3DERR_OUTOFVIDEOMEMORY;
+    }
+    for (DWORD i2 = 0; i2 < fcount; i2++) mesh->attrib_buffer[i2] = 0;
+
+    static const ID3DXMeshVtbl mesh_vtbl = {
+        .QueryInterface = d3dx_mesh_query_interface,
+        .AddRef = d3dx_mesh_add_ref,
+        .Release = d3dx_mesh_release,
+        .DrawSubset = d3dx_mesh_draw_subset,
+        .GetNumFaces = d3dx_mesh_get_num_faces,
+        .GetNumVertices = d3dx_mesh_get_num_vertices,
+        .GetFVF = d3dx_mesh_get_fvf,
+        .GetDeclaration = d3dx_mesh_get_declaration,
+        .GetOptions = d3dx_mesh_get_options,
+        .GetDevice = d3dx_mesh_get_device,
+        .CloneMeshFVF = d3dx_mesh_clone_mesh_fvf,
+        .CloneMesh = d3dx_mesh_clone_mesh,
+        .GetVertexBuffer = d3dx_mesh_get_vertex_buffer,
+        .GetIndexBuffer = d3dx_mesh_get_index_buffer,
+        .LockVertexBuffer = d3dx_mesh_lock_vertex_buffer,
+        .UnlockVertexBuffer = d3dx_mesh_unlock_vertex_buffer,
+        .LockIndexBuffer = d3dx_mesh_lock_index_buffer,
+        .UnlockIndexBuffer = d3dx_mesh_unlock_index_buffer,
+        .GetAttributeTable = d3dx_mesh_get_attribute_table,
+        .ConvertPointRepsToAdjacency = d3dx_mesh_convert_point_reps_to_adjacency,
+        .ConvertAdjacencyToPointReps = d3dx_mesh_convert_adjacency_to_point_reps,
+        .GenerateAdjacency = d3dx_mesh_generate_adjacency,
+        .LockAttributeBuffer = d3dx_mesh_lock_attribute_buffer,
+        .UnlockAttributeBuffer = d3dx_mesh_unlock_attribute_buffer,
+        .Optimize = d3dx_mesh_optimize,
+        .OptimizeInplace = d3dx_mesh_optimize_inplace
+    };
+
+    mesh->pVtbl = &mesh_vtbl;
+    mesh->device = device;
+    mesh->vb = vb;
+    mesh->ib = ib;
+    mesh->num_vertices = vcount;
+    mesh->num_faces = fcount;
+    mesh->fvf = fvf;
+    mesh->options = options;
+
+    *pp_mesh = mesh;
+    return D3D_OK;
+}
+
 
 HRESULT WINAPI D3DXCreateBox(LPDIRECT3DDEVICE8 pDevice, FLOAT Width, FLOAT Height, FLOAT Depth, LPD3DXMESH *ppMesh, LPD3DXBUFFER *ppAdjacency) {
     if (!pDevice || Width <= 0.0f || Height <= 0.0f || Depth <= 0.0f || !ppMesh) return D3DERR_INVALIDCALL;
@@ -2455,7 +2569,64 @@ HRESULT WINAPI D3DXComputeNormals(LPD3DXBASEMESH pMesh, CONST DWORD *pAdjacency)
     mesh->pVtbl->UnlockVertexBuffer(mesh);
     return D3D_OK;
 }
-HRESULT WINAPI D3DXLoadMeshFromX(LPSTR pFilename, DWORD Options, LPDIRECT3DDEVICE8 pD3D, LPD3DXBUFFER *ppAdjacency, LPD3DXBUFFER *ppMaterials, DWORD *pNumMaterials, LPD3DXMESH *ppMesh) { return D3DXERR_NOTAVAILABLE; }
+
+// Load mesh from an .x file using the minimal parser
+HRESULT WINAPI D3DXLoadMeshFromX(LPSTR filename, DWORD Options,
+                                 LPDIRECT3DDEVICE8 device,
+                                 LPD3DXBUFFER *ppAdjacency,
+                                 LPD3DXBUFFER *ppMaterials,
+                                 DWORD *pNumMaterials,
+                                 LPD3DXMESH *ppMesh) {
+    (void)Options;
+    if (!filename || !device || !ppMesh) return D3DERR_INVALIDCALL;
+
+    FILE *f = fopen(filename, "rb");
+    if (!f) return D3DXERR_INVALIDDATA;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0) { fclose(f); return D3DXERR_INVALIDDATA; }
+    BYTE *data = malloc(size);
+    if (!data) { fclose(f); return D3DERR_OUTOFVIDEOMEMORY; }
+    if (fread(data, 1, size, f) != (size_t)size) {
+        fclose(f); free(data); return D3DXERR_INVALIDDATA; }
+    fclose(f);
+
+    VertexPN *verts = NULL; WORD *indices = NULL; DWORD vcount = 0, fcount = 0;
+    HRESULT hr;
+    if (size > 16 && memcmp(data, "xof ", 4) == 0 &&
+        (memcmp(data + 8, "txt", 3) == 0 || memcmp(data + 8, "bin", 3) == 0)) {
+        const char *head = (const char *)data + 16;
+        if (memcmp(data + 8, "txt", 3) == 0)
+            hr = parse_text_mesh(head, &verts, &vcount, &indices, &fcount);
+        else
+            hr = parse_binary_mesh((const BYTE *)head, size - 16, &verts, &vcount,
+                                   &indices, &fcount);
+    } else {
+        hr = parse_text_mesh((const char *)data, &verts, &vcount, &indices, &fcount);
+    }
+    free(data);
+    if (FAILED(hr)) return hr;
+
+    hr = create_mesh_from_data(device, verts, vcount, indices, fcount, ppMesh);
+    free(verts);
+    free(indices);
+    if (FAILED(hr)) return hr;
+
+    if (ppAdjacency) {
+        hr = D3DXCreateBuffer(fcount * 3 * sizeof(DWORD), ppAdjacency);
+        if (SUCCEEDED(hr)) {
+            DWORD *adj = (DWORD *)(*ppAdjacency)->pVtbl->GetBufferPointer(*ppAdjacency);
+            memset(adj, 0xFFFFFFFF, fcount * 3 * sizeof(DWORD));
+        }
+    }
+    if (ppMaterials) *ppMaterials = NULL;
+    if (pNumMaterials) *pNumMaterials = 0;
+
+    D3DXComputeNormals(*ppMesh, NULL);
+    return D3D_OK;
+}
+
 HRESULT WINAPI D3DXCreateSkinMesh(DWORD NumFaces, DWORD NumVertices, DWORD NumBones, DWORD Options, CONST DWORD *pDeclaration, LPDIRECT3DDEVICE8 pD3D, LPD3DXSKINMESH *ppSkinMesh) { return D3DXERR_SKINNINGNOTSUPPORTED; }
 HRESULT WINAPI D3DXCreateSkinMeshFVF(DWORD NumFaces, DWORD NumVertices, DWORD NumBones, DWORD Options, DWORD FVF, LPDIRECT3DDEVICE8 pD3D, LPD3DXSKINMESH *ppSkinMesh) { return D3DXERR_SKINNINGNOTSUPPORTED; }
 

--- a/lib/d3d8_gles/src/x_mesh_parser.c
+++ b/lib/d3d8_gles/src/x_mesh_parser.c
@@ -1,0 +1,163 @@
+#include "d3d8_to_gles.h"
+#include "x_mesh_parser.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+
+static void skip_sep(const char **p) {
+    while (**p && (isspace((unsigned char)**p) || **p == ',' || **p == ';'))
+        (*p)++;
+}
+
+static int parse_uint(const char **p, DWORD *out) {
+    skip_sep(p);
+    if (!**p) return 0;
+    *out = (DWORD)strtoul(*p, (char **)p, 10);
+    skip_sep(p);
+    return 1;
+}
+
+static int parse_float(const char **p, float *out) {
+    skip_sep(p);
+    if (!**p) return 0;
+    *out = strtof(*p, (char **)p);
+    skip_sep(p);
+    return 1;
+}
+
+HRESULT parse_text_mesh(const char *text, VertexPN **pp_vertices,
+                             DWORD *p_vcount, WORD **pp_indices,
+                             DWORD *p_fcount) {
+    const char *p = strstr(text, "Mesh");
+    if (!p) return D3DXERR_INVALIDDATA;
+    p = strchr(p, '{');
+    if (!p) return D3DXERR_INVALIDDATA;
+    p++;
+
+    DWORD vcount;
+    if (!parse_uint(&p, &vcount) || vcount == 0) return D3DXERR_INVALIDDATA;
+    VertexPN *verts = calloc(vcount, sizeof(VertexPN));
+    if (!verts) return D3DERR_OUTOFVIDEOMEMORY;
+
+    for (DWORD i = 0; i < vcount; i++) {
+        if (!parse_float(&p, &verts[i].x) ||
+            !parse_float(&p, &verts[i].y) ||
+            !parse_float(&p, &verts[i].z)) {
+            free(verts);
+            return D3DXERR_INVALIDDATA;
+        }
+        if (i + 1 < vcount) {
+            const char *c = strchr(p, ',');
+            if (c) p = c + 1;
+        }
+    }
+    const char *semi = strchr(p, ';');
+    if (semi) p = semi + 1;
+    skip_sep(&p);
+
+    DWORD fcount;
+    if (!parse_uint(&p, &fcount) || fcount == 0) { free(verts); return D3DXERR_INVALIDDATA; }
+    WORD *indices = calloc(fcount * 3, sizeof(WORD));
+    if (!indices) { free(verts); return D3DERR_OUTOFVIDEOMEMORY; }
+
+    for (DWORD f = 0; f < fcount; f++) {
+        DWORD n;
+        if (!parse_uint(&p, &n) || n != 3) { free(verts); free(indices); return D3DXERR_INVALIDDATA; }
+        DWORD i0,i1,i2;
+        if (!parse_uint(&p,&i0) || !parse_uint(&p,&i1) || !parse_uint(&p,&i2)) {
+            free(verts); free(indices); return D3DXERR_INVALIDDATA; }
+        indices[f*3+0] = (WORD)i0;
+        indices[f*3+1] = (WORD)i1;
+        indices[f*3+2] = (WORD)i2;
+        const char *s2 = strchr(p, ';');
+        if (s2) p = s2 + 1;
+        skip_sep(&p);
+    }
+
+    // Optional normals
+    const char *norm = strstr(p, "MeshNormals");
+    if (norm) {
+        p = strchr(norm, '{');
+        if (p) {
+            p++;
+            DWORD n_norm;
+            if (parse_uint(&p, &n_norm)) {
+                for (DWORD i = 0; i < n_norm && i < vcount; i++) {
+                    parse_float(&p, &verts[i].nx);
+                    parse_float(&p, &verts[i].ny);
+                    parse_float(&p, &verts[i].nz);
+                    const char *c = strchr(p, ';');
+                    if (c) p = c + 1;
+                }
+            }
+        }
+    }
+
+    *pp_vertices = verts;
+    *p_vcount = vcount;
+    *pp_indices = indices;
+    *p_fcount = fcount;
+    return D3D_OK;
+}
+
+static uint32_t read_u32(const BYTE **p) {
+    uint32_t v;
+    memcpy(&v, *p, 4);
+    *p += 4;
+    return v;
+}
+
+static float read_f32(const BYTE **p) {
+    float v;
+    memcpy(&v, *p, 4);
+    *p += 4;
+    return v;
+}
+
+HRESULT parse_binary_mesh(const BYTE *data, size_t size,
+                                 VertexPN **pp_vertices, DWORD *p_vcount,
+                                 WORD **pp_indices, DWORD *p_fcount) {
+    const BYTE *p = data;
+    if (size < 4) return D3DXERR_INVALIDDATA;
+    DWORD vcount = read_u32(&p);
+    if (vcount == 0 || size < 4 + vcount * 12) return D3DXERR_INVALIDDATA;
+    VertexPN *verts = calloc(vcount, sizeof(VertexPN));
+    if (!verts) return D3DERR_OUTOFVIDEOMEMORY;
+    for (DWORD i = 0; i < vcount; i++) {
+        verts[i].x = read_f32(&p);
+        verts[i].y = read_f32(&p);
+        verts[i].z = read_f32(&p);
+    }
+    if (p >= data + size) { free(verts); return D3DXERR_INVALIDDATA; }
+    DWORD fcount = read_u32(&p);
+    if (fcount == 0 || size < (p - data) + fcount * 4 * 4) {
+        free(verts);
+        return D3DXERR_INVALIDDATA;
+    }
+    WORD *indices = calloc(fcount * 3, sizeof(WORD));
+    if (!indices) { free(verts); return D3DERR_OUTOFVIDEOMEMORY; }
+    for (DWORD f = 0; f < fcount; f++) {
+        DWORD n = read_u32(&p);
+        if (n != 3) { free(verts); free(indices); return D3DXERR_INVALIDDATA; }
+        indices[f*3+0] = (WORD)read_u32(&p);
+        indices[f*3+1] = (WORD)read_u32(&p);
+        indices[f*3+2] = (WORD)read_u32(&p);
+    }
+    if (p + 4 <= data + size) {
+        DWORD n_norm = read_u32(&p);
+        for (DWORD i = 0; i < n_norm && i < vcount; i++) {
+            verts[i].nx = read_f32(&p);
+            verts[i].ny = read_f32(&p);
+            verts[i].nz = read_f32(&p);
+        }
+    }
+    *pp_vertices = verts;
+    *p_vcount = vcount;
+    *pp_indices = indices;
+    *p_fcount = fcount;
+    return D3D_OK;
+}
+
+

--- a/lib/d3d8_gles/src/x_mesh_parser.h
+++ b/lib/d3d8_gles/src/x_mesh_parser.h
@@ -1,0 +1,11 @@
+#ifndef X_MESH_PARSER_H
+#define X_MESH_PARSER_H
+#include "d3d8_to_gles.h"
+#include <stddef.h>
+
+HRESULT parse_text_mesh(const char *text, VertexPN **pp_vertices,
+                        DWORD *p_vcount, WORD **pp_indices, DWORD *p_fcount);
+HRESULT parse_binary_mesh(const BYTE *data, size_t size, VertexPN **pp_vertices,
+                          DWORD *p_vcount, WORD **pp_indices, DWORD *p_fcount);
+
+#endif

--- a/migration.md
+++ b/migration.md
@@ -315,6 +315,8 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
   D3DXCreateTextureFromFileExA, D3DXLoadSurfaceFromSurface and D3DXFilterTexture.
 - Added D3DXVec3Transform and D3DXComputeBoundingBox implementations in the
   d3d8_gles shim.
+- Implemented a minimal D3DXLoadMeshFromX loader capable of parsing text and
+  binary .x meshes for positions and normals only.
 - Removed unused Win32 headers from `lvgl_device/common` and deleted the old
   `Win32BIGFile*.cpp.disabled` sources. `LvglLocalFileSystem` now calls
   `std::filesystem` directly for directory creation and existence checks.


### PR DESCRIPTION
## Summary
- add `D3DXLoadMeshFromX` prototype and error code to headers
- implement basic text/binary .x mesh parsing
- create vertex/index buffers from parsed data
- expose helper to build an `ID3DXMesh`
- document progress in `migration.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: miscutil.cpp ambiguous declaration)*
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_685bed0ed6148325b2a18ff18a482683