### PR TITLE
Remove GetTickCount in audio

### DIFF
--- a/src/libraries/ww_vegas/ww_audio/SoundScene.cpp
+++ b/src/libraries/ww_vegas/ww_audio/SoundScene.cpp
@@ -140,7 +140,7 @@ SoundSceneClass::Collect_Logical_Sounds (int listener_count)
 {
 	WWPROFILE ("Collect_Logical_Sounds");
 
-	uint32 timestamp = ::GetTickCount ();
+	uint32 timestamp = WW3D::Get_Sync_Time();
 
 	//
 	//	Determine how many listeners to process

--- a/src/libraries/ww_vegas/ww_audio/audible_sound.cpp
+++ b/src/libraries/ww_vegas/ww_audio/audible_sound.cpp
@@ -346,7 +346,7 @@ AudibleSoundClass::Play (bool alloc_handle)
 	if (m_State != STATE_PLAYING) {
 		WWAudioClass::Get_Instance ()->Add_To_Playlist (this);
 		m_State				= STATE_PLAYING;
-		m_Timestamp			= ::GetTickCount ();
+		m_Timestamp			= WW3D::Get_Sync_Time();
 		m_LoopsLeft			= m_LoopCount;		
 
 		// If we have a valid handle, then start playing the sample
@@ -515,7 +515,7 @@ AudibleSoundClass::Seek (unsigned long milliseconds)
 		// from this information
 		m_CurrentPosition = milliseconds;
 		if (m_State == STATE_PLAYING) {
-			m_Timestamp = ::GetTickCount () - m_CurrentPosition;
+			m_Timestamp = WW3D::Get_Sync_Time() - m_CurrentPosition;
 		}
 
 		// Update the actual sound data if we are playing the sound
@@ -940,7 +940,7 @@ void
 AudibleSoundClass::Update_Play_Position (void)
 {
 	// Determine the current offset from the beginning of the sound buffer.
-	unsigned long play_time = ::GetTickCount () - m_Timestamp;
+	unsigned long play_time = WW3D::Get_Sync_Time() - m_Timestamp;
 	m_CurrentPosition = play_time;
 
 	// Have we gone past the end of a sounds play-time?
@@ -948,7 +948,7 @@ AudibleSoundClass::Update_Play_Position (void)
 
 		// Normalize our position and timestamp information
 		m_CurrentPosition = m_CurrentPosition % m_Length;
-		m_Timestamp = ::GetTickCount () - m_CurrentPosition;
+		m_Timestamp = WW3D::Get_Sync_Time() - m_CurrentPosition;
 
 		// Decrement our count of remaining loops (if necessary)
 		if (m_LoopCount != INFINITE_LOOPS) {

--- a/src/libraries/ww_vegas/ww_audio/sound3d.cpp
+++ b/src/libraries/ww_vegas/ww_audio/sound3d.cpp
@@ -150,7 +150,7 @@ Sound3DClass::Play (bool alloc_handle)
 {
 	// Record our first 'tick' if we just started playing
 	if (m_State != STATE_PLAYING) {
-		m_LastUpdate = ::GetTickCount ();
+		m_LastUpdate = WW3D::Get_Sync_Time();
 	}
 	
 	// Allow the base class to process this call
@@ -203,7 +203,7 @@ Sound3DClass::On_Frame_Update (unsigned int milliseconds)
 			//	Extrapolate our current velocity given the last time slice and the distance
 			// we moved.
 			//
-			float secs_since_last_update = (::GetTickCount () - m_LastUpdate);
+			float secs_since_last_update = (WW3D::Get_Sync_Time() - m_LastUpdate);
 			if (secs_since_last_update > 0) {
 				curr_vel = ((curr_pos - last_pos) / secs_since_last_update);
 			} else {
@@ -216,7 +216,7 @@ Sound3DClass::On_Frame_Update (unsigned int milliseconds)
 
 	// Remember when the last time we updated our 'auto-calc'
 	// variables.
-	m_LastUpdate = ::GetTickCount ();
+	m_LastUpdate = WW3D::Get_Sync_Time();
 	m_PrevTransform = m_Transform;
 
 	// Allow the base class to process this call

--- a/src/libraries/ww_vegas/ww_audio/threads.cpp
+++ b/src/libraries/ww_vegas/ww_audio/threads.cpp
@@ -151,7 +151,7 @@ WWAudioThreadsClass::Add_Delayed_Release_Object
 			//
 			DELAYED_RELEASE_INFO *info = W3DNEW DELAYED_RELEASE_INFO;
 			info->object	= object;
-			info->time		= ::GetTickCount () + delay;
+			info->time		= WW3D::Get_Sync_Time() + delay;
 			info->next		= m_ReleaseListHead;
 
 			m_ReleaseListHead = info;
@@ -216,7 +216,7 @@ WWAudioThreadsClass::Delayed_Release_Thread_Proc (LPVOID /*param*/)
 			//	Loop through all the objects in our delay list, and
 			// free any that have expired.
 			//
-			DWORD current_time			= ::GetTickCount ();
+			DWORD current_time			= WW3D::Get_Sync_Time();
 			DELAYED_RELEASE_INFO *curr = NULL;
 			DELAYED_RELEASE_INFO *prev	= NULL;
 			DELAYED_RELEASE_INFO *next	= NULL;


### PR DESCRIPTION
## Summary
- replace calls to `GetTickCount` with `WW3D::Get_Sync_Time` in audio

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing dependencies in ww_3d2)*

------
https://chatgpt.com/codex/tasks/task_e_685d81679e14832599a3fc3872b36d2a