### PR TITLE
Merge codex modify display mode

### DIFF
--- a/lib/d3d8_gles/src/d3d8_to_gles.c
+++ b/lib/d3d8_gles/src/d3d8_to_gles.c
@@ -252,8 +252,14 @@ UINT WINAPI D3DXGetFVFVertexSize(DWORD FVF);
 HRESULT WINAPI D3DXDeclaratorFromFVF(DWORD FVF,
                                      DWORD Declaration[MAX_FVF_DECL_SIZE]);
 
-// Last created device's display mode for adapter queries
-static D3DDISPLAYMODE g_current_display_mode;
+// Last created device's display mode for adapter queries. Initialise with a
+// sane default so adapter queries succeed before any device is created.
+static D3DDISPLAYMODE g_current_display_mode = {
+    800,        /* Width */
+    600,        /* Height */
+    60,         /* RefreshRate */
+    D3DFMT_X8R8G8B8 /* Format */
+};
 
 static float dword_to_float(DWORD v) {
   union {


### PR DESCRIPTION
## Summary
- initialize a default display mode structure for adapter queries
- leave `d3d8_get_adapter_display_mode` returning the current mode

## Testing
- `cmake -S . -B build`
- `cmake --build build --target d3d8_to_gles`


------
https://chatgpt.com/codex/tasks/task_e_685c2ce629d083258396deec6f241e09