### PR TITLE
Replace deprecated hash_map

### DIFF
--- a/include/game_client/fxlist.h
+++ b/include/game_client/fxlist.h
@@ -212,7 +212,7 @@ public:
 private:
 
 	// use the hashing function for Ints. 
-	typedef std::hash_map< NameKeyType, FXList, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > FXListMap;
+	typedef std::unordered_map< NameKeyType, FXList, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > FXListMap;
 
 	FXListMap m_fxmap;
 

--- a/include/game_client/gameclient.h
+++ b/include/game_client/gameclient.h
@@ -57,7 +57,7 @@ struct RayEffectData;
 
 /// Function pointers for use by GameClient callback functions.
 typedef void (*GameClientFuncPtr)(Drawable *draw, void *userData);
-typedef std::hash_map<DrawableID, Drawable *, rts::hash<DrawableID>, rts::equal_to<DrawableID>> DrawablePtrHash;
+typedef std::unordered_map<DrawableID, Drawable *, rts::hash<DrawableID>, rts::equal_to<DrawableID>> DrawablePtrHash;
 typedef DrawablePtrHash::iterator DrawablePtrHashIt;
 
 //-----------------------------------------------------------------------------

--- a/include/game_client/particlesys.h
+++ b/include/game_client/particlesys.h
@@ -716,7 +716,7 @@ class ParticleSystemManager : public SubsystemInterface,
 public:
 	typedef std::list<ParticleSystem *> ParticleSystemList;
 	typedef std::list<ParticleSystem *>::iterator ParticleSystemListIt;
-	typedef std::hash_map<AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString>> TemplateMap;
+	typedef std::unordered_map<AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString>> TemplateMap;
 
 	ParticleSystemManager(void);
 	virtual ~ParticleSystemManager();

--- a/include/game_client/windowvideomanager.h
+++ b/include/game_client/windowvideomanager.h
@@ -156,7 +156,7 @@ private:
 	}
 	};
 
-	typedef std::hash_map< ConstGameWindowPtr, WindowVideo *, hashConstGameWindowPtr, std::equal_to<ConstGameWindowPtr> > WindowVideoMap;
+	typedef std::unordered_map< ConstGameWindowPtr, WindowVideo *, hashConstGameWindowPtr, std::equal_to<ConstGameWindowPtr> > WindowVideoMap;
 
 	WindowVideoMap m_playingVideos;								///< List of currently playin Videos
 	//WindowVideoMap m_pausedVideos;									///< List of currently paused Videos

--- a/include/game_engine/common/damagefx.h
+++ b/include/game_engine/common/damagefx.h
@@ -157,7 +157,7 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, DamageFX, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > DamageFXMap;
+	typedef std::unordered_map< NameKeyType, DamageFX, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > DamageFXMap;
 	DamageFXMap m_dfxmap;
 
 };

--- a/include/game_engine/common/player.h
+++ b/include/game_engine/common/player.h
@@ -148,7 +148,7 @@ struct SpecialPowerReadyTimerType
 
 
 // ------------------------------------------------------------------------------------------------
-typedef std::hash_map< PlayerIndex, Relationship, std::hash<PlayerIndex>, std::equal_to<PlayerIndex> > PlayerRelationMapType;
+typedef std::unordered_map< PlayerIndex, Relationship, std::hash<PlayerIndex>, std::equal_to<PlayerIndex> > PlayerRelationMapType;
 class PlayerRelationMap : public MemoryPoolObject,
 													public Snapshot
 {

--- a/include/game_engine/common/sparsematchfinder.h
+++ b/include/game_engine/common/sparsematchfinder.h
@@ -73,7 +73,7 @@ private:
 	};
 
 	//-------------------------------------------------------------------------------------------------
-	typedef std::hash_map< BITSET, const MATCHABLE*, HashMapHelper, HashMapHelper > MatchMap;
+	typedef std::unordered_map< BITSET, const MATCHABLE*, HashMapHelper, HashMapHelper > MatchMap;
 
 	//-------------------------------------------------------------------------------------------------
 	// MEMBER VARS

--- a/include/game_engine/common/stltypedefs.h
+++ b/include/game_engine/common/stltypedefs.h
@@ -72,7 +72,7 @@ enum DrawableID;
 
 #include <algorithm>
 #include <bitset>
-#include <hash_map>
+#include <unordered_map>
 #include <list>
 #include <map>
 #include <queue>
@@ -114,7 +114,7 @@ typedef std::vector<Bool>::iterator												BoolVectorIterator;
 typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
 typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
 
