### PR TITLE
Fix _stdcall usage in audio callbacks

### DIFF
--- a/include/common/win32_compat.h
+++ b/include/common/win32_compat.h
@@ -11,6 +11,12 @@
 #ifndef _cdecl
 #define _cdecl
 #endif
+#ifndef __stdcall
+#define __stdcall
+#endif
+#ifndef _stdcall
+#define _stdcall
+#endif
 
 using DWORD = std::uint32_t;
 using WORD  = std::uint16_t;


### PR DESCRIPTION
## Summary
- define `_stdcall` and `__stdcall` on non-Windows builds

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685d8c94afa08325b8081d5a8ebc0495