### PR TITLE
Document SDL2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ On **macOS** you must use the Apple Clang compiler (usually `/usr/bin/clang`).
 Using GCC will fail because the audio backend requires Clang's `-fblocks`
 extension when compiling against CoreAudio headers.
 
+The LVGL examples rely on the SDL2 development headers. Install them via your
+package manager (for example `apt install libsdl2-dev` on Linux or `brew install sdl2`
+on macOS) and enable the backend with `-DLVGL_USE_SDL=ON` if not already
+configured.  If SDL2 is in a non-standard location set `CMAKE_PREFIX_PATH` so
+that `find_package(SDL2)` can locate `SDL2/SDL.h`.
+
 NOTE: As modern versions of MSVC enforce newer revisions of the C++ standard, you will need to make extensive changes to the codebase before it successfully compiles, even more so if you plan on compiling for the Win64 platform.
 
 When the workspace has finished building, the compiled binaries will be copied to the folder called `/Run/` found in the root of each games directory. 

--- a/lib/lvgl/lv_conf.h
+++ b/lib/lvgl/lv_conf.h
@@ -7,6 +7,11 @@
 #ifndef LV_USE_SDL
 #define LV_USE_SDL 1
 #endif
+#if LV_USE_SDL
+#ifndef LV_SDL_INCLUDE_PATH
+#define LV_SDL_INCLUDE_PATH <SDL2/SDL.h>
+#endif
+#endif
 #ifndef LV_USE_X11
 #define LV_USE_X11 0
 #endif

--- a/migration.md
+++ b/migration.md
@@ -325,4 +325,4 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
   `std::filesystem` directly for directory creation and existence checks.
 - CMake now exports SDL2 include directories for LVGL so SDL.h resolves on macOS.
 - macOS builds now link the LVGL library against the SDL2 framework
-  (`-framework SDL2`) when the SDL backend is enabled.
+- lv_conf.h now defines LV_SDL_INCLUDE_PATH ensuring SDL2 headers are found. README explains installing SDL2 development packages.


### PR DESCRIPTION
## Summary
- define `LV_SDL_INCLUDE_PATH` in `lv_conf.h`
- explain SDL2 headers requirement in README
- note SDL2 include path definition in migration log

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685c35f802048325805d0bf2a833d32b