### PR TITLE
Fix LVGL SDL2 linking on macOS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -67,6 +67,12 @@ if(LVGL_USE_SDL)
     target_link_libraries(lvgl PUBLIC SDL2::SDL2)
     target_include_directories(lvgl PUBLIC ${SDL2_INCLUDE_DIRS})
     target_compile_definitions(lvgl PUBLIC LV_USE_SDL=1)
+    if(APPLE)
+        # When SDL2 is installed as a framework on macOS, CMake's package
+        # configuration may not inject the required "-framework SDL2" linker
+        # option.  Add it explicitly so lvgl links correctly.
+        target_link_options(lvgl PUBLIC "-framework" "SDL2")
+    endif()
 endif()
 
 if(LVGL_USE_X11)

--- a/migration.md
+++ b/migration.md
@@ -329,3 +329,5 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
   `Win32BIGFile*.cpp.disabled` sources. `LvglLocalFileSystem` now calls
   `std::filesystem` directly for directory creation and existence checks.
 - CMake now exports SDL2 include directories for LVGL so SDL.h resolves on macOS.
+- macOS builds now link the LVGL library against the SDL2 framework
+  (`-framework SDL2`) when the SDL backend is enabled.


### PR DESCRIPTION
## Summary
- add explicit `-framework SDL2` linker flag for macOS LVGL builds
- document SDL2 framework handling in `migration.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j1` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685c2fbbca648325b1d9167beeed316e