### PR TITLE
Fix missing win32 compat types

### DIFF
--- a/include/common/AsciiString.h
+++ b/include/common/AsciiString.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "ascii_string.h"

--- a/include/game_engine/common/AsciiString.h
+++ b/include/game_engine/common/AsciiString.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "ascii_string.h"

--- a/src/libraries/ww_vegas/ww_audio/ww_audio.cpp
+++ b/src/libraries/ww_vegas/ww_audio/ww_audio.cpp
@@ -40,7 +40,7 @@
 #include "wwdebug.h"
 #include "utils.h"
 #include "realcrc.h"
-#include "sound_buffer.h"
+#include "libraries/ww_vegas/ww_audio/SoundBuffer.h"
 #include "audible_sound.h"
 #include "sound3d.h"
 #include "raw_file.h"

--- a/src/libraries/ww_vegas/ww_audio/ww_audio.h
+++ b/src/libraries/ww_vegas/ww_audio/ww_audio.h
@@ -47,8 +47,8 @@
 #pragma warning (pop)
 
 #include "vector.h"
-#include "sound_buffer.h"
-#include "audio_events.h"
+#include "libraries/ww_vegas/ww_audio/SoundBuffer.h"
+#include "libraries/ww_vegas/ww_audio/audio_events.h"
 #include "wwstring.h"
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/libraries/ww_vegas/ww_util/miscutil.h
+++ b/src/libraries/ww_vegas/ww_util/miscutil.h
@@ -35,7 +35,7 @@
 	#include "always.h"
 #endif
 
-#include	"bittype.h"
+#include "libraries/ww_vegas/ww_lib/bittype.h"
 #include	"wwstring.h"
 
 const float MISCUTIL_EPSILON = 0.0001f;


### PR DESCRIPTION
## Summary
- include correct `bittype.h` path to define Win32 style types
- fix case-sensitive includes in wwaudio
- add shim headers for `AsciiString` to keep legacy includes working
- build `wwutil` library successfully

## Testing
- `cmake --build build --target wwutil -j2`

------
https://chatgpt.com/codex/tasks/task_e_685d5f94e88c83259a1bd11465e5c591