### PR TITLE
Fix callback helpers using this pointer

### DIFF
--- a/include/libraries/ww_vegas/ww_audio/AudioEvents.h
+++ b/include/libraries/ww_vegas/ww_audio/AudioEvents.h
@@ -182,11 +182,11 @@ AudioCallbackListClass<T>::Add_Callback (T pointer, uint32 user_data)
 template <class T> T
 AudioCallbackListClass<T>::Get_Callback (int index, uint32 *user_data)
 {
-	if (user_data != NULL) {
-		(*user_data) = Vector[index].user_data;
-	}
+       if (user_data != NULL) {
+               (*user_data) = this->Vector[index].user_data;
+       }
 
-	return Vector[index].callback_ptr;
+       return this->Vector[index].callback_ptr;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -195,12 +195,12 @@ AudioCallbackListClass<T>::Get_Callback (int index, uint32 *user_data)
 template <class T> void
 AudioCallbackListClass<T>::Remove_Callback (T pointer)
 {
-	for (int index = 0; index < ActiveCount; index ++) {
-		if (Vector[index].callback_ptr == pointer) {
-			Delete (index);
-			break;
-		}
-	}
+       for (int index = 0; index < this->ActiveCount; index ++) {
+               if (this->Vector[index].callback_ptr == pointer) {
+                       this->Delete (index);
+                       break;
+               }
+       }
 
 	return ;
 }


### PR DESCRIPTION
## Summary
- fix SimpleDynVecClass member access for callbacks

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: invalid code in repo)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c628a348325877aeaedad4702b2