### PR TITLE
Implement caps lock state for LVGL keyboard

### DIFF
--- a/include/game_engine_device/lvgl_device/game_client/lvglkeyboard.h
+++ b/include/game_engine_device/lvgl_device/game_client/lvglkeyboard.h
@@ -19,4 +19,5 @@ protected:
 
 private:
     lv_indev_t *m_indev;
+    Bool m_caps_state;
 };

--- a/lib/lvgl/src/core/lv_group.h
+++ b/lib/lvgl/src/core/lv_group.h
@@ -35,6 +35,7 @@ typedef enum {
     LV_KEY_PREV      = 11,  /*0x0B, '*/
     LV_KEY_HOME      = 2,   /*0x02, STX*/
     LV_KEY_END       = 3,   /*0x03, ETX*/
+    LV_KEY_CAPS_LOCK = 21,
 } lv_key_t;
 
 /**********************

--- a/lib/lvgl/src/drivers/sdl/lv_sdl_keyboard.c
+++ b/lib/lvgl/src/drivers/sdl/lv_sdl_keyboard.c
@@ -210,6 +210,9 @@ static uint32_t keycode_to_ctrl_key(SDL_Keycode sdl_key)
         case SDLK_END:
             return LV_KEY_END;
 
+        case SDLK_CAPSLOCK:
+            return LV_KEY_CAPS_LOCK;
+
         default:
             return '\0';
     }

--- a/migration.md
+++ b/migration.md
@@ -167,6 +167,8 @@ are now detected and `convert_lv_key()` translates every key listed in
 `KeyDefs.h`, matching the behaviour of `Win32DIKeyboard`.  The new
 `lvglDevice` library now lives under `src/game_engine_device/lvgl_device` and is
 linked unconditionally from `src/CMakeLists.txt`.
+Caps Lock state is now tracked inside `LvglKeyboard` using `lv_indev_get_key()`
+so text entry mirrors the Win32 behaviour.
 
 Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sensitive buil
 - The W3D device common files (radar, convert and factory helpers) now live under `src/game_engine_device/w3d_device/Common` with their headers available in `include/game_engine_device/w3d_device`. Basic player management classes have been moved to `src/game_engine/common/RTS` and corresponding headers under `include/GameEngine/Common`.

--- a/src/game_engine_device/lvgl_device/game_client/lvgl_keyboard.cpp
+++ b/src/game_engine_device/lvgl_device/game_client/lvgl_keyboard.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 
 LvglKeyboard::LvglKeyboard()
-    : m_indev(nullptr)
+    : m_indev(nullptr), m_caps_state(FALSE)
 {
 }
 
@@ -28,6 +28,7 @@ static UnsignedByte convert_lv_key(uint32_t k)
         case LV_KEY_PREV:      return KEY_TAB;
         case LV_KEY_HOME:      return KEY_HOME;
         case LV_KEY_END:       return KEY_END;
+        case LV_KEY_CAPS_LOCK: return KEY_CAPS;
         default: break;
     }
 
@@ -119,7 +120,7 @@ void LvglKeyboard::update()
 
 Bool LvglKeyboard::getCapsState()
 {
-    return FALSE;
+    return m_caps_state;
 }
 
 void LvglKeyboard::getKey(KeyboardIO *key)
@@ -148,6 +149,9 @@ void LvglKeyboard::getKey(KeyboardIO *key)
         return;
 
     key->key = convert_lv_key(data.key);
+    if(data.key == LV_KEY_CAPS_LOCK && data.state == LV_INDEV_STATE_PRESSED)
+        m_caps_state = !m_caps_state;
+
     key->state = (data.state == LV_INDEV_STATE_PRESSED) ? KEY_STATE_DOWN : KEY_STATE_UP;
     key->sequence = lv_tick_get();
 


### PR DESCRIPTION
## Summary
- extend LVGL key enum with `LV_KEY_CAPS_LOCK`
- detect `SDLK_CAPSLOCK` in `lv_sdl_keyboard` and expose `LV_KEY_CAPS_LOCK`
- toggle a new member inside `LvglKeyboard` when that key is pressed
- return this flag from `getCapsState`
- document the change in `migration.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ambiguating new declaration of `GetFileAttributes`)*

------
https://chatgpt.com/codex/tasks/task_e_685bed24688483258a4de61b30b20657