### PR TITLE
Improve CPU detection portability

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -293,6 +293,8 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - lvgl_hello now selects the SDL backend by default, improving rendering on macOS.
 - Added d3d8_triangle example showing the DirectX 8 shim. It opens an SDL window via LvglPlatform and renders a rotating coloured triangle using D3D8 calls.
 - Updated CPU detection code for non-Windows builds and replaced Windows headers with portable stubs.
+- CPU detection now uses <cpuid.h> on Unix-like systems and guards all
+  Windows-only assembly with `_WIN32` checks.
 - Standardised Vegas WW list headers to snake case.
 - LVGL's X11 backend is now optional. The cmake option `LVGL_USE_X11` defaults to OFF
   and `lv_conf.h` honours compile definitions so backends can be toggled without


### PR DESCRIPTION
## Summary
- guard cpuid assembly with `_WIN32`
- use `<cpuid.h>` for cross-platform CPU info when available
- update migration notes

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: miscutil.h: LPCSTR does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f6c4f9483259772b556d001ec02