### PR TITLE
Fix include paths and cmake directories

### DIFF
--- a/include/libraries/ww_vegas/ww_math/matrix3d.h
+++ b/include/libraries/ww_vegas/ww_math/matrix3d.h
@@ -89,7 +89,7 @@
 #include "osdep.h"
 #endif
 
-#include "always.h"
+#include "libraries/ww_vegas/ww_lib/always.h"
 #include <assert.h>
 #include "vector2.h"
 #include "vector3.h"

--- a/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_3d2/CMakeLists.txt
@@ -1,9 +1,11 @@
 file(GLOB WW3D2_SRCS CONFIGURE_DEPENDS *.cpp)
 add_library(ww3d2 STATIC ${WW3D2_SRCS})
 target_include_directories(ww3d2 PUBLIC
+    ${PROJECT_SOURCE_DIR}/src/tools/WW3D/pluglib
+    ${PROJECT_SOURCE_DIR}/src/tools/ww_3d/pluglib
     ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_3d2
-    ${PROJECT_SOURCE_DIR}/src/tools/WW3D/pluglib)
+    ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_lib
+    ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_3d2)
 
 target_link_libraries(ww3d2 PUBLIC
     wwlib

--- a/src/libraries/ww_vegas/ww_3d2/animatedsoundmgr.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/animatedsoundmgr.cpp
@@ -39,7 +39,7 @@
 
 #include <string.h>	// stricmp()
 #include "animatedsoundmgr.h"
-#include "common/ini.h"
+#include "game_engine/common/ini.h"
 #include "inisup.h"
 #include "ffactory.h"
 #include "wwfile.h"

--- a/src/libraries/ww_vegas/ww_3d2/camera.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/camera.cpp
@@ -70,7 +70,7 @@
 
 #include "camera.h"
 #include "ww3d.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "dx8wrapper.h"
 
 

--- a/src/libraries/ww_vegas/ww_3d2/camera.h
+++ b/src/libraries/ww_vegas/ww_3d2/camera.h
@@ -53,7 +53,7 @@
 #include "frustum.h"
 #include "obbox.h"
 #include "vector2.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "colmath.h"
 
 class RenderInfoClass;

--- a/src/libraries/ww_vegas/ww_3d2/dazzle.h
+++ b/src/libraries/ww_vegas/ww_3d2/dazzle.h
@@ -31,7 +31,7 @@
 #include "proto.h"
 #include "w3derr.h"
 #include "shader.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 
 class CameraClass;
 class DazzleVisibilityClass;

--- a/src/libraries/ww_vegas/ww_3d2/decalsys.h
+++ b/src/libraries/ww_vegas/ww_3d2/decalsys.h
@@ -45,7 +45,7 @@
 
 #include "always.h"
 #include "matrix3d.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "obbox.h"
 #include "robjlist.h"
 #include "matpass.h"

--- a/src/libraries/ww_vegas/ww_3d2/dx8wrapper.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/dx8wrapper.cpp
@@ -47,7 +47,7 @@
 #include "ww3d.h"
 #include "camera.h"
 #include "wwstring.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "vertmaterial.h"
 #include "rddesc.h"
 #include "lightenvironment.h"

--- a/src/libraries/ww_vegas/ww_3d2/dx8wrapper.h
+++ b/src/libraries/ww_vegas/ww_3d2/dx8wrapper.h
@@ -46,7 +46,7 @@
 #include "always.h"
 #include "dllist.h"
 #include "d3d8.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "statistics.h"
 #include "wwstring.h"
 #include "lightenvironment.h"

--- a/src/libraries/ww_vegas/ww_3d2/matinfo.h
+++ b/src/libraries/ww_vegas/ww_3d2/matinfo.h
@@ -236,7 +236,7 @@ inline int MaterialInfoClass::Add_Vertex_Material(VertexMaterialClass * vmat)
 inline int MaterialInfoClass::Get_Vertex_Material_Index(const char * name)
 {
 	for (int i=0; i<VertexMaterials.Count(); i++) {
-		if (stricmp(name,VertexMaterials[i]->Get_Name()) == 0) {
+		if (strcasecmp(name,VertexMaterials[i]->Get_Name()) == 0) {
 			return i;
 		}
 	}

--- a/src/libraries/ww_vegas/ww_3d2/matrixmapper.h
+++ b/src/libraries/ww_vegas/ww_3d2/matrixmapper.h
@@ -42,7 +42,7 @@
 
 #include "always.h"
 #include "bittype.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "mapper.h"
 
 // Modified to use DX 8 texture matrices

--- a/src/libraries/ww_vegas/ww_3d2/pointgr.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/pointgr.cpp
@@ -76,7 +76,7 @@
 #include "texture.h"
 #include "vector.h"
 #include "vp.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "dx8wrapper.h"
 #include "dx8vertexbuffer.h"
 #include "dx8indexbuffer.h"

--- a/src/libraries/ww_vegas/ww_3d2/projector.h
+++ b/src/libraries/ww_vegas/ww_3d2/projector.h
@@ -41,7 +41,7 @@
 
 #include "always.h"
 #include "matrix3d.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "aabox.h"
 #include "obbox.h"
 

--- a/src/libraries/ww_vegas/ww_3d2/render2d.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/render2d.cpp
@@ -39,7 +39,7 @@
 #include "font3d.h"
 #include "rect.h"
 #include "texture.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "matrix3d.h"
 #include "dx8wrapper.h"
 #include "dx8indexbuffer.h"

--- a/src/libraries/ww_vegas/ww_3d2/rinfo.h
+++ b/src/libraries/ww_vegas/ww_3d2/rinfo.h
@@ -50,7 +50,7 @@
 #include "shader.h"
 #include "vector.h"
 #include "matrix3d.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 
 
 class MaterialPassClass;

--- a/src/libraries/ww_vegas/ww_3d2/shader.h
+++ b/src/libraries/ww_vegas/ww_3d2/shader.h
@@ -44,7 +44,7 @@
 
 #include "always.h"
 
-#if defined (SR_OS_SOLARIS)
+#ifdef PASS_MAX
 #undef PASS_MAX
 #endif
 

--- a/src/libraries/ww_vegas/ww_3d2/sr_util.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/sr_util.cpp
@@ -45,7 +45,7 @@
 #include "sr_util.h"
 #include "wwdebug.h"
 #include "camera.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 
 #ifdef WW3D_DX8
 

--- a/src/libraries/ww_vegas/ww_3d2/texproject.h
+++ b/src/libraries/ww_vegas/ww_3d2/texproject.h
@@ -45,7 +45,7 @@
 
 #include "always.h"
 #include "matrix3d.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "obbox.h"
 #include "matpass.h"
 #include "matrixmapper.h"

--- a/src/libraries/ww_vegas/ww_3d2/vertmaterial.h
+++ b/src/libraries/ww_vegas/ww_3d2/vertmaterial.h
@@ -269,7 +269,7 @@ private:
 	** Apply the render states corresponding to a NULL vetex material to D3D
 	*/
 	static void			Apply_Null(void);
-	unsigned long		VertexMaterialClass::Compute_CRC(void) const;
+	unsigned long		Compute_CRC(void) const;
 
 	static VertexMaterialClass *Presets[PRESET_COUNT];
 };

--- a/src/libraries/ww_vegas/ww_3d2/visrasterizer.h
+++ b/src/libraries/ww_vegas/ww_3d2/visrasterizer.h
@@ -45,7 +45,7 @@
 
 #include "always.h"
 #include "matrix3d.h"
-#include "matrix4.h"
+#include "libraries/ww_vegas/ww_math/matrix4.h"
 #include "vector3i.h"
 #include "vector3.h"
 #include "simplevec.h"

--- a/src/libraries/ww_vegas/ww_math/CMakeLists.txt
+++ b/src/libraries/ww_vegas/ww_math/CMakeLists.txt
@@ -5,7 +5,10 @@ file(GLOB WWMATH_SRCS CONFIGURE_DEPENDS
 add_library(wwmath STATIC ${WWMATH_SRCS})
 
 target_include_directories(wwmath PUBLIC
+    ${PROJECT_SOURCE_DIR}/src/tools/WW3D/pluglib
+    ${PROJECT_SOURCE_DIR}/src/tools/ww_3d/pluglib
     ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/libraries/ww_vegas/ww_lib
     ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_math
     ${PROJECT_SOURCE_DIR}/src/libraries/ww_vegas/ww_save_load
 )

--- a/src/libraries/ww_vegas/ww_math/wwmath.cpp
+++ b/src/libraries/ww_vegas/ww_math/wwmath.cpp
@@ -34,7 +34,7 @@
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-#include "wwmath.h"
+#include "libraries/ww_vegas/ww_math/wwmath.h"
 #include "wwhack.h"
 #include "lookuptable.h"
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- fix wrong header reference in wwmath
- include proper ini.h in AnimatedSoundMgr
- clean up always.h include
- update CMake include order for ww3d2 and wwmath modules
- switch many ww_3d2 headers to use correct matrix4 path

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing Vector3 methods in old pluglib)*

------
https://chatgpt.com/codex/tasks/task_e_685c88b3d29c8325bd1e6115ef7912f4