### PR TITLE
Add SDL2 package to GitHub builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libx11-dev libgl1-mesa-dev libglu1-mesa-dev xorg-dev
+          sudo apt-get install -y build-essential cmake libx11-dev libgl1-mesa-dev libglu1-mesa-dev xorg-dev libsdl2-dev
       - name: Configure and Build
         run: |
           cmake -S . -B build


### PR DESCRIPTION
## Summary
- include libsdl2-dev in the CI setup so the SDL backend can build

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: `Matrix3D::buildTransformMatrix` undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_685d2382ab4083259183f4b0d0b280ce