### PR TITLE
Remove X11 override in LVGL build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,7 +89,6 @@ endif()
 if(LVGL_USE_X11)
     target_include_directories(lvgl PUBLIC ${X11_INCLUDE_DIR})
     target_link_libraries(lvgl PUBLIC ${X11_LIBRARIES})
-    target_compile_definitions(lvgl PUBLIC LV_USE_X11=1)
 endif()
 
 if(LVGL_USE_WAYLAND)

--- a/migration.md
+++ b/migration.md
@@ -299,6 +299,8 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - LVGL's X11 backend is now optional. The cmake option `LVGL_USE_X11` defaults to OFF
   and `lv_conf.h` honours compile definitions so backends can be toggled without
   warnings.
+- The build no longer passes `-DLV_USE_X11=1`. `lv_conf.h` sets this flag so the
+  backend can be enabled without compiler warnings.
 - WW3D2 links against the `d3d8_gles` shim and `gameenginedevice` now links this
   library so DirectX 8 calls route through the OpenGL ES translation layer.
 - The microGLES renderer under `lib/u_gles` is built by default. Its `renderer_lib`


### PR DESCRIPTION
## Summary
- rely on `lv_conf.h` for LVGL backend flags
- document that the build no longer forces `-DLV_USE_X11=1`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: fatal error: common/GameMemory.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a5b599c83258fd0cb4a9334b359