### PR TITLE
Fix SDL2 detection in GitHub builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,10 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libx11-dev libgl1-mesa-dev libglu1-mesa-dev xorg-dev libsdl2-dev
+          sudo apt-get install -y \
+            build-essential cmake pkg-config \
+            libx11-dev libgl1-mesa-dev libglu1-mesa-dev \
+            xorg-dev libsdl2-dev
       - name: Configure and Build
         run: |
           cmake -S . -B build

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,7 +21,18 @@ if(LVGL_USE_SDL)
         ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_mouse.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_mousewheel.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lvgl/src/drivers/sdl/lv_sdl_window.c)
-    find_package(SDL2 REQUIRED)
+
+    # Try the SDL2 CMake configuration first. If not found fall back to
+    # pkg-config so distributions without SDL2Config.cmake still work.
+    find_package(SDL2 CONFIG QUIET)
+    if(NOT SDL2_FOUND)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(SDL2 REQUIRED sdl2)
+        add_library(SDL2::SDL2 INTERFACE IMPORTED)
+        set_target_properties(SDL2::SDL2 PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES "${SDL2_LIBRARIES}")
+    endif()
 endif()
 
 if(LVGL_USE_X11)

--- a/migration.md
+++ b/migration.md
@@ -345,3 +345,4 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
   When enabled the d3d8_gles layer drops its EGL dependency and all rendering
   occurs through microGLES via the LVGL display API.
 - Remaining directories converted to snake_case (e.g. src/tools/nvasm and src/game_engine_device/w3d_device/game_client/gui/gadget) to eliminate case sensitivity issues.
+- SDL2 detection now falls back to pkg-config when the CMake configuration is missing, improving compatibility with minimal distributions.


### PR DESCRIPTION
## Summary
- install pkg-config during CI builds
- fall back to pkg-config when SDL2Config.cmake is missing
- note SDL2 pkg-config fallback in migration guide

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: `Matrix3D::Get_X_Rotation` missing `WWMath::Atan2`)*

------
https://chatgpt.com/codex/tasks/task_e_685d2767bf548325bc18a3365b24da3b