### PR TITLE
Add microGLES initialization option

### DIFF
--- a/lib/d3d8_gles/README.md
+++ b/lib/d3d8_gles/README.md
@@ -34,6 +34,12 @@ To enable debug logging, set the `ENABLE_LOGGING` option:
 cmake -DENABLE_LOGGING=ON ..
 ```
 
+To use the software renderer provided by `lib/u_gles` and bypass EGL setup,
+enable the `USE_MICROGLES` option at configure time:
+```bash
+cmake -DUSE_MICROGLES=ON ..
+```
+
 The build produces a static library (`libd3d8_to_gles.a`) in `build/`.
 
 ## Usage


### PR DESCRIPTION
## Summary
- add `USE_MICROGLES` option to d3d8_gles
- skip EGL setup when `USE_MICROGLES` is enabled and initialise through `GL_init_with_framebuffer`
- document the new option in d3d8_gles README

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: Atan2 is not a member of WWMath)*
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_685c56e2523883258a963b06c7e14c9d