### PR TITLE
Fix GCC build with missing stdcall

### DIFF
--- a/include/libraries/ww_vegas/ww_audio/AudioEvents.h
+++ b/include/libraries/ww_vegas/ww_audio/AudioEvents.h
@@ -65,6 +65,9 @@ class StringClass;
 // Callback declarations.  These functions are called when a registered event occurs
 // in the sound library/
 //
+#ifndef _stdcall
+#define _stdcall
+#endif
 typedef void (_stdcall  *LPFNSOSCALLBACK)		(SoundSceneObjClass *sound_obj, uint32 user_param);
 typedef void (_stdcall  *LPFNEOSCALLBACK)		(SoundSceneObjClass *sound_obj, uint32 user_param);
 typedef void (_stdcall  *LPFNHEARDCALLBACK)	(LogicalListenerClass *listener, LogicalSoundClass *sound_obj, uint32 user_param);


### PR DESCRIPTION
## Summary
- define `_stdcall` if missing to allow GCC builds

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685d8d06a49c83258715f1b6fedec2ee