### PR TITLE
Fix Atan2 header issue

### DIFF
--- a/include/libraries/ww_vegas/ww_lib/always.h
+++ b/include/libraries/ww_vegas/ww_lib/always.h
@@ -201,23 +201,26 @@ public:
 #undef max
 #endif
 
+#ifndef WW_ALWAYS_MINMAX
+#define WW_ALWAYS_MINMAX
 template <class T> T min(T a,T b)
 {
-	if (a<b) {
-		return a;
-	} else {
-		return b;
-	}
+        if (a<b) {
+                return a;
+        } else {
+                return b;
+        }
 }
 
 template <class T> T max(T a,T b)
 {
-	if (a>b) {
-		return a;
-	} else {
-		return b;
-	}
+        if (a>b) {
+                return a;
+        } else {
+                return b;
+        }
 }
+#endif
 
 
 /*

--- a/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(ww3d2 STATIC ${WW3D2_SRCS})
 target_include_directories(ww3d2 PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_3d2
-    ${PROJECT_SOURCE_DIR}/src/tools/ww3d/pluglib)
+    ${PROJECT_SOURCE_DIR}/src/tools/WW3D/pluglib)
 
 target_link_libraries(ww3d2 PUBLIC
     wwlib

--- a/src/libraries/ww_vegas/ww_3d2/rendobj.h
+++ b/src/libraries/ww_vegas/ww_3d2/rendobj.h
@@ -213,7 +213,7 @@ public:
 
 	RenderObjClass(void);
 	RenderObjClass(const RenderObjClass & src);
-	RenderObjClass & RenderObjClass::operator = (const RenderObjClass &);
+        RenderObjClass & operator = (const RenderObjClass &);
 	virtual ~RenderObjClass(void)																					{ }
 
 

--- a/src/tools/WW3D/pluglib/always.h
+++ b/src/tools/WW3D/pluglib/always.h
@@ -37,8 +37,10 @@
 #pragma once
 #endif // _MSC_VER >= 1000
 
-#ifndef ALWAYS_H
-#define ALWAYS_H
+#ifndef PLUGLIB_ALWAYS_H
+#define PLUGLIB_ALWAYS_H
+
+#include <always.h>
 
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #pragma warning(disable : 4530)
@@ -113,23 +115,26 @@ void* __cdecl operator new(unsigned int s);
 #undef max
 #endif
 
+#ifndef WW_ALWAYS_MINMAX
+#define WW_ALWAYS_MINMAX
 template <class T> T min(T a,T b)
 {
-	if (a<b) {
-		return a;
-	} else {
-		return b;
-	}
+        if (a<b) {
+                return a;
+        } else {
+                return b;
+        }
 }
 
 template <class T> T max(T a,T b)
 {
-	if (a>b) {
-		return a;
-	} else {
-		return b;
-	}
+        if (a>b) {
+                return a;
+        } else {
+                return b;
+        }
 }
+#endif
 
 
 /*
@@ -167,4 +172,4 @@ template <class T> T max(T a,T b)
 #endif
 
 
-#endif
+#endif // PLUGLIB_ALWAYS_H

--- a/src/tools/WW3D/pluglib/wwmath.h
+++ b/src/tools/WW3D/pluglib/wwmath.h
@@ -42,7 +42,7 @@
 #ifndef WWMATH_H
 #define WWMATH_H
 
-#include "always.h"
+#include <always.h>
 #include <math.h>
 #include <assert.h>
 
@@ -91,7 +91,9 @@ public:
 
 static float		Fabs(float val) { return (float)fabs(val); }
 static float		Sqrt(float val) { return (float)sqrt(val); }
-static float		Inv_Sqrt(float val) { return 1.0f / (float)sqrt(val); }
+static float            Inv_Sqrt(float val) { return 1.0f / (float)sqrt(val); }
+static float            Atan(float x) { return static_cast<float>(atan(x)); }
+static float            Atan2(float y,float x) { return static_cast<float>(atan2(y,x)); }
 static float		Sign(float val);
 static float		Floor(float val) { return (float)floor(val); }
 static bool			Fast_Is_Float_Positive(const float & val);


### PR DESCRIPTION
## Summary
- correct header collisions by renaming pluglib's include guard
- centralise always.h usage and prevent duplicate min/max templates
- remove extra qualifier from `RenderObjClass` assignment operator

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: Matrix3 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c61ea07b8832583f291fafc9c85d7