### PR TITLE
Remove duplicate debug headers

### DIFF
--- a/include/common/debug.h
+++ b/include/common/debug.h
@@ -1,2 +1,0 @@
-#pragma once
-#include "game_engine/common/debug.h"

--- a/include/common/windows.h
+++ b/include/common/windows.h
@@ -20,6 +20,9 @@ using LPSTR = char *;
 using LPCSTR = const char *;
 using LPWSTR = wchar_t *;
 using LPCWSTR = const wchar_t *;
+#ifndef LPCTSTR
+#define LPCTSTR const char *
+#endif
 
 struct POINT
 {

--- a/include/game_engine/common/ascii_string.h
+++ b/include/game_engine/common/ascii_string.h
@@ -53,7 +53,7 @@
 #include <string.h>
 #include <strings.h>
 #include "lib/base_type.h"
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 #include "common/errors.h"
 
 #ifndef _WIN32

--- a/include/game_engine/common/crcdebug.h
+++ b/include/game_engine/common/crcdebug.h
@@ -31,7 +31,7 @@
 #ifndef __CRCDEBUG_H__
 #define __CRCDEBUG_H__
 
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 
 #ifndef NO_DEBUG_CRC
 	#ifdef DEBUG_LOGGING

--- a/include/game_engine/common/gamememory.h
+++ b/include/game_engine/common/gamememory.h
@@ -71,7 +71,7 @@
 // USER INCLUDES //////////////////////////////////////////////////////////////
 
 #include "lib/base_type.h"
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 #include "common/errors.h"
 
 // MACROS //////////////////////////////////////////////////////////////////
@@ -857,6 +857,7 @@ extern void userMemoryManagerInitPools();
 extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocationCount, Int& overflowAllocationCount);
 
 #ifdef __cplusplus
+#ifdef _WIN32
 
 #ifndef _OPERATOR_NEW_DEFINED_
 
@@ -881,7 +882,8 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 	inline void* __cdecl operator new[]						(size_t s, void *p) { return p; }
 	inline void __cdecl operator delete[]					(void *, void *p)		{ }
 
-#endif
+#endif // _OPERATOR_NEW_DEFINED_
+#endif // _WIN32
 
 #ifdef MEMORYPOOL_DEBUG_CUSTOM_NEW
 	#define MSGNEW(MSG)		new(MSG, 0)

--- a/include/game_engine/common/money.h
+++ b/include/game_engine/common/money.h
@@ -48,7 +48,7 @@
 #define _MONEY_H_
 
 #include "lib/base_type.h"
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 #include "common/Snapshot.h"
 
 // ----------------------------------------------------------------------------------------------

--- a/include/game_engine/common/namekeygenerator.h
+++ b/include/game_engine/common/namekeygenerator.h
@@ -35,7 +35,7 @@
 
 #include "lib/base_type.h"
 #include "game_engine/common/subsystem_interface.h"
-#include "common/GameMemory.h"
+#include "game_engine/common/GameMemory.h"
 #include "common/AsciiString.h"
 
 //------------------------------------------------------------------------------------------------- 

--- a/include/game_engine/common/player.h
+++ b/include/game_engine/common/player.h
@@ -47,7 +47,7 @@
 #ifndef _PLAYER_H_
 #define _PLAYER_H_
 
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 #include "common/Energy.h"
 #include "game_engine/common/gametype.h"
 #include "common/Handicap.h"

--- a/include/game_engine/common/playertemplate.h
+++ b/include/game_engine/common/playertemplate.h
@@ -49,7 +49,7 @@
 
 #include "game_engine/common/subsystem_interface.h"
 #include "common/gamememory.h"
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 #include "common/Handicap.h"
 #include "common/Money.h"
 #include "common/Science.h"

--- a/include/game_engine/common/stltypedefs.h
+++ b/include/game_engine/common/stltypedefs.h
@@ -58,6 +58,7 @@ class STLSpecialAlloc;
 #include "common/unicodestring.h"
 #include "common/gamecommon.h"
 #include "common/gametype.h"
+#include "game_engine/common/namekeygenerator.h"
 #include "game_engine/common/gamememory.h"
 
 //-----------------------------------------------------------------------------

