### PR TITLE
Fix SDL2 headers not exported to lvgl

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -65,6 +65,7 @@ target_include_directories(lvgl PUBLIC
 
 if(LVGL_USE_SDL)
     target_link_libraries(lvgl PUBLIC SDL2::SDL2)
+    target_include_directories(lvgl PUBLIC ${SDL2_INCLUDE_DIRS})
     target_compile_definitions(lvgl PUBLIC LV_USE_SDL=1)
 endif()
 

--- a/migration.md
+++ b/migration.md
@@ -328,3 +328,4 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - Removed unused Win32 headers from `lvgl_device/common` and deleted the old
   `Win32BIGFile*.cpp.disabled` sources. `LvglLocalFileSystem` now calls
   `std::filesystem` directly for directory creation and existence checks.
+- CMake now exports SDL2 include directories for LVGL so SDL.h resolves on macOS.


### PR DESCRIPTION
## Summary
- add SDL2_INCLUDE_DIRS to lvgl target
- document SDL2 include path fix

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: 'Atan2' is not a member of 'WWMath')*

------
https://chatgpt.com/codex/tasks/task_e_685c0b0ba49c83259d086820a0e33a45