### PR TITLE
feat: add portable time helpers

### DIFF
--- a/include/common/time_utils.h
+++ b/include/common/time_utils.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace time_utils {
+
+inline std::uint64_t ticks_ns() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+inline std::uint64_t frequency_ns() { return 1000000000ULL; }
+
+inline std::uint64_t milliseconds() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+} // namespace time_utils
+

--- a/include/pre_compiled/pre_rts.h
+++ b/include/pre_compiled/pre_rts.h
@@ -60,6 +60,7 @@ class STLSpecialAlloc;
 #else
 #include "common/win32_compat.h"
 #endif
+#include "common/time_utils.h"
 
 //------------------------------------------------------------------------------------ STL Includes
 // srj sez: no, include STLTypesdefs below, instead, thanks

--- a/src/game_engine/common/game_engine.cpp
+++ b/src/game_engine/common/game_engine.cpp
@@ -654,9 +654,9 @@ extern HWND ApplicationHWnd;
 void GameEngine::execute( void )
 {
 	
-	DWORD prevTime = timeGetTime();
+	DWORD prevTime = time_utils::milliseconds();
 #if defined(_DEBUG) || defined(_INTERNAL)
-	DWORD startTime = timeGetTime() / 1000;
+	DWORD startTime = time_utils::milliseconds() / 1000;
 #endif
 
 	// pretty basic for now
@@ -677,7 +677,7 @@ void GameEngine::execute( void )
 				// enter only if in benchmark mode
 				if (TheGlobalData->m_benchmarkTimer > 0)
 				{
-					DWORD currentTime = timeGetTime() / 1000;
+					DWORD currentTime = time_utils::milliseconds() / 1000;
 					if (TheGlobalData->m_benchmarkTimer < currentTime - startTime)
 					{
 						if (TheGameLogic->isInGame())
@@ -735,12 +735,12 @@ void GameEngine::execute( void )
 		#endif
 
 					// limit the framerate
-					DWORD now = timeGetTime();
+					DWORD now = time_utils::milliseconds();
 					DWORD limit = (1000.0f/m_maxFPS)-1;
 					while (TheGlobalData->m_useFpsLimit && (now - prevTime) < limit) 
 					{
 						::Sleep(0);
-						now = timeGetTime();
+						now = time_utils::milliseconds();
 					}
 					//Int slept = now - prevTime;
 					//DEBUG_LOG(("delayed %d\n",slept));

--- a/src/game_engine/common/perf_timer.cpp
+++ b/src/game_engine/common/perf_timer.cpp
@@ -63,7 +63,7 @@ void GetPrecisionTimerTicksPerSec(Int64* t)
 void InitPrecisionTimer()
 {
 #ifdef USE_QPF
-	QueryPerformanceFrequency((LARGE_INTEGER*)&s_ticksPerSec);
+    s_ticksPerSec = time_utils::frequency_ns();
 #else
 	// Init the precision timers
 	Int64 totalTime = 0;
@@ -77,11 +77,11 @@ void InitPrecisionTimer()
 		Int64		   StartTicks;
 		Int64		   EndTicks;
 
-		TimeStart = timeGetTime();
+		TimeStart = time_utils::milliseconds();
 		GetPrecisionTimer(&StartTicks);
 		for(;;)
 		{
-			TimeStop = timeGetTime();
+			TimeStop = time_utils::milliseconds();
 			if ((TimeStop - TimeStart) > 1000)
 			{
 				GetPrecisionTimer(&EndTicks);

--- a/src/game_engine/common/stats_collector.cpp
+++ b/src/game_engine/common/stats_collector.cpp
@@ -129,7 +129,7 @@ void StatsCollector::reset( void )
 	// zero out
 	zeroOutStats();
 
-	m_lastUpdate = TheGameLogic->getFrame(); // timeGetTime();
+	m_lastUpdate = TheGameLogic->getFrame(); // time_utils::milliseconds();
 }	
 
 // Msgs pass through here so we can track whichever ones we want
@@ -196,7 +196,7 @@ void StatsCollector::update( void )
 
 	zeroOutStats();
 
-	m_lastUpdate = TheGameLogic->getFrame(); //timeGetTime();
+	m_lastUpdate = TheGameLogic->getFrame(); //time_utils::milliseconds();
 	
 }
 

--- a/src/game_engine/common/system/copy_protection.cpp
+++ b/src/game_engine/common/system/copy_protection.cpp
@@ -108,11 +108,11 @@ Bool CopyProtect::notifyLauncher(void)
 	PeekMessage(&msg, NULL, WM_USER, WM_USER, PM_NOREMOVE);
 
 	// Signal launcher to send the beef
-	unsigned long eventTime = (timeGetTime() + 60000);
+	unsigned long eventTime = (time_utils::milliseconds() + 60000);
 
 	HANDLE event = NULL;
 
-	while (timeGetTime() < eventTime)
+	while (time_utils::milliseconds() < eventTime)
 	{
 		event = OpenEvent(EVENT_MODIFY_STATE, TRUE, protectGUID);
 
@@ -131,9 +131,9 @@ Bool CopyProtect::notifyLauncher(void)
 		DEBUG_LOG(("Launcher notified.\n"));
 		DEBUG_LOG(("Waiting for message from launcher.\n"));
 		
-		unsigned long endTime = (timeGetTime() + 10000);
+		unsigned long endTime = (time_utils::milliseconds() + 10000);
 
-		while (timeGetTime() <= endTime)
+		while (time_utils::milliseconds() <= endTime)
 		{
 			if (PeekMessage(&msg, NULL, 0xBEEF, 0xBEEF, PM_REMOVE))
 			{
@@ -141,7 +141,7 @@ Bool CopyProtect::notifyLauncher(void)
 				if (msg.message == 0xBEEF)
 				{
 					DEBUG_LOG(("COPYPROTECTION - Received message from launcher (Elapsed time %ld).\n",
-						(10000 - (endTime - timeGetTime()))));
+						(10000 - (endTime - time_utils::milliseconds()))));
 
 					HANDLE mappedFile = (HANDLE)msg.lParam;
 					s_protectedData = MapViewOfFileEx(mappedFile, FILE_MAP_ALL_ACCESS, 0, 0, 0, NULL);

--- a/src/game_engine/common/system/debug.cpp
+++ b/src/game_engine/common/system/debug.cpp
@@ -557,7 +557,7 @@ void DebugSetFlags(int flags)
 // ----------------------------------------------------------------------------
 SimpleProfiler::SimpleProfiler()
 {
-	QueryPerformanceFrequency((LARGE_INTEGER*)&m_freq);
+    m_freq = time_utils::frequency_ns();
 	m_startThisSession = 0;
 	m_totalThisSession = 0;
 	m_totalAllSessions = 0;
@@ -568,7 +568,7 @@ SimpleProfiler::SimpleProfiler()
 void SimpleProfiler::start()
 {
 	DEBUG_ASSERTCRASH(m_startThisSession == 0, ("already started"));
-	QueryPerformanceCounter((LARGE_INTEGER*)&m_startThisSession);
+    m_startThisSession = time_utils::ticks_ns();
 }
 
 // ----------------------------------------------------------------------------
@@ -576,10 +576,9 @@ void SimpleProfiler::stop()
 {
 	if (m_startThisSession != 0) 
 	{
-		__int64 stop;
-		QueryPerformanceCounter((LARGE_INTEGER*)&stop);
-		m_totalThisSession = stop - m_startThisSession;
-		m_totalAllSessions += stop - m_startThisSession;
+            __int64 stop = time_utils::ticks_ns();
+            m_totalThisSession = stop - m_startThisSession;
+            m_totalAllSessions += stop - m_startThisSession;
 		m_startThisSession = 0;
 		++m_numSessions;
 	}

--- a/src/game_engine/game_client/Display.cpp
+++ b/src/game_engine/game_client/Display.cpp
@@ -215,7 +215,7 @@ void Display::playLogoMovie( AsciiString movieName, Int minMovieLength, Int minC
 	m_currentlyPlayingMovie = movieName;
 	m_movieHoldTime = minMovieLength;
 	m_copyrightHoldTime = minCopyrightLength;
-	m_elapsedMovieTime = timeGetTime();  // we're using time get time becuase legal want's actual "Seconds"
+	m_elapsedMovieTime = time_utils::milliseconds();  // we're using time get time becuase legal want's actual "Seconds"
 	
 	m_videoBuffer = createVideoBuffer();
 	if (	m_videoBuffer == NULL || 
@@ -321,10 +321,10 @@ void Display::update( void )
 					else
 						m_copyrightDisplayString->setFont(TheFontLibrary->getFont("Courier", 
 						TheGlobalLanguageData->adjustFontSize(12), TRUE));	
-					m_elapsedCopywriteTime = timeGetTime();
+					m_elapsedCopywriteTime = time_utils::milliseconds();
 				}
-				if(m_movieHoldTime + m_elapsedMovieTime < timeGetTime() && 
-						m_copyrightHoldTime + m_elapsedCopywriteTime < timeGetTime())
+				if(m_movieHoldTime + m_elapsedMovieTime < time_utils::milliseconds() && 
+						m_copyrightHoldTime + m_elapsedCopywriteTime < time_utils::milliseconds())
 				{
 					m_movieHoldTime = -1;
 					m_elapsedMovieTime = 0;

--- a/src/game_engine/game_client/GameClient.cpp
+++ b/src/game_engine/game_client/GameClient.cpp
@@ -530,8 +530,8 @@ void GameClient::update( void )
 				{				
 					legal->hide(FALSE);
 					legal->bringForward();
-					Int beginTime = timeGetTime();
-					while(beginTime + 4000 > timeGetTime() )
+					Int beginTime = time_utils::milliseconds();
+					while(beginTime + 4000 > time_utils::milliseconds() )
 					{
 						TheWindowManager->update();
 						// redraw all views, update the GUI

--- a/src/game_engine/game_client/gui/LoadScreen.cpp
+++ b/src/game_engine/game_client/gui/LoadScreen.cpp
@@ -563,7 +563,7 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 		}
 		
 		Int delay = mission->m_voiceLength * 1000;
-		Int begin = timeGetTime();
+		Int begin = time_utils::milliseconds();
 		Int currTime = begin;
 		Int fudgeFactor = 0;
 		while(begin + delay > currTime )
@@ -574,7 +574,7 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 			TheWindowManager->update();
 			TheDisplay->draw();
 			Sleep(100);
-			currTime = timeGetTime();
+			currTime = time_utils::milliseconds();
 		}
 		
 
@@ -708,8 +708,8 @@ void ShellGameLoadScreen::init( GameInfo *game )
 			win->winHide(FALSE);
 		firstLoad = FALSE;
 
-		UnsignedInt showTime = timeGetTime();
-		while(showTime + 3000 > timeGetTime())
+		UnsignedInt showTime = time_utils::milliseconds();
+		while(showTime + 3000 > time_utils::milliseconds())
 		{	
 			LoadScreen::update(0);
 			Sleep(100);

--- a/src/game_engine/game_client/gui/ProcessAnimateWindow.cpp
+++ b/src/game_engine/game_client/gui/ProcessAnimateWindow.cpp
@@ -96,7 +96,7 @@ void ProcessAnimateWindowSlideFromRight::initReverseAnimateWindow( AnimateWindow
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x *= -1;
 	vel.y *= -1;
@@ -146,7 +146,7 @@ void ProcessAnimateWindowSlideFromRight::initAnimateWindow( AnimateWindow *animW
 	vel.y = 0.0f;
 
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 
@@ -165,7 +165,7 @@ Bool ProcessAnimateWindowSlideFromRight::updateAnimateWindow( AnimateWindow *ani
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 	// it's set that the window is passed in as it's current position being it's rest position
 	// so save off the rest position
@@ -213,7 +213,7 @@ Bool ProcessAnimateWindowSlideFromRight::reverseAnimateWindow( AnimateWindow *an
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -280,7 +280,7 @@ void ProcessAnimateWindowSlideFromLeft::initReverseAnimateWindow( AnimateWindow 
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x *= -1;
 	vel.y *= -1;
@@ -325,7 +325,7 @@ void ProcessAnimateWindowSlideFromLeft::initAnimateWindow( AnimateWindow *animWi
 	//Now initialize the velocities
 	vel = m_maxVel;
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 Bool ProcessAnimateWindowSlideFromLeft::updateAnimateWindow( AnimateWindow *animWin )
@@ -342,7 +342,7 @@ Bool ProcessAnimateWindowSlideFromLeft::updateAnimateWindow( AnimateWindow *anim
 		return TRUE;
 	
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -391,7 +391,7 @@ Bool ProcessAnimateWindowSlideFromLeft::reverseAnimateWindow( AnimateWindow *ani
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -458,7 +458,7 @@ void ProcessAnimateWindowSlideFromTop::initReverseAnimateWindow( AnimateWindow *
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x *= -1;
 	vel.y *= -1;
@@ -503,7 +503,7 @@ void ProcessAnimateWindowSlideFromTop::initAnimateWindow( AnimateWindow *animWin
 	//Now initialize the velocities
 	vel = m_maxVel;
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 Bool ProcessAnimateWindowSlideFromTop::updateAnimateWindow( AnimateWindow *animWin )
@@ -520,7 +520,7 @@ Bool ProcessAnimateWindowSlideFromTop::updateAnimateWindow( AnimateWindow *animW
 		return TRUE;
 	
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -570,7 +570,7 @@ Bool ProcessAnimateWindowSlideFromTop::reverseAnimateWindow( AnimateWindow *anim
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -637,7 +637,7 @@ void ProcessAnimateWindowSlideFromBottom::initReverseAnimateWindow( AnimateWindo
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x *= -1;
 	vel.y *= -1;
@@ -683,7 +683,7 @@ void ProcessAnimateWindowSlideFromBottom::initAnimateWindow( AnimateWindow *anim
 	//Now initialize the velocities
 	vel = m_maxVel;
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 Bool ProcessAnimateWindowSlideFromBottom::updateAnimateWindow( AnimateWindow *animWin )
@@ -700,7 +700,7 @@ Bool ProcessAnimateWindowSlideFromBottom::updateAnimateWindow( AnimateWindow *an
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -750,7 +750,7 @@ Bool ProcessAnimateWindowSlideFromBottom::reverseAnimateWindow( AnimateWindow *a
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -838,7 +838,7 @@ void ProcessAnimateWindowSlideFromBottomTimed::initReverseAnimateWindow( Animate
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 
 	DEBUG_LOG(("initReverseAnimateWindow at %d (%d->%d)\n", now, now, now + m_maxDuration));
 	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, now, now + m_maxDuration);
@@ -879,7 +879,7 @@ void ProcessAnimateWindowSlideFromBottomTimed::initAnimateWindow( AnimateWindow 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 	UnsignedInt delay = animWin->getDelay();
 
 	DEBUG_LOG(("initAnimateWindow at %d (%d->%d)\n", now, now + delay, now + m_maxDuration + delay));
@@ -900,7 +900,7 @@ Bool ProcessAnimateWindowSlideFromBottomTimed::updateAnimateWindow( AnimateWindo
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -916,7 +916,7 @@ Bool ProcessAnimateWindowSlideFromBottomTimed::updateAnimateWindow( AnimateWindo
 	ICoord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 	UnsignedInt startTime = animWin->getStartTime();
 	UnsignedInt endTime = animWin->getEndTime();
 
@@ -970,7 +970,7 @@ void ProcessAnimateWindowSpiral::initReverseAnimateWindow( AnimateWindow *animWi
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x = 0;
 	vel.y = 0;
@@ -1016,7 +1016,7 @@ void ProcessAnimateWindowSpiral::initAnimateWindow( AnimateWindow *animWin )
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 //-----------------------------------------------------------------------------
@@ -1034,7 +1034,7 @@ Bool ProcessAnimateWindowSpiral::updateAnimateWindow( AnimateWindow *animWin )
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -1151,7 +1151,7 @@ void ProcessAnimateWindowSlideFromTopFast::initReverseAnimateWindow( AnimateWind
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x *= -1;
 	vel.y *= -1;
@@ -1199,7 +1199,7 @@ void ProcessAnimateWindowSlideFromTopFast::initAnimateWindow( AnimateWindow *ani
 	//Now initialize the velocities
 	vel = m_maxVel;
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 Bool ProcessAnimateWindowSlideFromTopFast::updateAnimateWindow( AnimateWindow *animWin )
@@ -1216,7 +1216,7 @@ Bool ProcessAnimateWindowSlideFromTopFast::updateAnimateWindow( AnimateWindow *a
 		return TRUE;
 	
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -1266,7 +1266,7 @@ Bool ProcessAnimateWindowSlideFromTopFast::reverseAnimateWindow( AnimateWindow *
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position
@@ -1336,7 +1336,7 @@ void ProcessAnimateWindowSlideFromRightFast::initReverseAnimateWindow( AnimateWi
 		return;
 	}
 	if(animWin->getDelay() > 0)
-		animWin->setStartTime(timeGetTime() + (maxDelay - animWin->getDelay()));
+		animWin->setStartTime(time_utils::milliseconds() + (maxDelay - animWin->getDelay()));
 	Coord2D vel = animWin->getVel();
 	vel.x *= -1;
 	vel.y *= -1;
@@ -1405,7 +1405,7 @@ void ProcessAnimateWindowSlideFromRightFast::initAnimateWindow( AnimateWindow *a
 	vel.y = 0.0f;
 
 
-	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
+	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, time_utils::milliseconds() + animWin->getDelay(), 0);
 }
 
 
@@ -1424,7 +1424,7 @@ Bool ProcessAnimateWindowSlideFromRightFast::updateAnimateWindow( AnimateWindow 
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 	// it's set that the window is passed in as it's current position being it's rest position
 	// so save off the rest position
@@ -1472,7 +1472,7 @@ Bool ProcessAnimateWindowSlideFromRightFast::reverseAnimateWindow( AnimateWindow
 		return TRUE;
 
 	// if the window hasn't started animating...return that we're not finished
-	if(timeGetTime() < animWin->getStartTime())
+	if(time_utils::milliseconds() < animWin->getStartTime())
 		return FALSE;
 
 	// it's set that the window is passed in as it's current position being it's rest position

--- a/src/game_engine/game_client/gui/gadget/GadgetListBox.cpp
+++ b/src/game_engine/game_client/gui/gadget/GadgetListBox.cpp
@@ -825,7 +825,7 @@ WindowMsgHandledType GadgetListBoxInput( GameWindow *window, UnsignedInt msg,
 			}
 			
 			//Bool dblClicked = FALSE;
-			if( list->doubleClickTime + doubleClickTime > timeGetTime() && 
+			if( list->doubleClickTime + doubleClickTime > time_utils::milliseconds() && 
 					(i == oldPos || (oldPos == -1 && ( i>=0 && i<list->endPos ) )) )
 			{
 				int temp;
@@ -854,7 +854,7 @@ WindowMsgHandledType GadgetListBoxInput( GameWindow *window, UnsignedInt msg,
 			{
 				list->selectPos = oldPos;
 			}
-			list->doubleClickTime = timeGetTime();
+			list->doubleClickTime = time_utils::milliseconds();
 			TheWindowManager->winSendSystemMsg( window->winGetOwner(), 
 																					GLM_SELECTED,
 																					(WindowMsgData)window, 

--- a/src/game_engine/game_client/gui/gui_callbacks/ControlBarPopupDescription.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/ControlBarPopupDescription.cpp
@@ -143,9 +143,9 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 	if(prevWindow == cmdButton)	
 	{
 		m_showBuildToolTipLayout = TRUE;
-		if(!isInitialized &&  beginWaitTime + cmdButton->getTooltipDelay() < timeGetTime())
+		if(!isInitialized &&  beginWaitTime + cmdButton->getTooltipDelay() < time_utils::milliseconds())
 		{
-			//DEBUG_LOG(("%d beginwaittime, %d tooltipdelay, %dtimegettime\n", beginWaitTime, cmdButton->getTooltipDelay(), timeGetTime()));
+			//DEBUG_LOG(("%d beginwaittime, %d tooltipdelay, %dtimegettime\n", beginWaitTime, cmdButton->getTooltipDelay(), time_utils::milliseconds()));
 			passedWaitTime = TRUE;
 		}
 		
@@ -176,7 +176,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 	if(!passedWaitTime)
 	{
 		prevWindow = cmdButton;
-		beginWaitTime = timeGetTime();
+		beginWaitTime = time_utils::milliseconds();
 		isInitialized = FALSE;
 		return;
 	}

--- a/src/game_engine/game_client/gui/gui_callbacks/menus/PopupReplay.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/menus/PopupReplay.cpp
@@ -177,7 +177,7 @@ void PopupReplayUpdate( WindowLayout *layout, void *userData )
 	{
 		// the replay save confirmation popup is up
 		// check to see if its time to take it down.
-		if ((timeGetTime() - s_fileSavePopupStartTime) >= s_fileSavePopupDuration) 
+		if ((time_utils::milliseconds() - s_fileSavePopupStartTime) >= s_fileSavePopupDuration) 
 		{
 			ShowReplaySavedPopup(FALSE);
 
@@ -334,7 +334,7 @@ void reallySaveReplay(void)
 	PopulateReplayFileListbox(listboxGames);
 
 	ShowReplaySavedPopup(TRUE);
-	s_fileSavePopupStartTime = timeGetTime();
+	s_fileSavePopupStartTime = time_utils::milliseconds();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/src/game_engine/game_client/gui/gui_callbacks/menus/WOLBuddyOverlay.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/menus/WOLBuddyOverlay.cpp
@@ -644,7 +644,7 @@ void HandleBuddyResponses( void )
 	{
 		DEBUG_CRASH(("No buddy message queue!\n"));
 	}
-	if(noticeLayout && timeGetTime() > noticeExpires)
+	if(noticeLayout && time_utils::milliseconds() > noticeExpires)
 	{
 		deleteNotificationBox();
 	}
@@ -677,7 +677,7 @@ void showNotificationBox( AsciiString nick, UnicodeString message)
 		message.format(message, nick.str());
 	GadgetButtonSetText(win, message);
 	//GadgetStaticTextSetText(win, message);
-	noticeExpires = timeGetTime() + NOTIFICATION_EXPIRES;
+	noticeExpires = time_utils::milliseconds() + NOTIFICATION_EXPIRES;
 	noticeLayout->bringForward();
 
 	AudioEventRTS buttonClick("GUICommunicatorIncoming");

--- a/src/game_engine/game_client/gui/gui_callbacks/menus/WOLGameSetupMenu.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/menus/WOLGameSetupMenu.cpp
@@ -1319,7 +1319,7 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 	WOLPositionStartSpots();
 
 	lastSlotlistTime = 0;
-	enterTime = timeGetTime();
+	enterTime = time_utils::milliseconds();
 
 	// Set Keyboard to chat entry
 	TheWindowManager->winSetFocus( textEntryChat );
@@ -1484,7 +1484,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 
 		Bool isHosting = TheGameSpyInfo->amIHost(); // only while in game setup screen
 		isHosting = isHosting || (TheGameSpyGame && TheGameSpyGame->isInGame() && TheGameSpyGame->amIHost()); // while in game
-		if (!isHosting && !lastSlotlistTime && timeGetTime() > enterTime + 10000)
+		if (!isHosting && !lastSlotlistTime && time_utils::milliseconds() > enterTime + 10000)
 		{
 			// don't do this if we're disconnected
 			if (TheGameSpyPeerMessageQueue->isConnected())
@@ -1898,7 +1898,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							newMapCRC = game->getMapCRC();
 							if (isInGame)
 							{
-								lastSlotlistTime = timeGetTime();
+								lastSlotlistTime = time_utils::milliseconds();
 								if ( (oldMapCRC ^ newMapCRC) || (!wasInGame && isInGame) )
 								{
 									// it changed.  send it

--- a/src/game_engine/game_client/gui/gui_callbacks/menus/WOLLobbyMenu.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/menus/WOLLobbyMenu.cpp
@@ -850,14 +850,14 @@ static void refreshGameList( Bool forceRefresh )
 {
 	Int refreshInterval = gameListRefreshInterval;
 
-	if (forceRefresh || ((gameListRefreshTime == 0) || ((gameListRefreshTime + refreshInterval) <= timeGetTime())))
+	if (forceRefresh || ((gameListRefreshTime == 0) || ((gameListRefreshTime + refreshInterval) <= time_utils::milliseconds())))
 	{
 		if (TheGameSpyInfo->hasStagingRoomListChanged())
 		{
 			//DEBUG_LOG(("################### refreshing game list\n"));
-			//DEBUG_LOG(("gameRefreshTime=%d, refreshInterval=%d, now=%d\n", gameListRefreshTime, refreshInterval, timeGetTime()));
+			//DEBUG_LOG(("gameRefreshTime=%d, refreshInterval=%d, now=%d\n", gameListRefreshTime, refreshInterval, time_utils::milliseconds()));
 			RefreshGameListBoxes();
-			gameListRefreshTime = timeGetTime();
+			gameListRefreshTime = time_utils::milliseconds();
 		} else {
 			//DEBUG_LOG(("-"));
 		}
@@ -873,10 +873,10 @@ static void refreshPlayerList( Bool forceRefresh )
 {
 		Int refreshInterval = playerListRefreshInterval;
 
-		if (forceRefresh ||((playerListRefreshTime == 0) || ((playerListRefreshTime + refreshInterval) <= timeGetTime())))
+		if (forceRefresh ||((playerListRefreshTime == 0) || ((playerListRefreshTime + refreshInterval) <= time_utils::milliseconds())))
 		{
 				PopulateLobbyPlayerListbox();
-				playerListRefreshTime = timeGetTime();
+				playerListRefreshTime = time_utils::milliseconds();
 		}
 }
 //-------------------------------------------------------------------------------------------------
@@ -918,8 +918,8 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 		HandlePersistentStorageResponses();
 
 #ifdef PERF_TEST
-		UnsignedInt start = timeGetTime();
-		UnsignedInt end = timeGetTime();
+		UnsignedInt start = time_utils::milliseconds();
+		UnsignedInt end = time_utils::milliseconds();
 		std::list<Int> responses;
 		Int numMessages = 0;
 #endif // PERF_TEST
@@ -1274,7 +1274,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 
 #ifdef PERF_TEST
 		// check performance
-		end = timeGetTime();
+		end = time_utils::milliseconds();
 		PERF_LOG(("Frame time was %d ms\n", end-start));
 		std::list<Int>::const_iterator it;
 		for (it = responses.begin(); it != responses.end(); ++it)
@@ -1288,14 +1288,14 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 // Removed 2-17-03 to pull out into a function so we can do the same checks 
 		Int refreshInterval = gameListRefreshInterval;
 
-		if ((gameListRefreshTime == 0) || ((gameListRefreshTime + refreshInterval) <= timeGetTime()))
+		if ((gameListRefreshTime == 0) || ((gameListRefreshTime + refreshInterval) <= time_utils::milliseconds()))
 		{
 			if (TheGameSpyInfo->hasStagingRoomListChanged())
 			{
 				//DEBUG_LOG(("################### refreshing game list\n"));
-				//DEBUG_LOG(("gameRefreshTime=%d, refreshInterval=%d, now=%d\n", gameListRefreshTime, refreshInterval, timeGetTime()));
+				//DEBUG_LOG(("gameRefreshTime=%d, refreshInterval=%d, now=%d\n", gameListRefreshTime, refreshInterval, time_utils::milliseconds()));
 				RefreshGameListBoxes();
-				gameListRefreshTime = timeGetTime();
+				gameListRefreshTime = time_utils::milliseconds();
 			} else {
 				//DEBUG_LOG(("-"));
 			}

--- a/src/game_engine/game_client/gui/gui_callbacks/menus/WOLLoginMenu.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/menus/WOLLoginMenu.cpp
@@ -870,7 +870,7 @@ void WOLLoginMenuUpdate( WindowLayout * layout, void *userData)
 		checkLogin();
 	}
 
-	if (TheGameSpyInfo && !buttonPushed && loginAttemptTime && (loginAttemptTime + loginTimeoutInMS < timeGetTime()))
+	if (TheGameSpyInfo && !buttonPushed && loginAttemptTime && (loginAttemptTime + loginTimeoutInMS < time_utils::milliseconds()))
 	{
 		// timed out a login attempt, so say so
 		loginAttemptTime = 0;
@@ -1252,7 +1252,7 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 
 						if ( !email.isEmpty() && !login.isEmpty() && !password.isEmpty() )
 						{
-							loginAttemptTime = timeGetTime();
+							loginAttemptTime = time_utils::milliseconds();
 							BuddyRequest req;
 							req.buddyRequestType = BuddyRequest::BUDDYREQUEST_LOGINNEW;
 							strcpy(req.arg.login.nick, login.str());
@@ -1341,7 +1341,7 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 
 						if ( !email.isEmpty() && !login.isEmpty() && !password.isEmpty() )
 						{
-							loginAttemptTime = timeGetTime();
+							loginAttemptTime = time_utils::milliseconds();
 							BuddyRequest req;
 							req.buddyRequestType = BuddyRequest::BUDDYREQUEST_LOGIN;
 							strcpy(req.arg.login.nick, login.str());
@@ -1405,7 +1405,7 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 
 						if ( !login.isEmpty() )
 						{
-							loginAttemptTime = timeGetTime();
+							loginAttemptTime = time_utils::milliseconds();
 							PeerRequest req;
 							req.peerRequestType = PeerRequest::PEERREQUEST_LOGIN;
 							req.nick = login.str();

--- a/src/game_engine/game_client/gui/gui_callbacks/menus/WOLQuickMatchMenu.cpp
+++ b/src/game_engine/game_client/gui/gui_callbacks/menus/WOLQuickMatchMenu.cpp
@@ -1121,8 +1121,8 @@ void WOLQuickMatchMenuUpdate( WindowLayout * layout, void *userData)
 		}
 
 #ifdef PERF_TEST
-		UnsignedInt start = timeGetTime();
-		UnsignedInt end = timeGetTime();
+		UnsignedInt start = time_utils::milliseconds();
+		UnsignedInt end = time_utils::milliseconds();
 		std::list<Int> responses;
 		Int numMessages = 0;
 #endif // PERF_TEST
@@ -1382,7 +1382,7 @@ void WOLQuickMatchMenuUpdate( WindowLayout * layout, void *userData)
 		}
 #ifdef PERF_TEST
 		// check performance
-		end = timeGetTime();
+		end = time_utils::milliseconds();
 		UnsignedInt frameTime = end-start;
 		if (frameTime > 100 || responses.size() > 20)
 		{

--- a/src/game_engine/game_client/gui/shell/Shell.cpp
+++ b/src/game_engine/game_client/gui/shell/Shell.cpp
@@ -177,9 +177,9 @@ void Shell::reset( void )
 //-------------------------------------------------------------------------------------------------
 void Shell::update( void )
 {
-	static Int lastUpdate = timeGetTime();
+	static Int lastUpdate = time_utils::milliseconds();
 	static const Int shellUpdateDelay = 30;  // try to update 30 frames a second
-	Int now = timeGetTime();
+	Int now = time_utils::milliseconds();
 	
 	//
 	// we keep the shell updates fixed in time so that we can write consitent animation

--- a/src/game_engine/game_client/input/mouse.cpp
+++ b/src/game_engine/game_client/input/mouse.cpp
@@ -340,7 +340,7 @@ void Mouse::processMouseEvent( Int index )
 //			if (!m_displayTooltip)
 //			{
 //				m_highlightPos = 0;
-//				m_highlightUpdateStart = timeGetTime();
+//				m_highlightUpdateStart = time_utils::milliseconds();
 //			}
 //
 //			// display tooltip for current window
@@ -668,7 +668,7 @@ void Mouse::createStreamMessages( void )
 		return;  // no place to put messages
 
 	GameMessage *msg = NULL;
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 
 	// basic position messages are always created
 	msg = TheMessageStream->appendMessage( GameMessage::MSG_RAW_MOUSE_POSITION );
@@ -684,7 +684,7 @@ void Mouse::createStreamMessages( void )
 		if (!m_displayTooltip)
 		{
 			m_highlightPos = 0;
-			m_highlightUpdateStart = timeGetTime();
+			m_highlightUpdateStart = time_utils::milliseconds();
 		}
 
 		// display tooltip for current window
@@ -969,7 +969,7 @@ void Mouse::draw( void )
 // ------------------------------------------------------------------------------------------------
 void Mouse::resetTooltipDelay( void )
 {
-	m_stillTime = timeGetTime();
+	m_stillTime = time_utils::milliseconds();
 	m_displayTooltip = FALSE;
 }
 
@@ -1030,7 +1030,7 @@ void Mouse::drawTooltip( void )
 		// get ready for the next part of the anim
 		if (m_highlightPos < width + HIGHLIGHT_WIDTH)
 		{
-			UnsignedInt now = timeGetTime();
+			UnsignedInt now = time_utils::milliseconds();
 			m_highlightPos = (width*(now-m_highlightUpdateStart))/m_tooltipFillTime;
 		}
 	}  // end if

--- a/src/game_engine/game_logic/ai/AIPathfind.cpp
+++ b/src/game_engine/game_logic/ai/AIPathfind.cpp
@@ -2255,11 +2255,11 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 {
 #ifdef DEBUG_QPF
 #if defined(DEBUG_LOGGING) 
-	__int64 startTime64;
-	double timeToUpdate=0.0f;
-	__int64 endTime64,freq64;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
-	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
+        __int64 startTime64;
+        double timeToUpdate=0.0f;
+        __int64 endTime64,freq64;
+        freq64 = time_utils::frequency_ns();
+        startTime64 = time_utils::ticks_ns();
 #endif
 #endif
 
@@ -2350,8 +2350,8 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 	}
 #ifdef DEBUG_QPF
 #if defined(DEBUG_LOGGING)
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
+        endTime64 = time_utils::ticks_ns();
+        timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 	DEBUG_LOG(("Time to calculate first %f\n", timeToUpdate));
 #endif
 #endif
@@ -2409,8 +2409,8 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
 #ifdef DEBUG_QPF
 #if defined(DEBUG_LOGGING) 
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
+        endTime64 = time_utils::ticks_ns();
+        timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 	DEBUG_LOG(("Time to calculate second %f\n", timeToUpdate));
 #endif
 #endif
@@ -2516,8 +2516,8 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
 #ifdef DEBUG_QPF
 #if defined(DEBUG_LOGGING) 
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
+        endTime64 = time_utils::ticks_ns();
+        timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 	DEBUG_LOG(("Time to calculate zones %f, cells %d\n", timeToUpdate, (globalBounds.hi.x-globalBounds.lo.x)*(globalBounds.hi.y-globalBounds.lo.y)));
 #endif
 #endif
@@ -5388,11 +5388,11 @@ void Pathfinder::processPathfindQueue(void)
 #ifdef DEBUG_QPF
 #if defined _DEBUG || defined _INTERNAL
 	Int startTimeMS = ::GetTickCount();
-	__int64 startTime64;
-	double timeToUpdate=0.0f;
-	__int64 endTime64,freq64;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
-	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
+        __int64 startTime64;
+        double timeToUpdate=0.0f;
+        __int64 endTime64,freq64;
+        freq64 = time_utils::frequency_ns();
+        startTime64 = time_utils::ticks_ns();
 #endif
 #endif
 
@@ -5434,8 +5434,8 @@ void Pathfinder::processPathfindQueue(void)
 	if (pathsFound>0) {
 #ifdef DEBUG_QPF
 #if defined _DEBUG || defined _INTERNAL
-		QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-		timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
+                endTime64 = time_utils::ticks_ns();
+                timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 		if (timeToUpdate>0.01f) 
 		{
 			DEBUG_LOG(("%d Pathfind queue: %d paths, %d cells", TheGameLogic->getFrame(), pathsFound, m_cumulativeCellsAllocated));

--- a/src/game_engine/game_logic/object/update/ai_update/RailroadGuideAIUpdate.cpp
+++ b/src/game_engine/game_logic/object/update/ai_update/RailroadGuideAIUpdate.cpp
@@ -132,9 +132,9 @@ RailroadBehavior::RailroadBehavior( Thing *thing, const ModuleData *moduleData )
 
 
 #ifdef RAILROAD_DESYNC_TEST
-	_LARGE_INTEGER pc;
-	QueryPerformanceCounter( &pc ); // absolutely, positively random every call!
-	Real random = 100000.0f / (Real)pc.LowPart;
+        _LARGE_INTEGER pc;
+        pc.QuadPart = time_utils::ticks_ns(); // absolutely, positively random every call!
+        Real random = 100000.0f / (Real)pc.LowPart;
 	conductorPullInfo.m_direction = random;
 	m_pullInfo.m_direction = random;
 #endif

--- a/src/game_engine/game_logic/script_engine/ScriptEngine.cpp
+++ b/src/game_engine/game_logic/script_engine/ScriptEngine.cpp
@@ -4769,11 +4769,11 @@ void ScriptEngine::update( void )
 	USE_PERF_TIMER(ScriptEngine)
 #ifdef SPECIAL_SCRIPT_PROFILING
 #ifdef DEBUG_LOGGING
-	__int64 startTime64;
-	double timeToUpdate=0.0f;
-	__int64 endTime64,freq64;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);//LORENZEN'S NOTE_TO_SELF: USE THIS
-	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);//LORENZEN'S NOTE_TO_SELF: USE THIS
+        __int64 startTime64;
+        double timeToUpdate=0.0f;
+        __int64 endTime64,freq64;
+        freq64 = time_utils::frequency_ns();
+        startTime64 = time_utils::ticks_ns();
 /* dump out the named objects table.  For extremely intense debug only.  jba. :P
 	for (VecNamedRequestsIt it = m_namedObjects.begin(); it != m_namedObjects.end(); ++it) {
 		AsciiString name = it->first;
@@ -4889,8 +4889,8 @@ void ScriptEngine::update( void )
 
 #ifdef SPECIAL_SCRIPT_PROFILING
 #ifdef DEBUG_LOGGING
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);//LORENZEN'S NOTE_TO_SELF: USE THIS
-	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));//LORENZEN'S NOTE_TO_SELF: USE THIS
+        endTime64 = time_utils::ticks_ns();
+        timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 	m_numFrames++;
 	m_totalUpdateTime+=timeToUpdate;
 	if (timeToUpdate > m_maxUpdateTime) m_maxUpdateTime = timeToUpdate;
@@ -6257,8 +6257,8 @@ void ScriptEngine::executeScript( Script *pScript )
 	__int64 startTime64;
 	Real timeToEvaluate=0.0f;
 	__int64 endTime64,freq64;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
-	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
+        freq64 = time_utils::frequency_ns();
+        startTime64 = time_utils::ticks_ns();
 #endif
 #endif
 
@@ -6322,8 +6322,8 @@ void ScriptEngine::executeScript( Script *pScript )
 	}
 #ifdef DEBUG_LOGGING
 #ifdef SPECIAL_SCRIPT_PROFILING
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-	timeToEvaluate = ((Real)(endTime64-startTime64) / (Real)(freq64));
+        endTime64 = time_utils::ticks_ns();
+        timeToEvaluate = ((Real)(endTime64-startTime64) / (Real)(freq64));
 	pScript->setCurTime(timeToEvaluate);
 #endif
 #endif
@@ -6870,11 +6870,11 @@ Bool ScriptEngine::evaluateConditions( Script *pScript, Team *thisTeam, Player *
 #define COLLECT_CONDITION_EVAL_TIMES
 #endif
 #ifdef COLLECT_CONDITION_EVAL_TIMES
-	__int64 startTime64;
-	Real timeToEvaluate=0.0f;
-	__int64 endTime64,freq64;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
-	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
+        __int64 startTime64;
+        Real timeToEvaluate=0.0f;
+        __int64 endTime64,freq64;
+        freq64 = time_utils::frequency_ns();
+        startTime64 = time_utils::ticks_ns();
 #endif
 	OrCondition *pCurCondition;
 	for (pCurCondition = pConditionHead; pCurCondition; pCurCondition = pCurCondition->getNextOrCondition()) {
@@ -6894,8 +6894,8 @@ Bool ScriptEngine::evaluateConditions( Script *pScript, Team *thisTeam, Player *
 		}
 	}
 #ifdef COLLECT_CONDITION_EVAL_TIMES
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-	timeToEvaluate = ((Real)(endTime64-startTime64) / (Real)(freq64));
+        endTime64 = time_utils::ticks_ns();
+        timeToEvaluate = ((Real)(endTime64-startTime64) / (Real)(freq64));
 	pScript->incrementConditionCount();
 	pScript->addToConditionTime(timeToEvaluate);
 #endif

--- a/src/game_engine/game_logic/system/GameLogic.cpp
+++ b/src/game_engine/game_logic/system/GameLogic.cpp
@@ -1603,7 +1603,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	#endif
 
 	progressCount = LOAD_PROGRESS_LOOP_ALL_THE_FREAKN_OBJECTS;
-	Int timer = timeGetTime();
+	Int timer = time_utils::milliseconds();
 	if( saveGame == FALSE )
 	{
 
@@ -1690,12 +1690,12 @@ void GameLogic::startNewGame( Bool saveGame )
 
 			}  // end if
 		
-			if(timeGetTime() > timer + 500)
+			if(time_utils::milliseconds() > timer + 500)
 			{
 				if(progressCount < LOAD_PROGRESS_MAX_ALL_THE_FREAKN_OBJECTS)
 					progressCount ++;
 				updateLoadProgress(progressCount);
-				timer = timeGetTime();
+				timer = time_utils::milliseconds();
 			}
 
 		}	// for, loading map objects
@@ -2764,8 +2764,8 @@ static void unitTimings(void)
 		settleFrames--;
 		if (settleFrames>0) return;
 
-		QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
-		QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
+                startTime64 = time_utils::ticks_ns();
+                freq64 = time_utils::frequency_ns();
 		timeFrames = TIME_FRAMES/FACTOR;
 
 		// reset the draw counter
@@ -2777,8 +2777,8 @@ static void unitTimings(void)
 		timeFrames--;
 		if (timeFrames>0) return;
 		
-		QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-		double timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
+                endTime64 = time_utils::ticks_ns();
+                double timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 		timeToUpdate *= FACTOR;
 	
 		
@@ -3753,7 +3753,7 @@ void GameLogic::lastHeardFrom( Int playerId )
 {
 	if( playerId < 0 || playerId >= MAX_SLOTS)
 		return;
-	m_progressCompleteTimeout[playerId] = timeGetTime();
+	m_progressCompleteTimeout[playerId] = time_utils::milliseconds();
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -3764,7 +3764,7 @@ void GameLogic::testTimeOut( void )
 	if(isProgressComplete())
 		return;
 
-	Int curTime = timeGetTime();
+	Int curTime = time_utils::milliseconds();
 	// Loop and test everyone in our game.
 	for(Int i =0; i < MAX_SLOTS; ++i)
 	{
@@ -3794,7 +3794,7 @@ void GameLogic::initTimeOutValues( void )
 		return;
 	for(Int i = 0; i < TheNetwork->getNumPlayers(); ++i)
 	{
-		m_progressCompleteTimeout[i] = timeGetTime();
+		m_progressCompleteTimeout[i] = time_utils::milliseconds();
 	}
 }
 

--- a/src/game_engine/game_network/Connection.cpp
+++ b/src/game_engine/game_network/Connection.cpp
@@ -251,7 +251,7 @@ Bool Connection::isQueueEmpty() {
 void Connection::setQuitting( void )
 {
 	m_isQuitting = TRUE;
-	m_quitTime = timeGetTime();
+	m_quitTime = time_utils::milliseconds();
 	DEBUG_LOG(("Connection::setQuitting() at time %d\n", m_quitTime));
 }
 
@@ -261,7 +261,7 @@ void Connection::setQuitting( void )
  */
 UnsignedInt Connection::doSend() {
 	Int numpackets = 0;
-	time_t curtime = timeGetTime();
+	time_t curtime = time_utils::milliseconds();
 	Bool couldQueue = TRUE;
 
 	// Do this check first, since it's an important fail-safe
@@ -380,7 +380,7 @@ NetCommandRef * Connection::processAck(UnsignedShort commandID, UnsignedByte ori
 
 	Int index = temp->getCommand()->getID() % CONNECTION_LATENCY_HISTORY_LENGTH;
 	m_averageLatency -= ((Real)(m_latencies[index])) / CONNECTION_LATENCY_HISTORY_LENGTH;
-	Real lat = timeGetTime() - temp->getTimeLastSent();
+	Real lat = time_utils::milliseconds() - temp->getTimeLastSent();
 	m_averageLatency += lat / CONNECTION_LATENCY_HISTORY_LENGTH;
 	m_latencies[index] = lat;
 
@@ -400,7 +400,7 @@ void Connection::setFrameGrouping(time_t frameGrouping) {
 
 void Connection::doRetryMetrics() {
 	static Int numSeconds = 0;
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 
 	if ((curTime - m_retryMetricsTime) > 10000) {
 		m_retryMetricsTime = curTime;

--- a/src/game_engine/game_network/ConnectionManager.cpp
+++ b/src/game_engine/game_network/ConnectionManager.cpp
@@ -1225,7 +1225,7 @@ void ConnectionManager::update(Bool isInGame) {
 
 void ConnectionManager::updateRunAhead(Int oldRunAhead, Int frameRate, Bool didSelfSlug, Int nextExecutionFrame) {
 	static time_t lasttimesent = 0;
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 
 	if ((lasttimesent == 0) || ((curTime - lasttimesent) > TheGlobalData->m_networkRunAheadMetricsTime)) {
 		if (m_localSlot == m_packetRouterSlot) {
@@ -1678,7 +1678,7 @@ void ConnectionManager::doKeepAlive() {
 	static Int nextIndex = 0;
 	static time_t startTime = 0;
 
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 
 	if (startTime == 0) {
 		startTime = curTime;

--- a/src/game_engine/game_network/DisconnectManager.cpp
+++ b/src/game_engine/game_network/DisconnectManager.cpp
@@ -101,14 +101,14 @@ void DisconnectManager::init() {
 
 void DisconnectManager::update(ConnectionManager *conMgr) {
 	if (m_lastFrameTime == -1) {
-		m_lastFrameTime = timeGetTime();
+		m_lastFrameTime = time_utils::milliseconds();
 	}
 
 	// The game logic stalls on the frame we are currently waiting for commands on,
 	// so we have to check for the current logic frame being one higher than
 	// the last one we had the commands ready for.
 	if (TheGameLogic->getFrame() == m_lastFrame) {
-		time_t curTime = timeGetTime();
+		time_t curTime = time_utils::milliseconds();
 		if ((curTime - m_lastFrameTime) > TheGlobalData->m_networkDisconnectTime) {
 			if (m_disconnectState == DISCONNECTSTATETYPE_SCREENOFF) {
 				turnOnScreen(conMgr);
@@ -125,7 +125,7 @@ void DisconnectManager::update(ConnectionManager *conMgr) {
 		// check to see if we need to send pings
 		if (m_pingFrame < TheGameLogic->getFrame())
 		{
-			time_t curTime = timeGetTime();
+			time_t curTime = time_utils::milliseconds();
 			if ((curTime - m_lastFrameTime) > 10000) /// @todo: plug in some better measure here
 			{
 				m_pingFrame = TheGameLogic->getFrame();
@@ -205,7 +205,7 @@ void DisconnectManager::updateDisconnectStatus(ConnectionManager *conMgr) {
 		if (conMgr->isPlayerConnected(i)) {
 			Int slot = translatedSlotPosition(i, conMgr->getLocalPlayerID());
 			if (slot != -1) {
-				time_t curTime = timeGetTime();
+				time_t curTime = time_utils::milliseconds();
 				time_t newTime = TheGlobalData->m_networkPlayerTimeoutTime - (curTime - m_playerTimeouts[slot]);
 
 // if someone is more than 2/3 timed out, lets get our frame numbers sync'd up.  Also if someone is voted out
@@ -253,7 +253,7 @@ void DisconnectManager::updateDisconnectStatus(ConnectionManager *conMgr) {
 
 void DisconnectManager::updateWaitForPacketRouter(ConnectionManager *conMgr) {
 /*
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 	time_t newTime = TheGlobalData->m_networkPlayerTimeoutTime - (curTime - m_packetRouterTimeout);
 	if (newTime < 0) {
 		newTime = 0;
@@ -428,7 +428,7 @@ void DisconnectManager::applyDisconnectVote(Int slot, UnsignedInt frame, Int fro
 
 void DisconnectManager::nextFrame(UnsignedInt frame, ConnectionManager *conMgr) {
 	m_lastFrame = frame;
-	m_lastFrameTime = timeGetTime();
+	m_lastFrameTime = time_utils::milliseconds();
 	resetPlayerTimeouts(conMgr);
 }
 
@@ -458,7 +458,7 @@ Bool DisconnectManager::allowedToContinue() {
 }
 
 void DisconnectManager::sendKeepAlive(ConnectionManager *conMgr) {
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 
 	if (((curTime - m_lastKeepAliveSendTime) > 500) || (m_lastKeepAliveSendTime == -1)) {
 		NetDisconnectKeepAliveCommandMsg *msg = newInstance(NetDisconnectKeepAliveCommandMsg);
@@ -521,11 +521,11 @@ void DisconnectManager::resetPlayerTimeouts(ConnectionManager *conMgr) {
 }
 
 void DisconnectManager::resetPlayerTimeout(Int slot) {
-	m_playerTimeouts[slot] = timeGetTime();
+	m_playerTimeouts[slot] = time_utils::milliseconds();
 }
 
 void DisconnectManager::resetPacketRouterTimeout() {
-	m_packetRouterTimeout = timeGetTime();
+	m_packetRouterTimeout = time_utils::milliseconds();
 }
 
 void DisconnectManager::turnOnScreen(ConnectionManager *conMgr) {
@@ -539,7 +539,7 @@ void DisconnectManager::turnOnScreen(ConnectionManager *conMgr) {
 
 	m_haveNotifiedOtherPlayersOfCurrentFrame = FALSE;
 
-	m_timeOfDisconnectScreenOn = timeGetTime();
+	m_timeOfDisconnectScreenOn = time_utils::milliseconds();
 	DEBUG_LOG(("DisconnectManager::turnOnScreen - turned on screen at time %d\n", m_timeOfDisconnectScreenOn));
 }
 
@@ -693,7 +693,7 @@ Bool DisconnectManager::hasPlayerTimedOut(Int slot) {
 		return FALSE;
 	}
 
-	time_t newTime = TheGlobalData->m_networkPlayerTimeoutTime - (timeGetTime() - m_playerTimeouts[slot]);
+	time_t newTime = TheGlobalData->m_networkPlayerTimeoutTime - (time_utils::milliseconds() - m_playerTimeouts[slot]);
 	if (newTime <= 0) {
 		return TRUE;
 	}

--- a/src/game_engine/game_network/FileTransfer.cpp
+++ b/src/game_engine/game_network/FileTransfer.cpp
@@ -47,7 +47,7 @@ static Bool doFileTransfer( AsciiString filename, MapTransferLoadScreen *ls, Int
 	if (mask)
 	{
 		ls->setCurrentFilename(filename);
-		UnsignedInt startTime = timeGetTime();
+		UnsignedInt startTime = time_utils::milliseconds();
 		const Int timeoutPeriod = 2*60*1000;
 		ls->processTimeout(timeoutPeriod/1000);
 
@@ -109,7 +109,7 @@ static Bool doFileTransfer( AsciiString filename, MapTransferLoadScreen *ls, Int
 				ls->processProgress(0, fileTransferPercent, "MapTransfer:Done");
 			}
 
-			Int now = timeGetTime();
+			Int now = time_utils::milliseconds();
 			if (now > startTime + timeoutPeriod) // bail if we don't finish in a reasonable amount of time
 			{
 				DEBUG_LOG(("Timing out file transfer\n"));

--- a/src/game_engine/game_network/FirewallHelper.cpp
+++ b/src/game_engine/game_network/FirewallHelper.cpp
@@ -116,7 +116,7 @@ FirewallHelperClass::FirewallHelperClass(void)
 	
 	m_currentState = DETECTIONSTATE_IDLE;
 
-	m_sourcePortPool = 4096 + ((timeGetTime() / 1000) % 1000); // do this to make sure we don't use the same source
+	m_sourcePortPool = 4096 + ((time_utils::milliseconds() / 1000) % 1000); // do this to make sure we don't use the same source
 																										// port before a previous connection has had a chance
 																										// to time out.
 }
@@ -656,7 +656,7 @@ Bool FirewallHelperClass::detectionBeginUpdate() {
 
 
 
-	m_timeoutStart = timeGetTime();
+	m_timeoutStart = time_utils::milliseconds();
 	m_timeoutLength = 5000;
 	DEBUG_LOG(("About to call gethostbyname for the mangler address\n"));
 	int namenum = 0;
@@ -715,7 +715,7 @@ Bool FirewallHelperClass::detectionBeginUpdate() {
 			DEBUG_LOG(("Found mangler address at %d.%d.%d.%d\n", mangler_addresses[m][0], mangler_addresses[m][1], mangler_addresses[m][2], mangler_addresses[m][3]));
 		}
 
-	} while ((m_numManglers < MAX_NUM_MANGLERS) && ((timeGetTime() - m_timeoutStart) < m_timeoutLength));
+	} while ((m_numManglers < MAX_NUM_MANGLERS) && ((time_utils::milliseconds() - m_timeoutStart) < m_timeoutLength));
 
 
 	DEBUG_ASSERTCRASH(m_numManglers > 2, ("not enough mangler addresses found."));
@@ -770,7 +770,7 @@ Bool FirewallHelperClass::detectionBeginUpdate() {
 	/*
 	** Send to the mangler from this port until we get a response.
 	*/
-	m_timeoutStart = timeGetTime();
+	m_timeoutStart = time_utils::milliseconds();
 	m_timeoutLength = 6000;
 
 	sendToManglerFromPort(m_manglers[0], m_sparePorts[0], m_packetID);
@@ -791,12 +791,12 @@ Bool FirewallHelperClass::detectionTest1Update() {
 			m_sourcePortAllocationDelta = 0;
 			DEBUG_LOG(("FirewallHelperClass::detectionTest1Update - Non-mangled response from mangler, quitting test.\n"));
 		}
-		if ((m_mangledPorts[0] == 0) && ((timeGetTime() - m_timeoutStart) < m_timeoutLength)) {
+		if ((m_mangledPorts[0] == 0) && ((time_utils::milliseconds() - m_timeoutStart) < m_timeoutLength)) {
 			// we are still waiting for a response and haven't timed out yet.
 			DEBUG_LOG(("FirewallHelperClass::detectionTest1Update - waiting for response from mangler.\n"));
 			return FALSE;
 		}
-		if ((m_mangledPorts[0] == 0) && ((timeGetTime() - m_timeoutStart) >= m_timeoutLength)) {
+		if ((m_mangledPorts[0] == 0) && ((time_utils::milliseconds() - m_timeoutStart) >= m_timeoutLength)) {
 			// we are still waiting for a response and we timed out.
 			DEBUG_LOG(("FirewallHelperClass::detectionTest1Update - timed out waiting for response from mangler.\n"));
 		}
@@ -820,7 +820,7 @@ Bool FirewallHelperClass::detectionTest1Update() {
 	/*
 	** Send to the mangler from this port until we get a response.
 	*/
-	m_timeoutStart = timeGetTime();
+	m_timeoutStart = time_utils::milliseconds();
 	m_timeoutLength = 6000;
 	m_mangledPorts[1] = 0;
 	sendToManglerFromPort(m_manglers[1], m_sparePorts[0], m_packetID+1);
@@ -834,7 +834,7 @@ Bool FirewallHelperClass::detectionTest2Update() {
 	m_mangledPorts[1] = getManglerResponse(m_packetID+1);
 
 	if (m_mangledPorts[1] == 0) {
-		if ((timeGetTime() - m_timeoutStart) <= m_timeoutLength) {
+		if ((time_utils::milliseconds() - m_timeoutStart) <= m_timeoutLength) {
 			return FALSE;
 		}
 		DEBUG_LOG(("FirewallHelperClass::detectionTest2Update - timed out waiting for mangler response\n"));
@@ -934,7 +934,7 @@ Bool FirewallHelperClass::detectionTest3Update() {
 		** Keep sending from each port until we get a response to all the sends. There's a implied
 		** delay between initial sends due to the timeout in Get_Mangler_Response.
 		*/
-		m_timeoutStart = timeGetTime();
+		m_timeoutStart = time_utils::milliseconds();
 		m_timeoutLength = 12000;
 
 		DEBUG_LOG(("FirewallHelperClass::detectionTest3Update - Sending to %d manglers\n", NUM_TEST_PORTS));
@@ -967,7 +967,7 @@ Bool FirewallHelperClass::detectionTest3WaitForResponsesUpdate() {
 	}
 
 	if (m_numResponses < NUM_TEST_PORTS) {
-		if ((timeGetTime() - m_timeoutStart) > m_timeoutLength) {
+		if ((time_utils::milliseconds() - m_timeoutStart) > m_timeoutLength) {
 			/*
 			** Close down those sockets - we are finished with them.
 			*/
@@ -1078,7 +1078,7 @@ Bool FirewallHelperClass::detectionTest3WaitForResponsesUpdate() {
 			/*
 			** Get a reference port.
 			*/
-			m_timeoutStart = timeGetTime();
+			m_timeoutStart = time_utils::milliseconds();
 			m_timeoutLength = 4000;
 			m_mangledPorts[0] = 0;
 			m_packetID += 10;
@@ -1117,7 +1117,7 @@ Bool FirewallHelperClass::detectionTest4Stage1Update() {
 	m_mangledPorts[0] = getManglerResponse(m_packetID);
 
 	if (m_mangledPorts[0] == 0) {
-		if ((timeGetTime() - m_timeoutStart) > m_timeoutLength) {
+		if ((time_utils::milliseconds() - m_timeoutStart) > m_timeoutLength) {
 			closeSpareSocket(m_sparePorts[0]);
 			closeSpareSocket(m_sparePorts[1]);
 			m_currentState = DETECTIONSTATE_DONE;
@@ -1143,7 +1143,7 @@ Bool FirewallHelperClass::detectionTest4Stage1Update() {
 	** what we would normally expect.
 	*/
 	m_packetID++;
-	m_timeoutStart = timeGetTime();
+	m_timeoutStart = time_utils::milliseconds();
 	m_timeoutLength = 4000;
 
 	sendToManglerFromPort(m_manglers[0], m_sparePorts[1], m_packetID);
@@ -1156,7 +1156,7 @@ Bool FirewallHelperClass::detectionTest4Stage2Update() {
 	m_mangledPorts[1] = getManglerResponse(m_packetID);
 
 	if (m_mangledPorts[1] == 0) {
-		if ((timeGetTime() - m_timeoutStart) > m_timeoutLength) {
+		if ((time_utils::milliseconds() - m_timeoutStart) > m_timeoutLength) {
 			closeSpareSocket(m_sparePorts[0]);
 			closeSpareSocket(m_sparePorts[1]);
 			m_currentState = DETECTIONSTATE_DONE;

--- a/src/game_engine/game_network/FrameMetrics.cpp
+++ b/src/game_engine/game_network/FrameMetrics.cpp
@@ -88,7 +88,7 @@ void FrameMetrics::reset() {
 
 void FrameMetrics::doPerFrameMetrics(UnsignedInt frame) {
 	// Do the measurement of the fps.
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 	if ((curTime - m_lastFpsTimeThing) >= 1000) {
 //		if ((m_fpsListIndex % 16) == 0) {
 //			DEBUG_LOG(("FrameMetrics::doPerFrameMetrics - adding %f to fps history. average before: %f ", m_fpsList[m_fpsListIndex], m_averageFps));
@@ -109,7 +109,7 @@ void FrameMetrics::doPerFrameMetrics(UnsignedInt frame) {
 }
 
 void FrameMetrics::processLatencyResponse(UnsignedInt frame) {
-	time_t curTime = timeGetTime();
+	time_t curTime = time_utils::milliseconds();
 	Int pendingIndex = frame % MAX_FRAMES_AHEAD;
 	time_t timeDiff = curTime - m_pendingLatencies[pendingIndex];
 

--- a/src/game_engine/game_network/GameSpy.cpp
+++ b/src/game_engine/game_network/GameSpy.cpp
@@ -300,7 +300,7 @@ void GameSpyChat::update( void )
 			}
 		}
 
-		UnsignedInt now = timeGetTime();
+		UnsignedInt now = time_utils::milliseconds();
 		if (m_loginTimeout && now > m_loginTimeout)
 		{
 			// login timed out
@@ -1403,7 +1403,7 @@ void GameSpyChat::login(AsciiString loginName, AsciiString password, AsciiString
 	}
 
 	//EnableLoginControls( FALSE );
-	m_loginTimeout = timeGetTime() + m_loginTimeoutPeriod;
+	m_loginTimeout = time_utils::milliseconds() + m_loginTimeoutPeriod;
 	if (!loginName.isEmpty() && !email.isEmpty() && !password.isEmpty())
 	{
 		m_usingProfiles = true;

--- a/src/game_engine/game_network/GameSpyPersistentStorage.cpp
+++ b/src/game_engine/game_network/GameSpyPersistentStorage.cpp
@@ -379,8 +379,8 @@ static Bool gameSpyInitPersistentStorageConnection( void )
 		return isProfileAuthorized;
 	}
 
-	UnsignedInt timeoutTime = timeGetTime() + 5000;
-	while (!isProfileAuthorized && timeGetTime() < timeoutTime && IsStatsConnected())
+	UnsignedInt timeoutTime = time_utils::milliseconds() + 5000;
+	while (!isProfileAuthorized && time_utils::milliseconds() < timeoutTime && IsStatsConnected())
 	{
 		PersistThink();
 		msleep(10);

--- a/src/game_engine/game_network/LANAPI.cpp
+++ b/src/game_engine/game_network/LANAPI.cpp
@@ -320,7 +320,7 @@ void LANAPI::update( void )
 	if(LANbuttonPushed)
 		return;
 	static const UnsignedInt LANAPIUpdateDelay = 200;
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 	
 	if( now > m_lastUpdate + LANAPIUpdateDelay)
 	{
@@ -644,7 +644,7 @@ void LANAPI::RequestGameJoin( LANGameInfo *game, UnsignedInt ip /* = 0 */ )
 	sendMessage(&msg, ip);
 
 	m_pendingAction = ACT_JOIN;
-	m_expiration = timeGetTime() + m_actionTimeout;
+	m_expiration = time_utils::milliseconds() + m_actionTimeout;
 }
 
 void LANAPI::RequestGameJoinDirectConnect(UnsignedInt ipaddress)
@@ -673,7 +673,7 @@ void LANAPI::RequestGameJoinDirectConnect(UnsignedInt ipaddress)
 	sendMessage(&msg, ipaddress);
 
 	m_pendingAction = ACT_JOINDIRECTCONNECT;
-	m_expiration = timeGetTime() + m_actionTimeout;
+	m_expiration = time_utils::milliseconds() + m_actionTimeout;
 }
 
 void LANAPI::RequestGameLeave( void )
@@ -697,7 +697,7 @@ void LANAPI::RequestGameLeave( void )
 	else
 	{
 		m_pendingAction = ACT_LEAVE;
-		m_expiration = timeGetTime() + m_actionTimeout;
+		m_expiration = time_utils::milliseconds() + m_actionTimeout;
 	}
 }
 
@@ -821,7 +821,7 @@ void LANAPI::RequestGameStartTimer( Int seconds )
 	if (m_inLobby || !m_currentGame || m_currentGame->getIP(0) != m_localIP)
 		return;
 
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 	m_gameStartTime = now + 1000;
 	m_gameStartSeconds = (seconds) ? seconds - 1 : 0;
 
@@ -923,7 +923,7 @@ void LANAPI::RequestGameCreate( UnicodeString gameName, Bool isDirectConnect )
 	myGame->setMap(mapName);
 	myGame->setIsDirectConnect(isDirectConnect);
 	
-	myGame->setLastHeard(timeGetTime());
+	myGame->setLastHeard(time_utils::milliseconds());
 	m_currentGame = myGame;
 
 /// @todo: Need to initialize the players elsewere.
@@ -1043,7 +1043,7 @@ void LANAPI::RequestSetName( UnicodeString newName )
 	}
 
 	// Set up timer
-	m_lastResendTime = timeGetTime();
+	m_lastResendTime = time_utils::milliseconds();
 
 	if (m_inLobby && m_pendingAction == ACT_NONE)
 	{
@@ -1067,7 +1067,7 @@ void LANAPI::RequestSetName( UnicodeString newName )
 		player->setName(m_name);
 		player->setHost(m_hostName);
 		player->setLogin(m_userName);
-		player->setLastHeard(timeGetTime());
+		player->setLastHeard(time_utils::milliseconds());
 
 		addPlayer(player);
 

--- a/src/game_engine/game_network/LANAPICallbacks.cpp
+++ b/src/game_engine/game_network/LANAPICallbacks.cpp
@@ -281,7 +281,7 @@ void LANAPI::OnGameOptions( UnsignedInt playerIP, Int playerSlot, AsciiString op
 
 	if (playerSlot == 0 && !m_currentGame->amIHost())
 	{
-		m_currentGame->setLastHeard(timeGetTime());
+		m_currentGame->setLastHeard(time_utils::milliseconds());
 		AsciiString oldOptions = GameInfoToAsciiString(m_currentGame); // save these off for if we get booted
 		if(ParseGameOptionsString(m_currentGame,options))
 		{
@@ -335,11 +335,11 @@ void LANAPI::OnGameOptions( UnsignedInt playerIP, Int playerSlot, AsciiString op
 		{
 			if (options.compare("HELLO") == 0)
 			{
-				m_currentGame->setPlayerLastHeard(playerSlot, timeGetTime());
+				m_currentGame->setPlayerLastHeard(playerSlot, time_utils::milliseconds());
 			}
 			else
 			{
-				m_currentGame->setPlayerLastHeard(playerSlot, timeGetTime());
+				m_currentGame->setPlayerLastHeard(playerSlot, time_utils::milliseconds());
 				Bool change = false;
 				Bool shouldUnaccept = false;
 				AsciiString key;

--- a/src/game_engine/game_network/LANAPIhandlers.cpp
+++ b/src/game_engine/game_network/LANAPIhandlers.cpp
@@ -49,7 +49,7 @@ void LANAPI::handleRequestLocations( LANMessage *msg, UnsignedInt senderIP )
 		reply.LANMessageType = LANMessage::MSG_LOBBY_ANNOUNCE;
 
 		sendMessage(&reply);
-		m_lastResendTime = timeGetTime();
+		m_lastResendTime = time_utils::milliseconds();
 	}
 	else
 	{
@@ -89,7 +89,7 @@ void LANAPI::handleRequestLocations( LANMessage *msg, UnsignedInt senderIP )
 	player->setName(UnicodeString(msg->name));
 	player->setHost(msg->hostName);
 	player->setLogin(msg->userName);
-	player->setLastHeard(timeGetTime());
+	player->setLastHeard(time_utils::milliseconds());
 
 	addPlayer(player);
 
@@ -121,7 +121,7 @@ void LANAPI::handleGameAnnounce( LANMessage *msg, UnsignedInt senderIP )
 			Bool success = ParseGameOptionsString(game,AsciiString(msg->GameInfo.options));
 			game->setGameInProgress(msg->GameInfo.inProgress);
 			game->setIsDirectConnect(msg->GameInfo.isDirectConnect);
-			game->setLastHeard(timeGetTime());
+			game->setLastHeard(time_utils::milliseconds());
 			if (!success)
 			{
 				// remove from list
@@ -145,7 +145,7 @@ void LANAPI::handleGameAnnounce( LANMessage *msg, UnsignedInt senderIP )
 		Bool success = ParseGameOptionsString(game,AsciiString(msg->GameInfo.options));
 		game->setGameInProgress(msg->GameInfo.inProgress);
 		game->setIsDirectConnect(msg->GameInfo.isDirectConnect);
-		game->setLastHeard(timeGetTime());
+		game->setLastHeard(time_utils::milliseconds());
 		if (!success)
 		{
 			// remove from list
@@ -175,7 +175,7 @@ void LANAPI::handleLobbyAnnounce( LANMessage *msg, UnsignedInt senderIP )
 	player->setName(UnicodeString(msg->name));
 	player->setHost(msg->hostName);
 	player->setLogin(msg->userName);
-	player->setLastHeard(timeGetTime());
+	player->setLastHeard(time_utils::milliseconds());
 
 	addPlayer(player);
 
@@ -342,7 +342,7 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 						newSlot.setState(SLOT_PLAYER, UnicodeString(msg->name));
 						newSlot.setIP(senderIP);
 						newSlot.setPort(NETWORK_BASE_PORT_NUMBER);
-						newSlot.setLastHeard(timeGetTime());
+						newSlot.setLastHeard(time_utils::milliseconds());
 						newSlot.setSerial(msg->GameToJoin.serial);
 						m_currentGame->setSlot(player,newSlot);
 						DEBUG_LOG(("LANAPI::handleRequestJoin - added player %ls at ip 0x%08x to the game\n", msg->name, senderIP));
@@ -470,7 +470,7 @@ void LANAPI::handleRequestGameLeave( LANMessage *msg, UnsignedInt senderIP )
 					lanPlayer->setName(UnicodeString(m_name));
 					lanPlayer->setHost(m_hostName);
 					lanPlayer->setLogin(m_userName);
-					lanPlayer->setLastHeard(timeGetTime());
+					lanPlayer->setLastHeard(time_utils::milliseconds());
 					addPlayer(lanPlayer);
 
 				}
@@ -579,7 +579,7 @@ void LANAPI::handleChat( LANMessage *msg, UnsignedInt senderIP )
 		if((player=LookupPlayer(senderIP)) != 0)
 		{
 			OnChat(UnicodeString(player->getName()), player->getIP(), UnicodeString(msg->Chat.message), msg->Chat.chatType);
-			player->setLastHeard(timeGetTime());
+			player->setLastHeard(time_utils::milliseconds());
 		}
 	}
 	else

--- a/src/game_engine/game_network/LANGameInfo.cpp
+++ b/src/game_engine/game_network/LANGameInfo.cpp
@@ -294,7 +294,7 @@ Bool ParseGameOptionsString(LANGameInfo *game, AsciiString options)
 			}
 		}
 		// clean up LAN users, etc.
-		UnsignedInt now = timeGetTime();
+		UnsignedInt now = time_utils::milliseconds();
 		for (i=0; i<MAX_SLOTS; ++i)
 		{
 			LANGameSlot *slot = game->getLANSlot(i);

--- a/src/game_engine/game_network/Network.cpp
+++ b/src/game_engine/game_network/Network.cpp
@@ -342,7 +342,7 @@ void Network::init()
 
 	m_localStatus = NETLOCALSTATUS_PREGAME;
 
-	QueryPerformanceFrequency((LARGE_INTEGER *)&m_perfCountFreq);
+    m_perfCountFreq = time_utils::frequency_ns();
 	m_nextFrameTime = 0;
 	m_sawCRCMismatch = FALSE;
 	m_checkCRCsThisFrame = FALSE;
@@ -758,8 +758,7 @@ void Network::endOfGameCheck() {
 }
 
 Bool Network::timeForNewFrame() {
-	__int64 curTime;
-	QueryPerformanceCounter((LARGE_INTEGER *)&curTime);
+    __int64 curTime = time_utils::ticks_ns();
 	__int64 frameDelay = m_perfCountFreq / m_frameRate;
 
 	/*

--- a/src/game_engine/game_network/Transport.cpp
+++ b/src/game_engine/game_network/Transport.cpp
@@ -117,8 +117,8 @@ Bool Transport::init( UnsignedInt ip, UnsignedShort port )
 		return false;
 	
 	int retval = -1;
-	time_t now = timeGetTime();
-	while ((retval != 0) && ((timeGetTime() - now) < 1000)) {
+	time_t now = time_utils::milliseconds();
+	while ((retval != 0) && ((time_utils::milliseconds() - now) < 1000)) {
 		retval = m_udpsock->Bind(ip, port);
 	}
 
@@ -149,7 +149,7 @@ Bool Transport::init( UnsignedInt ip, UnsignedShort port )
 		m_unknownPackets[i] = 0;
 	}
 	m_statisticsSlot = 0;
-	m_lastSecond = timeGetTime();
+	m_lastSecond = time_utils::milliseconds();
 
 	m_port = port;
 
@@ -205,7 +205,7 @@ Bool Transport::doSend() {
 	Bool retval = TRUE;
 
 	// Statistics gathering
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 	if (m_lastSecond + 1000 < now)
 	{
 		m_lastSecond = now;
@@ -286,7 +286,7 @@ Bool Transport::doRecv()
 	// Read in anything on our socket
 	sockaddr_in from;
 #if defined(_DEBUG) || defined(_INTERNAL)
-	UnsignedInt now = timeGetTime();
+	UnsignedInt now = time_utils::milliseconds();
 #endif
 
 	TransportMessage incomingMessage;

--- a/src/game_engine/game_network/game_spy/thread/PeerThread.cpp
+++ b/src/game_engine/game_network/game_spy/thread/PeerThread.cpp
@@ -1527,7 +1527,7 @@ void PeerThreadClass::Thread_Function()
 
 #ifdef DEBUG_LOGGING
 					static UnsignedInt prev = 0;
-					UnsignedInt now = timeGetTime();
+					UnsignedInt now = time_utils::milliseconds();
 					UnsignedInt diff = now - prev;
 					prev = now;
 #endif
@@ -1630,7 +1630,7 @@ void PeerThreadClass::Thread_Function()
 							peerLeaveRoom( peer, GroupRoom, NULL );
 						}
 						isThreadHosting = 1; // debugging
-						s_lastStateChangedHeartbeat = timeGetTime(); // wait the full interval before updating state
+						s_lastStateChangedHeartbeat = time_utils::milliseconds(); // wait the full interval before updating state
 						s_wantStateChangedHeartbeat = FALSE;
 						m_isHosting = TRUE;
 						m_allowObservers = incomingRequest.stagingRoomCreation.allowObservers;
@@ -1720,7 +1720,7 @@ void PeerThreadClass::Thread_Function()
 
 		if (isThreadHosting && s_wantStateChangedHeartbeat)
 		{
-			UnsignedInt now = timeGetTime();
+			UnsignedInt now = time_utils::milliseconds();
 			if (now > s_lastStateChangedHeartbeat + s_heartbeatInterval)
 			{
 				s_lastStateChangedHeartbeat = now;
@@ -1729,7 +1729,7 @@ void PeerThreadClass::Thread_Function()
 
 #ifdef DEBUG_LOGGING
 				static UnsignedInt prev = 0;
-				UnsignedInt now = timeGetTime();
+				UnsignedInt now = time_utils::milliseconds();
 				UnsignedInt diff = now - prev;
 				prev = now;
 #endif

--- a/src/game_engine_device/w3d_device/game_client/W3DDisplay.cpp
+++ b/src/game_engine_device/w3d_device/game_client/W3DDisplay.cpp
@@ -322,16 +322,16 @@ W3DAssetManager *W3DDisplay::m_assetManager = NULL;
 // only valid when "-vtune" is used... (srj)
 inline Int64 getPerformanceCounter()
 {
-	Int64 tmp;
-	QueryPerformanceCounter((LARGE_INTEGER *)&tmp);
-	return tmp;
+    Int64 tmp;
+    tmp = time_utils::ticks_ns();
+    return tmp;
 }
 
 inline Int64 getPerformanceCounterFrequency()
 {
-	Int64 tmp;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&tmp);
-	return tmp;
+    Int64 tmp;
+    tmp = time_utils::frequency_ns();
+    return tmp;
 }
 
 // W3DDisplay::W3DDisplay =====================================================
@@ -1761,9 +1761,9 @@ AGAIN:
 
 	// Fast & Frozen time limits the time to 33 fps.
 	Int minTime = 30;
-	static Int prevTime = timeGetTime(), now;
+	static Int prevTime = time_utils::milliseconds(), now;
 
-	now = timeGetTime();
+	now = time_utils::milliseconds();
 	if (TheTacticalView->getTimeMultiplier() > 1)
 	{
 		static Int timeMultiplierCounter = 1;
@@ -1775,7 +1775,7 @@ AGAIN:
 	}
 	else
 	{
-		now = timeGetTime();
+		now = time_utils::milliseconds();
 		prevTime = now - minTime; // do the first frame immediately.
 	}
 
@@ -1789,7 +1789,7 @@ AGAIN:
 				// limit the framerate
 				while (TheGlobalData->m_useFpsLimit && (now - prevTime) < minTime - 1)
 				{
-					now = timeGetTime();
+					now = time_utils::milliseconds();
 				}
 				prevTime = now;
 			}
@@ -2039,7 +2039,7 @@ void W3DDisplay::createLightPulse(const Coord3D *pos, const RGBColor *color,
 void W3DDisplay::toggleLetterBox(void)
 {
 	m_letterBoxEnabled = !m_letterBoxEnabled;
-	m_letterBoxFadeStartTime = timeGetTime();
+	m_letterBoxFadeStartTime = time_utils::milliseconds();
 }
 
 void W3DDisplay::enableLetterBox(Bool enable)
@@ -2049,7 +2049,7 @@ void W3DDisplay::enableLetterBox(Bool enable)
 		if (!m_letterBoxEnabled)
 		{ // letterbox mode not previously enabled
 			m_letterBoxEnabled = TRUE;
-			m_letterBoxFadeStartTime = timeGetTime();
+			m_letterBoxFadeStartTime = time_utils::milliseconds();
 		}
 	}
 	else
@@ -2057,7 +2057,7 @@ void W3DDisplay::enableLetterBox(Bool enable)
 		if (m_letterBoxEnabled)
 		{ // letterbox mode no previously disabled
 			m_letterBoxEnabled = FALSE;
-			m_letterBoxFadeStartTime = timeGetTime();
+			m_letterBoxFadeStartTime = time_utils::milliseconds();
 		}
 	}
 }
@@ -3235,8 +3235,8 @@ void W3DDisplay::dumpAssetUsage(const char *mapname)
 //-------------------------------------------------------------------------------------------------
 static void drawFramerateBar(void)
 {
-	static DWORD prevTime = timeGetTime();
-	DWORD now = timeGetTime();
+	static DWORD prevTime = time_utils::milliseconds();
+	DWORD now = time_utils::milliseconds();
 	Real percTime = (1000.0f / (now - prevTime)) / (1000.0f / TheGlobalData->m_framesPerSecondLimit);
 
 	if (percTime > 1.0f)

--- a/src/game_engine_device/w3d_device/game_client/W3DGranny.cpp
+++ b/src/game_engine_device/w3d_device/game_client/W3DGranny.cpp
@@ -1056,7 +1056,7 @@ void GrannyRenderObjClassSystem::shutdown( void )
 void GrannyRenderObjClassSystem::update()
 {
 
-	Int		iTime=timeGetTime();
+	Int		iTime=time_utils::milliseconds();
 }
 
 

--- a/src/game_engine_device/w3d_device/game_client/W3DMouse.cpp
+++ b/src/game_engine_device/w3d_device/game_client/W3DMouse.cpp
@@ -420,7 +420,7 @@ void W3DMouse::setCursor( MouseCursor cursor )
 			m_pDev->ShowCursor(TRUE);	//Enable DX8 cursor
 			m_currentD3DFrame=(Int)m_currentAnimFrame;
 			m_currentD3DCursor = cursor;
-			m_lastAnimTime=timeGetTime();
+			m_lastAnimTime=time_utils::milliseconds();
 		}
 	}
 	else if (m_currentRedrawMode == RM_POLYGON)
@@ -502,7 +502,7 @@ void W3DMouse::draw(void)
 			//Check if animated cursor and new frame
 			if (m_currentFrames > 1)
 			{
-				Int msTime=timeGetTime();
+				Int msTime=time_utils::milliseconds();
 				m_currentAnimFrame += (msTime-m_lastAnimTime) * m_currentFMS;
 				m_currentAnimFrame=fmod(m_currentAnimFrame,m_currentFrames);
 				m_lastAnimTime=msTime;

--- a/src/game_engine_device/w3d_device/game_client/W3DShaderManager.cpp
+++ b/src/game_engine_device/w3d_device/game_client/W3DShaderManager.cpp
@@ -2881,9 +2881,9 @@ Real W3DShaderManager::GetCPUBenchTime(void)
 	float ztot, yran, ymult, ymod, x, y, z, pi, prod;
     long int low, ixran, itot, j, iprod;
 
-  	__int64 endTime64,freq64,startTime64;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
-	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
+    __int64 endTime64,freq64,startTime64;
+    freq64 = time_utils::frequency_ns();
+    startTime64 = time_utils::ticks_ns();
 
     ztot = 0.0;
     low = 1;
@@ -2910,6 +2910,6 @@ Real W3DShaderManager::GetCPUBenchTime(void)
 	}
 	pi = 4.0 * (float)low/(float)itot;
 
-	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-	return ((double)(endTime64-startTime64)/(double)(freq64));
+    endTime64 = time_utils::ticks_ns();
+    return ((double)(endTime64-startTime64)/(double)(freq64));
 }

--- a/src/game_engine_device/w3d_device/game_client/W3DShroud.cpp
+++ b/src/game_engine_device/w3d_device/game_client/W3DShroud.cpp
@@ -713,9 +713,9 @@ void W3DShroud::render(CameraClass *cam)
 //-----------------------------------------------------------------------------
 void W3DShroud::interpolateFogLevels(RECT *rect)
 {
-	static UnsignedInt prevTime = timeGetTime();
+	static UnsignedInt prevTime = time_utils::milliseconds();
 
-	UnsignedInt timeDiff=timeGetTime()-prevTime;
+	UnsignedInt timeDiff=time_utils::milliseconds()-prevTime;
 
 	if (!timeDiff)
 		return;	//no time has elapsed

--- a/src/game_engine_device/w3d_device/game_client/W3DView.cpp
+++ b/src/game_engine_device/w3d_device/game_client/W3DView.cpp
@@ -827,11 +827,11 @@ void W3DView::update(void)
 	Bool recalcCamera = false;
 	Bool didScriptedMovement = false;
 #ifdef LOG_FRAME_TIMES
-	__int64 curTime64, freq64;
-	static __int64 prevTime64 = 0;
-	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
-	QueryPerformanceCounter((LARGE_INTEGER *)&curTime64);
-	freq64 /= 1000;
+    __int64 curTime64, freq64;
+    static __int64 prevTime64 = 0;
+    freq64 = time_utils::frequency_ns();
+    curTime64 = time_utils::ticks_ns();
+    freq64 /= 1000;
 
 	Int elapsedTimeMs = (curTime64 - prevTime64) / freq64;
 	prevTime64 = curTime64;

--- a/src/game_engine_device/w3d_device/game_client/gui/gui_callbacks/W3DMainMenu.cpp
+++ b/src/game_engine_device/w3d_device/game_client/gui/gui_callbacks/W3DMainMenu.cpp
@@ -111,8 +111,8 @@ static void advancePosition(GameWindow *window, const Image *image, UnsignedInt 
 	static Int x = -800;
 	static Int y = pos.y - (image->getImageHeight() / 2);
 
-	static UnsignedInt m_startTime = timeGetTime();
-	Int time = timeGetTime() - m_startTime;
+	static UnsignedInt m_startTime = time_utils::milliseconds();
+	Int time = time_utils::milliseconds() - m_startTime;
 	Real percentDone = INT_TO_REAL(time) / 10000;
 
 	if (goingForward)
@@ -120,7 +120,7 @@ static void advancePosition(GameWindow *window, const Image *image, UnsignedInt 
 		if (percentDone >= 1)
 		{
 			y = pos.y + size.y - (image->getImageHeight() / 2);
-			m_startTime = timeGetTime();
+			m_startTime = time_utils::milliseconds();
 			goingForward = FALSE;
 		}
 		else
@@ -134,7 +134,7 @@ static void advancePosition(GameWindow *window, const Image *image, UnsignedInt 
 		if (percentDone >= 1)
 		{
 			y = pos.y - (image->getImageHeight() / 2);
-			m_startTime = timeGetTime();
+			m_startTime = time_utils::milliseconds();
 			goingForward = TRUE;
 		}
 		else
@@ -295,14 +295,14 @@ void W3DMetalBarMenuDraw(GameWindow *window, WinInstanceData *instData)
 //	static Int x = pos.x - image->getImageWidth();
 //	static Int y = pos.y - (image->getImageHeight()/2);
 //
-//	static UnsignedInt m_startTime = timeGetTime();
-//	Int time = timeGetTime() - m_startTime;
+//	static UnsignedInt m_startTime = time_utils::milliseconds();
+//	Int time = time_utils::milliseconds() - m_startTime;
 //	Real percentDone = INT_TO_REAL(time) / 15624;
 //
 //	if(percentDone >= 1)
 //	{
 ////			y = pos.y + size.y - (image->getImageHeight()/2) - 2;
-//			m_startTime = timeGetTime();
+//			m_startTime = time_utils::milliseconds();
 //	}
 //		else
 //		{

--- a/src/game_engine_device/w3d_device/game_client/gui/gui_callbacks/w3d_main_menu.cpp
+++ b/src/game_engine_device/w3d_device/game_client/gui/gui_callbacks/w3d_main_menu.cpp
@@ -111,8 +111,8 @@ static void advancePosition(GameWindow *window, const Image *image, UnsignedInt 
 	static Int x = -800;
 	static Int y = pos.y - (image->getImageHeight() / 2);
 
-	static UnsignedInt m_startTime = timeGetTime();
-	Int time = timeGetTime() - m_startTime;
+	static UnsignedInt m_startTime = time_utils::milliseconds();
+	Int time = time_utils::milliseconds() - m_startTime;
 	Real percentDone = INT_TO_REAL(time) / 10000;
 
 	if (goingForward)
@@ -120,7 +120,7 @@ static void advancePosition(GameWindow *window, const Image *image, UnsignedInt 
 		if (percentDone >= 1)
 		{
 			y = pos.y + size.y - (image->getImageHeight() / 2);
-			m_startTime = timeGetTime();
+			m_startTime = time_utils::milliseconds();
 			goingForward = FALSE;
 		}
 		else
@@ -134,7 +134,7 @@ static void advancePosition(GameWindow *window, const Image *image, UnsignedInt 
 		if (percentDone >= 1)
 		{
 			y = pos.y - (image->getImageHeight() / 2);
-			m_startTime = timeGetTime();
+			m_startTime = time_utils::milliseconds();
 			goingForward = TRUE;
 		}
 		else
@@ -295,14 +295,14 @@ void W3DMetalBarMenuDraw(GameWindow *window, WinInstanceData *instData)
 //	static Int x = pos.x - image->getImageWidth();
 //	static Int y = pos.y - (image->getImageHeight()/2);
 //
-//	static UnsignedInt m_startTime = timeGetTime();
-//	Int time = timeGetTime() - m_startTime;
+//	static UnsignedInt m_startTime = time_utils::milliseconds();
+//	Int time = time_utils::milliseconds() - m_startTime;
 //	Real percentDone = INT_TO_REAL(time) / 15624;
 //
 //	if(percentDone >= 1)
 //	{
 ////			y = pos.y + size.y - (image->getImageHeight()/2) - 2;
-//			m_startTime = timeGetTime();
+//			m_startTime = time_utils::milliseconds();
 //	}
 //		else
 //		{

--- a/src/game_engine_device/w3d_device/game_client/shadow/W3DVolumetricShadow.cpp
+++ b/src/game_engine_device/w3d_device/game_client/shadow/W3DVolumetricShadow.cpp
@@ -1718,7 +1718,7 @@ void W3DVolumetricShadow::Update()
 	// changes or when the object rotation sufficiently changes
 	//
 
-//	currentTime = timeGetTime();
+//	currentTime = time_utils::milliseconds();
 //	if( currentTime - lastTime >= delay )
 	{
 		pos=m_robj->Get_Position();

--- a/src/game_engine_device/w3d_device/game_client/water/W3DWater.cpp
+++ b/src/game_engine_device/w3d_device/game_client/water/W3DWater.cpp
@@ -968,7 +968,7 @@ Int WaterRenderObjClass::init(Real waterLevel, Real dx, Real dy, SceneClass *par
 	m_dy=dy;
 	m_level=waterLevel;
 
-	m_LastUpdateTime=timeGetTime();
+	m_LastUpdateTime=time_utils::milliseconds();
 	m_uScrollPerMs=0.001f;
 	m_vScrollPerMs=0.001f;
 	m_uOffset=0;
@@ -2012,7 +2012,7 @@ void WaterRenderObjClass::renderSky(void)
 
 	Setting *setting=&m_settings[m_tod];
 
-	timeNow=timeGetTime();
+	timeNow=time_utils::milliseconds();
 
 	timeDiff=timeNow-m_LastUpdateTime;
 	m_LastUpdateTime=timeNow;

--- a/src/game_engine_device/w3d_device/game_client/water/W3DWaterTracks.cpp
+++ b/src/game_engine_device/w3d_device/game_client/water/W3DWaterTracks.cpp
@@ -826,10 +826,10 @@ void WaterTracksRenderSystem::shutdown( void )
 void WaterTracksRenderSystem::update()
 {
 
-	static  Int iLastTime=timeGetTime();
+	static  Int iLastTime=time_utils::milliseconds();
 	WaterTracksObj *mod=m_usedModules,*nextMod;
 
-	Int timeDiff = timeGetTime()-iLastTime;
+	Int timeDiff = time_utils::milliseconds()-iLastTime;
 	iLastTime += timeDiff;
 
 	//Lock framerate to 30 fps

--- a/src/libraries/wp_audio/AUD_Profiler.cpp
+++ b/src/libraries/wp_audio/AUD_Profiler.cpp
@@ -92,10 +92,7 @@ void ProfCacheInit(ProfileData *prof, int pages, int pageSize)
 {
 
 	memset(prof, 0, sizeof(ProfileData));
-	if (!QueryPerformanceFrequency((LARGE_INTEGER *)&prof->freq))
-	{
-		prof->freq = 0;
-	}
+    prof->freq = time_utils::frequency_ns();
 	prof->update = prof->freq;
 	prof->cacheSize = pages * pageSize;
 	prof->numPages = pages;
@@ -204,7 +201,7 @@ void ProfCacheNewFrame(ProfileData *prof)
 
 void ProfCacheLoadStart(ProfileData *prof, int bytes)
 {
-	QueryPerformanceCounter((LARGE_INTEGER *)&prof->start);
+    prof->start = time_utils::ticks_ns();
 	prof->dbytes = bytes;
 	prof->start_decomp = 0;
 	prof->pageCount++;
@@ -227,7 +224,7 @@ void ProfCacheAddLoadBytes(ProfileData *prof, int bytes)
 
 void ProfCacheDecompress(ProfileData *prof, int bytes)
 {
-	QueryPerformanceCounter((LARGE_INTEGER *)&prof->start_decomp);
+    prof->start_decomp = time_utils::ticks_ns();
 	prof->lbytes = bytes;
 }
 
@@ -238,7 +235,7 @@ void ProfCacheDecompress(ProfileData *prof, int bytes)
 
 void ProfCacheLoadEnd(ProfileData *prof)
 {
-	QueryPerformanceCounter((LARGE_INTEGER *)&prof->end);
+    prof->end = time_utils::ticks_ns();
 	prof->totalTime += prof->end - prof->start;
 	prof->totalDataBytes += prof->dbytes;
 	prof->totalFrameBytes += prof->dbytes;
@@ -430,10 +427,7 @@ void ProfileCPUInit(ProfileCPU &prof)
 
 	memset(&prof, 0, sizeof(ProfileCPU));
 
-	if (!QueryPerformanceFrequency((LARGE_INTEGER *)&prof.freq))
-	{
-		prof.freq = 0;
-	}
+    prof.freq = time_utils::frequency_ns();
 	prof.updateInterval = SECONDS(1);
 
 	if (prof.freq)
@@ -467,7 +461,7 @@ void ProfileCPUStart(ProfileCPU &prof)
 
 	if (prof.state == PROF_STATE_IDLE)
 	{
-		QueryPerformanceCounter((LARGE_INTEGER *)&prof.start);
+            prof.start = time_utils::ticks_ns();
 
 		if (prof.lastStart)
 		{
@@ -491,7 +485,7 @@ void ProfileCPUPause(ProfileCPU &prof)
 	{
 		ProfStamp end;
 
-		QueryPerformanceCounter((LARGE_INTEGER *)&end);
+            end = time_utils::ticks_ns();
 
 		prof.totalTicks += calc_ticks(prof.start, end);
 		prof.state = PROF_STATE_PAUSED;
@@ -507,7 +501,7 @@ void ProfileCPUResume(ProfileCPU &prof)
 {
 	if (prof.state == PROF_STATE_PAUSED)
 	{
-		QueryPerformanceCounter((LARGE_INTEGER *)&prof.start);
+            prof.start = time_utils::ticks_ns();
 		prof.state = PROF_STATE_PROFILING;
 	}
 }
@@ -521,7 +515,7 @@ void ProfileCPUEnd(ProfileCPU &prof)
 {
 	ProfStamp end;
 
-	QueryPerformanceCounter((LARGE_INTEGER *)&end);
+    end = time_utils::ticks_ns();
 
 	if (prof.state != PROF_STATE_IDLE)
 	{

--- a/src/libraries/wp_audio/AUD_Time.cpp
+++ b/src/libraries/wp_audio/AUD_Time.cpp
@@ -104,7 +104,7 @@ static TimeStamp highResGetTime(void)
 	} myTime;
 
 	// read the high res counter
-	QueryPerformanceCounter(&count);
+    count.QuadPart = time_utils::ticks_ns();
 
 	// convert high res ticks to number of milliseconds
 	myTime.largeInt.QuadPart = count.QuadPart / timerMilliSecScale;
@@ -142,7 +142,7 @@ retry:
 
 reread:
 
-	now = timeGetTime();
+    now = time_utils::milliseconds();
 
 	if (now < lw)
 	{
@@ -181,18 +181,18 @@ reread:
 
 void InitAudioTimer(void)
 {
-	LARGE_INTEGER freq;
+    LARGE_INTEGER freq;
 
-	// does hardware exist for high res counter?
-	if (QueryPerformanceFrequency(&freq))
-	{
-		// calculate timer ticks per second
-		timerMilliSecScale = freq.QuadPart / (LONGLONG)SECONDS(1);
+    freq.QuadPart = time_utils::frequency_ns();
+    if (freq.QuadPart)
+    {
+        // calculate timer ticks per second
+        timerMilliSecScale = freq.QuadPart / (LONGLONG)SECONDS(1);
 
-		timerFunc = highResGetTime;
-	}
-	else
-	{
+        timerFunc = highResGetTime;
+    }
+    else
+    {
 		// no high res timer, use old code instead
 		timerFunc = failsafeGetTime;
 	}

--- a/src/libraries/ww_vegas/ww_download/Download.cpp
+++ b/src/libraries/ww_vegas/ww_download/Download.cpp
@@ -344,7 +344,7 @@ HRESULT CDownload::PumpMessages()
 		if( m_TimeStarted == 0 )
 		{
 			// This is the first time through here - record the starting time.
-			m_TimeStarted = timeGetTime();
+			m_TimeStarted = time_utils::milliseconds();
 		}
 
 		if( iResult == FTP_SUCCEEDED )
@@ -364,7 +364,7 @@ HRESULT CDownload::PumpMessages()
 		// Calculate time taken so far, and predict how long there is left.
 		// The prediction returned is the average of the last 8 predictions.
 
-		timetaken = ( timeGetTime() - m_TimeStarted ) / 1000;
+		timetaken = ( time_utils::milliseconds() - m_TimeStarted ) / 1000;
 
 		//////////if( m_BytesRead > 0 ) // NAK - RP said this is wrong
       if( ( m_BytesRead - m_StartPosition ) > 0 )

--- a/src/tools/launcher/Protect.cpp
+++ b/src/tools/launcher/Protect.cpp
@@ -281,7 +281,7 @@ void SendProtectMessage(HANDLE process, DWORD threadID)
 	DebugPrint("Waiting for game (timeout in %.02f seconds)...\n", ((float)((5 * 60) * 1000) * 0.001));
 
 #ifdef _DEBUG
-	unsigned long start = timeGetTime();
+	unsigned long start = time_utils::milliseconds();
 #endif
 
 	HANDLE handles[2];
@@ -290,7 +290,7 @@ void SendProtectMessage(HANDLE process, DWORD threadID)
 	DWORD waitResult = WaitForMultipleObjects(2, &handles[0], FALSE, ((5 * 60) * 1000));
 
 #ifdef _DEBUG
-	unsigned long stop = timeGetTime();
+	unsigned long stop = time_utils::milliseconds();
 #endif
 
 	DebugPrint("WaitResult = %ld (WAIT_OBJECT_0 = %ld)\n", waitResult, WAIT_OBJECT_0);

--- a/src/tools/timing_test/timingTest.cpp
+++ b/src/tools/timing_test/timingTest.cpp
@@ -59,11 +59,11 @@ void InitPrecisionTimer()
 		INT64 StartTicks;
 		INT64 EndTicks;
 
-		TimeStart = timeGetTime();
+		TimeStart = time_utils::milliseconds();
 		GetPrecisionTimer(&StartTicks);
 		for (;;)
 		{
-			TimeStop = timeGetTime();
+			TimeStop = time_utils::milliseconds();
 			if ((TimeStop - TimeStart) > 1000)
 			{
 				GetPrecisionTimer(&EndTicks);


### PR DESCRIPTION
## Summary
- add `time_utils` header with C++ chrono wrappers
- include `time_utils` in the precompiled header
- replace `timeGetTime` and `QueryPerformanceCounter` usages

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685d846b36e48325943fbaf3f94933f1