--- a/include/game_engine/common/unicodestring.h
+++ b/include/game_engine/common/unicodestring.h
@@ -53,7 +53,7 @@
 #include <string.h>
 #include <wchar.h>
 #include "lib/base_type.h"
-#include "common/debug.h"
+#include "game_engine/common/debug.h"
 #include "common/errors.h"
 
 #ifndef _WIN32

--- a/include/gameengine/include/common/debug.h
+++ b/include/gameengine/include/common/debug.h
@@ -1,2 +1,0 @@
-#pragma once
-#include "../../../game_engine/common/debug.h"

--- a/include/libraries/ww_vegas/ww_audio/audible_sound.h
+++ b/include/libraries/ww_vegas/ww_audio/audible_sound.h
@@ -44,6 +44,7 @@
 #pragma warning (push, 3)
 #include "mss.h"
 #pragma warning (pop)
+#include "common/windows.h"
 
 //#include <malloc.h>
 #include "vector3.h"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,7 +89,6 @@ endif()
 if(LVGL_USE_X11)
     target_include_directories(lvgl PUBLIC ${X11_INCLUDE_DIR})
     target_link_libraries(lvgl PUBLIC ${X11_LIBRARIES})
-    target_compile_definitions(lvgl PUBLIC LV_USE_X11=1)
 endif()
 
 if(LVGL_USE_WAYLAND)

--- a/lib/miles_sdk_stub/mss/mss.h
+++ b/lib/miles_sdk_stub/mss/mss.h
@@ -57,15 +57,13 @@ typedef struct PCMWAVEFORMAT
 typedef HWAVEOUT *LPHWAVEOUT;
 #endif
 
-#if !defined _MSC_VER
 #if !defined(__stdcall)
-#if defined __has_attribute && __has_attribute(stdcall)
+#if defined(_WIN32) && !defined(__x86_64__)
 #define __stdcall __attribute__((stdcall))
 #else
 #define __stdcall
 #endif
 #endif /* !defined __stdcall */
-#endif /* !defined COMPILER_MSVC */
 
 #ifdef __cplusplus
 extern "C" {

--- a/migration.md
+++ b/migration.md
@@ -299,6 +299,8 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - LVGL's X11 backend is now optional. The cmake option `LVGL_USE_X11` defaults to OFF
   and `lv_conf.h` honours compile definitions so backends can be toggled without
   warnings.
+- The build no longer passes `-DLV_USE_X11=1`. `lv_conf.h` sets this flag so the
+  backend can be enabled without compiler warnings.
 - WW3D2 links against the `d3d8_gles` shim and `gameenginedevice` now links this
   library so DirectX 8 calls route through the OpenGL ES translation layer.
 - The microGLES renderer under `lib/u_gles` is built by default. Its `renderer_lib`
@@ -350,6 +352,6 @@ Stub headers for `common/File.h` and `lib/basetype.h` were added to fix case-sen
 - SDL2 detection now falls back to pkg-config when the CMake configuration is missing, improving compatibility with minimal distributions.
 - Added portable `strupr` and `strlwr` implementations in `windows.h` and renamed
   `INI.H` to `ini.h` to continue the snake_case cleanup.
-- Updated wwdebug headers to include 'game_engine/common/debug.h' and added a compatibility stub under 'include/gameengine/include/common'.
+- Updated wwdebug headers to include 'game_engine/common/debug.h'.
 - CMake subprojects no longer override the standard. All targets now
   compile as C++11 so compile commands use `-std=gnu++11` consistently.

--- a/src/libraries/ww_vegas/ww_3d2/animatedsoundmgr.cpp
+++ b/src/libraries/ww_vegas/ww_3d2/animatedsoundmgr.cpp
@@ -37,7 +37,8 @@
 // MBL Update for CNC3 INCURSION - 10.23.2002 - Expanded param handling, Added STOP command
 //
 
-#include <string.h>	// stricmp()
+#include <string.h>     // stricmp()
+#include "common/windows.h"
 #include "animatedsoundmgr.h"
 #include "game_engine/common/ini.h"
 #include "inisup.h"


### PR DESCRIPTION
## Summary
- consolidate debug header usage under `include/game_engine/common/debug.h`
- remove old compatibility stubs
- adjust includes to use the canonical path
- fix build issues from missing windows types

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing definitions in ww3d2 and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d6952471c83259dcf9d08dcfd16d6