### PR TITLE
Fix NameKeyType usage in STL typedefs

### DIFF
--- a/include/game_engine/common/stltypedefs.h
+++ b/include/game_engine/common/stltypedefs.h
@@ -66,7 +66,6 @@ class STLSpecialAlloc;
 
 // FORWARD DECLARATIONS
 class Object;
-enum NameKeyType;
 enum ObjectID;
 enum DrawableID;
 


### PR DESCRIPTION
## Summary
- remove the stale `NameKeyType` forward declaration from `stltypedefs.h`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2` *(fails: `time_utils` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c68f6488325a0c417b821da19e8