-// Some useful, common hash and equal_to functors for use with hash_map
+// Some useful, common hash and equal_to functors for use with unordered_map
 namespace rts 
 {
 	

--- a/include/game_engine/common/team.h
+++ b/include/game_engine/common/team.h
@@ -45,7 +45,7 @@ typedef UnsignedInt TeamPrototypeID;
 #define TEAM_PROTOTYPE_ID_INVALID 0
 
 // ------------------------------------------------------------------------------------------------
-typedef std::hash_map< TeamID, Relationship, std::hash<TeamID>, std::equal_to<TeamID> > TeamRelationMapType;
+typedef std::unordered_map< TeamID, Relationship, std::hash<TeamID>, std::equal_to<TeamID> > TeamRelationMapType;
 class TeamRelationMap : public MemoryPoolObject,
 												public Snapshot
 {

--- a/include/game_engine/common/thingfactory.h
+++ b/include/game_engine/common/thingfactory.h
@@ -47,7 +47,7 @@ class Object;
 class Drawable;
 class INI;
 
-typedef std::hash_map<AsciiString, ThingTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString>> ThingTemplateHashMap;
+typedef std::unordered_map<AsciiString, ThingTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString>> ThingTemplateHashMap;
 typedef ThingTemplateHashMap::iterator ThingTemplateHashMapIt;
 //-------------------------------------------------------------------------------------------------
 /** Implementation of the thing manager interface singleton */

--- a/include/game_engine/game_logic/armor.h
+++ b/include/game_engine/game_logic/armor.h
@@ -122,7 +122,7 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
+	typedef std::unordered_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
 	ArmorTemplateMap m_armorTemplates;
 
 };

--- a/include/game_engine/game_logic/gamelogic.h
+++ b/include/game_engine/game_logic/gamelogic.h
@@ -92,7 +92,7 @@ enum
 
 /// Function pointers for use by GameLogic callback functions.
 typedef void (*GameLogicFuncPtr)( Object *obj, void *userData ); 
-typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
+typedef std::unordered_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
 typedef ObjectPtrHash::const_iterator ObjectPtrIter;
 
 
@@ -264,13 +264,13 @@ private:
 		overrides to thing template buildable status. doesn't really belong here,
 		but has to go somewhere. (srj)
 	*/
-	typedef std::hash_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString> > BuildableMap;
+	typedef std::unordered_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString> > BuildableMap;
 	BuildableMap m_thingTemplateBuildableOverrides;
 
 	/**
 		overrides to control bars. doesn't really belong here, but has to go somewhere. (srj)
 	*/
-	typedef std::hash_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ControlBarOverrideMap;
+	typedef std::unordered_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ControlBarOverrideMap;
 	ControlBarOverrideMap m_controlBarOverrides;
 
 	Real m_width, m_height;																	///< Dimensions of the world

--- a/include/game_engine_device/miles_audio_device/miles_audio_manager.h
+++ b/include/game_engine_device/miles_audio_device/miles_audio_manager.h
@@ -100,7 +100,7 @@ struct OpenAudioFile
 	const AudioEventInfo *m_eventInfo; // Not mutable, unlike the one on AudioEventRTS.
 };
 
-typedef std::hash_map<AsciiString, OpenAudioFile, rts::hash<AsciiString>, rts::equal_to<AsciiString>> OpenFilesHash;
+typedef std::unordered_map<AsciiString, OpenAudioFile, rts::hash<AsciiString>, rts::equal_to<AsciiString>> OpenFilesHash;
 typedef OpenFilesHash::iterator OpenFilesHashIt;
 
 class AudioFileCache

--- a/include/game_engine_device/w3d_device/game_client/module/w3dmodeldraw.h
+++ b/include/game_engine_device/w3d_device/game_client/module/w3dmodeldraw.h
@@ -135,7 +135,7 @@ struct PristineBoneInfo
 	Matrix3D mtx;
 	Int boneIndex;
 };
-typedef std::hash_map<NameKeyType, PristineBoneInfo, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>> PristineBoneInfoMap;
+typedef std::unordered_map<NameKeyType, PristineBoneInfo, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>> PristineBoneInfoMap;
 
 //-------------------------------------------------------------------------------------------------
 
@@ -271,7 +271,7 @@ private:
 typedef std::vector<ModelConditionInfo> ModelConditionVector;
 
 //-------------------------------------------------------------------------------------------------
-typedef std::hash_map<TransitionSig, ModelConditionInfo, std::hash<TransitionSig>, std::equal_to<TransitionSig>> TransitionMap;
+typedef std::unordered_map<TransitionSig, ModelConditionInfo, std::hash<TransitionSig>, std::equal_to<TransitionSig>> TransitionMap;
 
 //-------------------------------------------------------------------------------------------------
 // this is more efficient and also helps solve a projectile-launch-offset problem for double-upgraded

--- a/src/game_engine/common/audio/game_speech.cpp
+++ b/src/game_engine/common/audio/game_speech.cpp
@@ -199,7 +199,7 @@ class Speaker : public SpeakerInterface
 };
 
 typedef std::vector<Speech> VecSpeech;
-typedef std::hash_map<const char*, Speech, std::hash<const char*>, rts::equal_to<const char*> > HashSpeech;
+typedef std::unordered_map<const char*, Speech, std::hash<const char*>, rts::equal_to<const char*> > HashSpeech;
 
 //===============================
 // SpeechManager: 

--- a/src/tools/crc_diff/expander.h
+++ b/src/tools/crc_diff/expander.h
@@ -27,7 +27,7 @@
 #define __EXPANDER_H__
 
 #include <map>
-#include <hash_map>
+#include <unordered_map>
 #include <string>
 
 typedef std::map<std::string, std::string> ExpansionMap;

--- a/src/tools/matchbot/generals.h
+++ b/src/tools/matchbot/generals.h
@@ -32,7 +32,7 @@
 #include <bitset>
 #include <vector>
 #include <map>
-#include <hash_map>
+#include <unordered_map>
 typedef std::vector<bool> MapBitSet;
 
 // =====================================================================


### PR DESCRIPTION
## Summary
- use `<unordered_map>` instead of deprecated `<hash_map>`
- update all std::hash_map usages to std::unordered_map

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: AnimatedSoundMgr build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c819b388325bdb9a90d62e8ff97